### PR TITLE
Fix timing and ordering of cues when out-of-order and overlapping durations exist

### DIFF
--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -458,7 +458,7 @@ ass_parse(
  * In the following function event == frame == cue. All words point to the text in ASS/media-struct/WebVTT.
  *
  * \output vtt_track->media_info.extra_data   (WEBVTT header + all STYLE cues)
- * \output vtt_track->total_frames_duration   (start of first cue clipped after current segment - start of first non-clipped cue)
+ * \output vtt_track->total_frames_duration   (sum of output frame durations)
  * \output vtt_track->first_frame_index       (event index for very first event output in this segment)
  * \output vtt_track->first_frame_time_offset (Start time of the very first event output in this segment)
  * \output vtt_track->total_frames_size       (Number of String Bytes used in all events that were output)


### PR DESCRIPTION
- Fix a bug calculating cue start timing when 2 or more cues are overlapping (not possible for SRT sources, but possible for ASS sources).
- Make sure the output cues in WebVTT are ordered by start-time, a requirement in the WebVTT standard.

e.g. ASS:
[Events]
Format: Layer,Start,End,Style,Name,MarginL,MarginR,MarginV,Effect,Text
Dialogue: 0,0:00:08.04,0:00:11.24,italics,Ichirou,0000,0000,0000,,All right, I'll make the 8:33 train without \Nany problems at this rate.
Dialogue: 0,0:00:26.85,0:00:31.56,italics,Ichirou,0000,0000,0000,,Man, this is rough. \NIt's nothing like being in school.
Dialogue: 0,0:00:14.20,0:00:16.53,italics,Ichirou,0000,0000,0000,,What? The train's here!
Dialogue: 0,0:00:06.85,0:00:51.56,italics,Ichirou,0000,0000,0000,,Not really last one

$curl -X GET -v 'http://localhost:80/new.ass/seg-3.vtt'

WEBVTT

c0000000
00:00:06.850 --> 00:00:51.560 position:050% size:057% line:12 align:center
Not really last one

c0000003
00:00:26.850 --> 00:00:31.560 position:050% size:093% line:12 align:center
Man, this is rough. 
It's nothing like being in school.
