### PR TITLE
VOD-2606, VOD-2575 Fix many ASS->WebVTT bugs discovered as part of COPS-3501

### DIFF
--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -214,7 +214,7 @@ static int split_event_text_to_chunks(char *src, int srclen, char **textp, int *
 
                     case (TAG_TYPE_NEWLINE_LARGE):
                     case (TAG_TYPE_NEWLINE_SMALL): {
-                        if cur_run > *max_run) {
+                        if (cur_run > *max_run) {
                             *max_run = cur_run; // we don't add the size of \r\n since they are not visible on screen.
                             cur_run = 0;        // max_run holds the longest run of visible characters on any line.
                         }
@@ -295,7 +295,7 @@ static int split_event_text_to_chunks(char *src, int srclen, char **textp, int *
         }
     }
 
-    if cur_run > *max_run) {
+    if (cur_run > *max_run) {
         *max_run = cur_run; // we don't add the size of \r\n since they are not visible on screen.
     }
 
@@ -336,7 +336,7 @@ static int split_event_text_to_chunks(char *src, int srclen, char **textp, int *
 
     vod_log_error(VOD_LOG_ERR, request_context->log, 0,
         "CUE max_run = %d", *max_run);
-        
+
     evorder[chunkidx] = initialstring;
     evlen[chunkidx]   = dstidx;
 
@@ -691,18 +691,20 @@ ass_parse_frames(
                     line = 7;
                 } else if (cur_style->Alignment < VALIGN_TOP) { //bottom Alignment  for values 1, 2, 3
                     margV = 100 - margV;
-                    line = FFMINMAX(margV >> 4, 0, 12);
+                    line = FFMINMAX((margV+4) >> 3, 0, 12);
                 } else {                                        //top alignment is the default assumption
-                    line = FFMINMAX(margV >> 4, 0, 12);
+                    line = FFMINMAX((margV+4) >> 3, 0, 12);
                 }
 
-                sizeH = FFMINMAX(margR - margL, 30, 100 - margL);
+                // cap horizontal size to more than 2x to make sure we don't break lines with generic font
+                // cap horizontal size to no more than 3x to make sure we allow right and left aligned events on same line
+                sizeH = FFMINMAX(margR - margL, (int)(max_run*2), (int)(max_run*3));
                 if ((bleft == FALSE) && (bright == FALSE)) {        //center Alignment  2/6/10
                     pos = FFMINMAX((margR + margL + 1)/2, sizeH/2, 100 - sizeH/2);
                 } else if (bleft == TRUE) {                         //left   Alignment  1/5/9
-                    pos = FFMINMAX(margL, 3, 100 - sizeH);
+                    pos = FFMINMAX(margL, 0, 100 - sizeH);
                 } else {                                            //right  Alignment  3/7/11
-                    pos = FFMINMAX(margR, sizeH, 97);
+                    pos = FFMINMAX(margR, sizeH, 100);
                 }
 
                 len = 10; vod_memcpy(p, " position:", len);                     p+=len;


### PR DESCRIPTION
1. Write cue "line" field in absolute number (0-12) instead of vertical %. Since lines in % turn on a webVTT boolean flag (snap-to-lines) that affects the rendering of multi-line, center-aligned subtitles.
2. MarginV of midtitles (alignment 4,5,6 in ASS) should be ignored, and line 7 (out of 15 total) should always be used.
3. Given that ASS allows multiple events to have areas intersecting, while WebVTT doesn't. We need to be more conservative on calculating the "size" field for each cue. Many scripts we have set it to 90% and more. This prevents other cues from being drawn on the same line. I now cap sizes to 2%-3% per visible character. This is big enough for fonts used on all browsers I tried (< 2%) and still has spare in case styles are followed. Tested on clips that have 9 subtitles in all numPad locations at the same time.
4. Arabic characters in UTF8 are all 2-bytes, starting with D8 or D9. To count them only once, I don't count the D8 and D9 bytes for calculating size.
5. All Arabic lines are started with "‏" escape sequence. The webVTT decoder knows to put the "!", "..." and other western 1-byte characters on the left side of the subtitle. Only problem with that might be lines which include mixed Arabic-western strings. But this is so rare, that I don't have a single example like that.