### PR TITLE
Update ASS/SCC code to Kaltura's coding style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1628,7 +1628,7 @@ padding is added as needed.
 
 #### vod_hls_mpegts_output_id3_timestamps
 * **syntax**: `vod_hls_mpegts_output_id3_timestamps on/off`
-* **default**: `on`
+* **default**: `off`
 * **context**: `http`, `server`, `location`
 
 When enabled, an ID3 TEXT frame will be outputted in each TS segment, containing a JSON with the absolute segment timestamp.
@@ -1865,6 +1865,75 @@ Note: Configuration directives that can accept variables are explicitly marked a
 			}
 		}
 	}
+
+#### Mapped + Remote configuration
+
+	http {
+		upstream jsonupstream {
+			server jsonserver:80;
+		}
+
+		server {
+			# vod settings
+			vod_mode mapped;
+			vod_upstream_location /json;
+			vod_remote_upstream_location /proxy;
+			vod_upstream_extra_args "pathOnly=1";
+			vod_last_modified 'Sun, 19 Nov 2000 08:52:00 GMT';
+			vod_last_modified_types *;
+
+			# vod caches
+			vod_metadata_cache metadata_cache 512m;
+			vod_response_cache response_cache 128m;
+			vod_mapping_cache mapping_cache 5m;
+
+			# gzip manifests
+			gzip on;
+			gzip_types application/vnd.apple.mpegurl;
+
+			# file handle caching / aio
+			open_file_cache	  max=1000 inactive=5m;
+			open_file_cache_valid    2m;
+			open_file_cache_min_uses 1;
+			open_file_cache_errors   on;
+			aio on;
+
+			location ^~ /json/hls/ {
+				internal;
+				proxy_pass http://jsonupstream/;
+				proxy_set_header Host $http_host;
+			}
+
+			location ~ /proxy/([^/]+)/(.*) {
+				internal;
+				proxy_pass $1://$2;
+				resolver 8.8.8.8;
+			}
+
+			location ~ ^/hls/ {
+				vod hls;
+
+				add_header Access-Control-Allow-Headers '*';
+				add_header Access-Control-Expose-Headers 'Server,range,Content-Length,Content-Range';
+				add_header Access-Control-Allow-Methods 'GET, HEAD, OPTIONS';
+				add_header Access-Control-Allow-Origin '*';
+				expires 100d;
+			}
+		}
+	}
+
+Set it up so that http://jsonserver:80/test.json returns the following JSON:
+
+	{
+		"sequences": [{
+			"clips": [{
+				"type": "source",
+				"path": "/http/commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+			}]
+		}]
+	}
+
+And use this stream URL - http://nginx-vod-server/hls/test.json/master.m3u8
 
 #### Remote configuration
 

--- a/test/playlist.php
+++ b/test/playlist.php
@@ -32,19 +32,19 @@ function getRequestParams()
 
 $params = getRequestParams();
 $discontinuity = (isset($params['disc']) && $params['disc']) ? true : false;
-$playlistType = isset($params['type']) ? $params['type'] : "live";
+$playlistType = isset($params['type']) ? $params['type'] : 'live';
 
 // input params
 $filePaths = array(
 	// clip 1
 	array(
-		"/path/to/video1.mp4",
-		"/path/to/subtitles1.srt",
+		'/path/to/video1.mp4',
+		'/path/to/subtitles1.srt',
 	),
 	// clip 2
 	array(
-		"/path/to/video2.mp4",
-		"/path/to/subtitles2.srt",
+		'/path/to/video2.mp4',
+		'/path/to/subtitles2.srt',
 	),
 );
 
@@ -67,8 +67,8 @@ $segmentCount = 10;
 function getSourceClip($filePath)
 {
 	return array(
-		"type" => "source",
-		"path" => $filePath
+		'type' => 'source',
+		'path' => $filePath
 	);
 }
 
@@ -83,12 +83,12 @@ function getDurationMillis($filePath)
 	{
 		return $duration;
 	}
-	
+
 	// execute ffprobe
 	$commandLine = "{$ffprobeBin} -i {$filePath} -show_streams -print_format json -v quiet";
 	$output = null;
 	exec($commandLine, $output);
-	
+
 	// parse the result - take the shortest duration
 	$ffmpegResult = json_decode(implode("\n", $output));
 	$duration = null;
@@ -100,10 +100,14 @@ function getDurationMillis($filePath)
 			$duration = $curDuration;
 		}
 	}
-	
+	if (!$duration)
+	{
+		die("Failed to get the duration of {$filePath}\n");
+	}
+
 	// store to cache
 	apc_store($cacheKey, $duration);
-	
+
 	return $duration;
 }
 
@@ -115,62 +119,79 @@ foreach ($filePaths as $curClip)
 
 $result = array();
 
-if ($playlistType == "live")
+if ($playlistType == 'live')
 {
-	// find the duration of each cycle
-	$cycleDuration = array_sum($durations);
-	
-	// if the cycle is too small to cover the DVR window, duplicate it
-	$dvrWindowSize = $segmentDuration * $segmentCount;
-	while ($cycleDuration <= $dvrWindowSize + $timeMargin)
+	// get cycle info
+	$cycleDurations = $durations;
+	$cycleFilePaths = $filePaths;
+	$cycleClipCount = count($cycleDurations);
+	$cycleDuration = array_sum($cycleDurations);
+	$cycleSegmentCount = 0;
+	foreach ($cycleDurations as $duration)
 	{
-		$filePaths = array_merge($filePaths, $filePaths);
-		$durations = array_merge($durations, $durations);
-		$cycleDuration *= 2;
+		$cycleSegmentCount += ceil($duration / $segmentDuration);
 	}
-	
-	// start the playlist from now() - <dvr window size>
-	$time = isset($params['time']) ? $params['time'] : time();
-	$currentTime = $time * 1000 - $timeMargin - $dvrWindowSize;
 
-	// get the reference time (the time of the first run)
+	// find the start / end time
+	$dvrWindowSize = $segmentDuration * $segmentCount;
+	$endTime = (isset($params['time']) ? $params['time'] : time()) * 1000;
+	$startTime = $endTime - $timeMargin - $dvrWindowSize;
+
+	// get the reference time (start time of the first run)
 	$referenceTime = apc_fetch('reference_time');
 	if (!$referenceTime)
 	{
-		$referenceTime = $currentTime;
+		$referenceTime = $startTime;
 		apc_store('reference_time', $referenceTime);
 	}
-	
-	// set the first clip time to now() rounded down to cycle duration
-	$cycleIndex = floor(($currentTime - $referenceTime) / $cycleDuration);
-	$result["firstClipTime"] = $referenceTime + $cycleIndex * $cycleDuration;
-	
-	if ($discontinuity)
+
+	// get the initial cycle info
+	$cycleIndex = floor(($startTime - $referenceTime) / $cycleDuration);
+	$clipIndex = $cycleIndex * $cycleClipCount;
+	$segmentIndex = $cycleIndex * $cycleSegmentCount;
+	$durations = array();
+	$filePaths = array();
+
+	$currentTime = $referenceTime + $cycleIndex * $cycleDuration;
+	while ($currentTime < $endTime)
 	{
-		// find the total number of segments in each cycle
-		$totalSegmentCount = 0;
-		foreach ($durations as $duration)
+		// get the current clip duration
+		$cycleClipIndex = $clipIndex % $cycleClipCount;
+		$duration = $cycleDurations[$cycleClipIndex];
+		if ($currentTime + $duration > $startTime)
 		{
-			$totalSegmentCount += ceil($duration / $segmentDuration);
+			if (!$durations)
+			{
+				// set first clip details
+				$result['firstClipTime'] = $currentTime;
+
+				if ($discontinuity)
+				{
+					$result['initialClipIndex'] = $clipIndex + 1;
+					$result['initialSegmentIndex'] = $segmentIndex + 1;
+				}
+			}
+
+			// add the current clip
+			$durations[] = $duration;
+			$filePaths[] = $cycleFilePaths[$cycleClipIndex];
 		}
 
-		// find the initial clip index and initial segment index
-		$result["initialClipIndex"] = $cycleIndex * count($durations) + 1;
-		$result["initialSegmentIndex"] = $cycleIndex * $totalSegmentCount + 1;
-	}
-	else
-	{
-		$result["segmentBaseTime"] = $referenceTime;
+		// move to the next clip
+		$clipIndex++;
+		$segmentIndex += ceil($duration / $segmentDuration);
+		$currentTime += $duration;
 	}
 
-	// duplicate the clips, this is required so that we won't run out of segments 
-	// close to the end of a cycle
-	$filePaths = array_merge($filePaths, $filePaths);
-	$durations = array_merge($durations, $durations);
+	if (!$discontinuity)
+	{
+		$result['segmentBaseTime'] = $referenceTime;
+	}
 }
 
 $sequences = array();
-foreach ($languages as $seqIndex => $language)
+$seqCount = count(reset($filePaths));
+for ($seqIndex = 0; $seqIndex < $seqCount; $seqIndex++)
 {
 	$clips = array();
 	foreach ($filePaths as $curClip)
@@ -179,22 +200,27 @@ foreach ($languages as $seqIndex => $language)
 	}
 
 	$sequence = array(
-		"clips" => $clips
+		'clips' => $clips
 	);
-	if ($language)
+
+	if (isset($languages[$seqIndex]))
 	{
-		$sequence['language'] = $language;
+		$language = $languages[$seqIndex];
+		if ($language)
+		{
+			$sequence['language'] = $language;
+		}
 	}
-	
+
 	$sequences[] = $sequence;
 }
 
 // generate the result object
 $result = array_merge($result, array(
-	"discontinuity" => $discontinuity,
-	"playlistType" => $playlistType,
-	"durations" => $durations,
-	"sequences" => $sequences,
+	'discontinuity' => $discontinuity,
+	'playlistType' => $playlistType,
+	'durations' => $durations,
+	'sequences' => $sequences,
 ));
 
 echo json_encode($result);

--- a/vod/filters/audio_decoder.c
+++ b/vod/filters/audio_decoder.c
@@ -19,7 +19,9 @@ static bool_t initialized = FALSE;
 void
 audio_decoder_process_init(vod_log_t* log)
 {
-	avcodec_register_all();
+	#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 18, 100)
+		avcodec_register_all();
+	#endif
 
 	decoder_codec = avcodec_find_decoder(AV_CODEC_ID_AAC);
 	if (decoder_codec == NULL)

--- a/vod/filters/audio_encoder.c
+++ b/vod/filters/audio_encoder.c
@@ -36,7 +36,9 @@ audio_encoder_is_format_supported(AVCodec *codec, enum AVSampleFormat sample_fmt
 void
 audio_encoder_process_init(vod_log_t* log)
 {
-	avcodec_register_all();
+	#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 18, 100)
+		avcodec_register_all();
+	#endif
 
 	encoder_codec = avcodec_find_encoder_by_name(AAC_ENCODER_NAME);
 	if (encoder_codec == NULL)

--- a/vod/filters/audio_filter.c
+++ b/vod/filters/audio_filter.c
@@ -231,8 +231,9 @@ typedef struct {
 } audio_filter_state_t;
 
 // globals
-static AVFilter *buffersrc_filter = NULL;
-static AVFilter *buffersink_filter = NULL;
+static const AVFilter *buffersrc_filter = NULL;
+static const AVFilter *buffersink_filter = NULL;
+
 static bool_t initialized = FALSE;
 
 static const uint64_t aac_channel_layout[] = {
@@ -249,7 +250,9 @@ static const uint64_t aac_channel_layout[] = {
 void 
 audio_filter_process_init(vod_log_t* log)
 {
-	avfilter_register_all();
+	#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 18, 100)
+		avfilter_register_all();
+	#endif
 
 	buffersrc_filter = avfilter_get_by_name(BUFFERSRC_FILTER_NAME);
 	if (buffersrc_filter == NULL)

--- a/vod/input/frames_source.h
+++ b/vod/input/frames_source.h
@@ -12,6 +12,7 @@ typedef struct {
 	vod_status_t(*start_frame)(void* context, struct input_frame_s* frame, read_cache_hint_t* cache_hint);
 	vod_status_t(*read)(void* context, u_char** buffer, uint32_t* size, bool_t* frame_done);
 	void(*disable_buffer_reuse)(void* context);
+	vod_status_t(*skip_frames)(void* context, uint32_t skip_count);
 } frames_source_t;
 
 #endif // __FRAMES_SOURCE_H__

--- a/vod/input/frames_source_cache.c
+++ b/vod/input/frames_source_cache.c
@@ -93,10 +93,17 @@ frames_source_cache_disable_buffer_reuse(void* ctx)
 	read_cache_disable_buffer_reuse(state->read_cache_state);
 }
 
+static vod_status_t
+frames_source_cache_skip_frames(void* ctx, uint32_t skip_count)
+{
+	return VOD_OK;
+}
+
 // globals
 frames_source_t frames_source_cache = {
 	frames_source_cache_set_cache_slot_id,
 	frames_source_cache_start_frame,
 	frames_source_cache_read,
 	frames_source_cache_disable_buffer_reuse,
+	frames_source_cache_skip_frames,
 };

--- a/vod/input/frames_source_memory.c
+++ b/vod/input/frames_source_memory.c
@@ -60,10 +60,17 @@ frames_source_memory_disable_buffer_reuse(void* ctx)
 {
 }
 
+static vod_status_t
+frames_source_memory_skip_frames(void* ctx, uint32_t skip_count)
+{
+	return VOD_OK;
+}
+
 // globals
 frames_source_t frames_source_memory = {
 	frames_source_memory_set_cache_slot_id,
 	frames_source_memory_start_frame,
 	frames_source_memory_read,
 	frames_source_memory_disable_buffer_reuse,
+	frames_source_memory_skip_frames,
 };

--- a/vod/media_set.h
+++ b/vod/media_set.h
@@ -18,7 +18,7 @@
 #define MAX_CLIPS (128)
 #define MAX_CLIPS_PER_REQUEST (16)
 #define MAX_SEQUENCES (32)
-#define MAX_SEQUENCE_IDS (2)
+#define MAX_SEQUENCE_IDS (4)
 #define MAX_SEQUENCE_TRACKS_MASKS (2)
 #define MAX_SOURCES (32)
 

--- a/vod/mp4/mp4_cenc_encrypt.h
+++ b/vod/mp4/mp4_cenc_encrypt.h
@@ -53,6 +53,7 @@ struct mp4_cenc_encrypt_video_state_s {
 	// fixed
 	mp4_cenc_encrypt_video_build_fragment_header_t build_fragment_header;
 	uint32_t nal_packet_size_length;
+	uint32_t codec_id;
 
 	// auxiliary data state
 	vod_dynamic_buf_t auxiliary_data;

--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -21,6 +21,7 @@ static const char*    FIXED_WEBVTT_ ## type ## _ ## name ## _STR   = str;
 
 PAIROF(CUE, 	NAME, 		8,	"c%07d");
 PAIROF(ESCAPE,	FOR_RTL,	5,	"&lrm;")
+
 #ifdef ASSUME_STYLE_SUPPORT
 PAIROF(STYLE, 	START, 		22,	"STYLE\r\n::cue(v[voice=\"")
 PAIROF(STYLE, 	END,		4,	"\"]) ")
@@ -28,30 +29,9 @@ PAIROF(BRACES,	START,		3,	"{\r\n")
 PAIROF(BRACES,	END,		3,	"}\r\n")
 PAIROF(VOICE,	START,		3,	"<v ")
 PAIROF(VOICE,	END,		1,	">")
-PAIROF(VOICE,	SPANEND,	4,	"</v>")
 // ignore this set for now, later we will use <v.strike StyleName>  for lines that are strikethrough
 //PAIROF(CLASS,	STRIKE, 	68,	"STYLE\r\n::cue(.strike) {\r\ntext-decoration: solid line-through;\r\n}\r\n\r\n")
 #endif
-//#define FIXED_WEBVTT_CUE_NAME_WIDTH 8
-//#define FIXED_WEBVTT_CUE_NAME_STR "c%07d"
-//#define FIXED_WEBVTT_STYLE_START_WIDTH 22
-//#define FIXED_WEBVTT_STYLE_START_STR "STYLE\r\n::cue(v[voice=\""
-//#define FIXED_WEBVTT_STYLE_END_WIDTH 4
-//#define FIXED_WEBVTT_STYLE_END_STR "\"]) "
-//#define FIXED_WEBVTT_BRACES_START_WIDTH 3
-//#define FIXED_WEBVTT_BRACES_START_STR "{\r\n"
-//#define FIXED_WEBVTT_BRACES_END_WIDTH 3
-//#define FIXED_WEBVTT_BRACES_END_STR "}\r\n"
-//#define FIXED_WEBVTT_VOICE_START_WIDTH  3
-//#define FIXED_WEBVTT_VOICE_START_STR  "<v "
-//#define FIXED_WEBVTT_VOICE_END_STR  ">"
-//#define FIXED_WEBVTT_VOICE_END_WIDTH  1
-//#define FIXED_WEBVTT_VOICE_SPANEND_STR  "</v>"
-//#define FIXED_WEBVTT_VOICE_SPANEND_WIDTH  4
-//#define FIXED_WEBVTT_ESCAPE_FOR_RTL_STR "&lrm;"
-//#define FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH 5
-//#define FIXED_WEBVTT_CLASS_STRIKE_STR  "STYLE\r\n::cue(.strike) {\r\ntext-decoration: solid line-through;\r\n}\r\n\r\n"
-//#define FIXED_WEBVTT_CLASS_STRIKE_WIDTH  68
 
 typedef enum
 {

--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -7,495 +7,502 @@
 
 #define ASS_SCRIPT_INFO_HEADER ("[Script Info]")
 
-#define FIXED_WEBVTT_CUE_NAME_WIDTH 8
-#define FIXED_WEBVTT_CUE_FORMAT_STR "c%07d"
-#define FIXED_WEBVTT_STYLE_START_WIDTH 22
-#define FIXED_WEBVTT_STYLE_START_STR "STYLE\r\n::cue(v[voice=\""
-#define FIXED_WEBVTT_STYLE_END_WIDTH 4
-#define FIXED_WEBVTT_STYLE_END_STR "\"]) "
-#define FIXED_WEBVTT_BRACES_START_WIDTH 3
-#define FIXED_WEBVTT_BRACES_START_STR "{\r\n"
-#define FIXED_WEBVTT_BRACES_END_WIDTH 3
-#define FIXED_WEBVTT_BRACES_END_STR "}\r\n"
-#define FIXED_WEBVTT_VOICE_START_STR  "<v "
-#define FIXED_WEBVTT_VOICE_START_WIDTH  3
-#define FIXED_WEBVTT_VOICE_END_STR  ">"
-#define FIXED_WEBVTT_VOICE_END_WIDTH  1
-#define FIXED_WEBVTT_VOICE_SPANEND_STR  "</v>"
-#define FIXED_WEBVTT_VOICE_SPANEND_WIDTH  4
-#define FIXED_WEBVTT_ESCAPE_FOR_RTL_STR "&lrm;"
-#define FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH 5
-
-// ignore this set for now, later we will use <v.strike StyleName>  for lines that are strikethrough
-#define FIXED_WEBVTT_CLASS_STRIKE      "STYLE\r\n::cue(.strike) {\r\ntext-decoration: solid line-through;\r\n}\r\n\r\n"
-#define FIXED_WEBVTT_CLASS_STRIKE_WIDTH  68
-
 #define MAX_STR_SIZE_EVNT_CHUNK 1024
 #define MAX_STR_SIZE_ALL_WEBVTT_STYLES 20480
 
-#define NUM_OF_INLINE_TAGS_SUPPORTED 3     //ibu
+#define NUM_OF_INLINE_TAGS_SUPPORTED 3	 //ibu
 #define NUM_OF_TAGS_ALLOWED_PER_LINE 1
 
 //#define ASSUME_STYLE_SUPPORT
 
+#define PAIROF(type, name, w, str)											\
+static const int      FIXED_WEBVTT_ ## type ## _ ## name ## _WIDTH = w;		\
+static const char*    FIXED_WEBVTT_ ## type ## _ ## name ## _STR   = str;
+
+PAIROF(CUE, 	NAME, 		8,	"c%07d");
+PAIROF(ESCAPE,	FOR_RTL,	5,	"&lrm;")
+#ifdef ASSUME_STYLE_SUPPORT
+PAIROF(STYLE, 	START, 		22,	"STYLE\r\n::cue(v[voice=\"")
+PAIROF(STYLE, 	END,		4,	"\"]) ")
+PAIROF(BRACES,	START,		3,	"{\r\n")
+PAIROF(BRACES,	END,		3,	"}\r\n")
+PAIROF(VOICE,	START,		3,	"<v ")
+PAIROF(VOICE,	END,		1,	">")
+PAIROF(VOICE,	SPANEND,	4,	"</v>")
+// ignore this set for now, later we will use <v.strike StyleName>  for lines that are strikethrough
+//PAIROF(CLASS,	STRIKE, 	68,	"STYLE\r\n::cue(.strike) {\r\ntext-decoration: solid line-through;\r\n}\r\n\r\n")
+#endif
+//#define FIXED_WEBVTT_CUE_NAME_WIDTH 8
+//#define FIXED_WEBVTT_CUE_NAME_STR "c%07d"
+//#define FIXED_WEBVTT_STYLE_START_WIDTH 22
+//#define FIXED_WEBVTT_STYLE_START_STR "STYLE\r\n::cue(v[voice=\""
+//#define FIXED_WEBVTT_STYLE_END_WIDTH 4
+//#define FIXED_WEBVTT_STYLE_END_STR "\"]) "
+//#define FIXED_WEBVTT_BRACES_START_WIDTH 3
+//#define FIXED_WEBVTT_BRACES_START_STR "{\r\n"
+//#define FIXED_WEBVTT_BRACES_END_WIDTH 3
+//#define FIXED_WEBVTT_BRACES_END_STR "}\r\n"
+//#define FIXED_WEBVTT_VOICE_START_WIDTH  3
+//#define FIXED_WEBVTT_VOICE_START_STR  "<v "
+//#define FIXED_WEBVTT_VOICE_END_STR  ">"
+//#define FIXED_WEBVTT_VOICE_END_WIDTH  1
+//#define FIXED_WEBVTT_VOICE_SPANEND_STR  "</v>"
+//#define FIXED_WEBVTT_VOICE_SPANEND_WIDTH  4
+//#define FIXED_WEBVTT_ESCAPE_FOR_RTL_STR "&lrm;"
+//#define FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH 5
+//#define FIXED_WEBVTT_CLASS_STRIKE_STR  "STYLE\r\n::cue(.strike) {\r\ntext-decoration: solid line-through;\r\n}\r\n\r\n"
+//#define FIXED_WEBVTT_CLASS_STRIKE_WIDTH  68
+
 typedef enum
 {
-    TAG_TYPE_NEWLINE_SMALL  = 0,
-    TAG_TYPE_NEWLINE_LARGE  = 1,
-    TAG_TYPE_AMPERSANT      = 2,
-    TAG_TYPE_SMALLERTHAN    = 3,
-    TAG_TYPE_BIGGERTHAN     = 4,
+	TAG_TYPE_NEWLINE_SMALL	= 0,
+	TAG_TYPE_NEWLINE_LARGE	= 1,
+	TAG_TYPE_AMPERSANT		= 2,
+	TAG_TYPE_SMALLERTHAN	= 3,
+	TAG_TYPE_BIGGERTHAN		= 4,
 
-    TAG_TYPE_OPEN_BRACES    = 5,
-    TAG_TYPE_CLOSE_BRACES   = 6,
+	TAG_TYPE_OPEN_BRACES	= 5,
+	TAG_TYPE_CLOSE_BRACES	= 6,
 
 // all starts should be in even index, all ends should be in odd index. This logic is assumed
-    TAG_TYPE_IBU_DATUM      = 7,
-    TAG_TYPE_ITALIC_END     = 7,
-    TAG_TYPE_ITALIC_START   = 8,
-    TAG_TYPE_BOLD_END       = 9,
-    TAG_TYPE_BOLD_START     = 10,
-    TAG_TYPE_UNDER_END      = 11,
-    TAG_TYPE_UNDER_START    = 12,
+	TAG_TYPE_IBU_DATUM		= 7,
+	TAG_TYPE_ITALIC_END		= 7,
+	TAG_TYPE_ITALIC_START	= 8,
+	TAG_TYPE_BOLD_END		= 9,
+	TAG_TYPE_BOLD_START		= 10,
+	TAG_TYPE_UNDER_END		= 11,
+	TAG_TYPE_UNDER_START	= 12,
 
-    TAG_TYPE_UNKNOWN_TAG    = 13, // has to be after all known braces types
-    TAG_TYPE_NONE           = 14
+	TAG_TYPE_UNKNOWN_TAG	= 13,
+	TAG_TYPE_NONE			= 14
 } ass_tag_idx_t;
 
-static const char* const tag_strings[TAG_TYPE_NONE] =
+static const char* tag_strings[TAG_TYPE_NONE] =
 {
-    "\\n",
-    "\\N",
-    "&",
-    "<",
-    ">",
+	"\\n",
+	"\\N",
+	"&",
+	"<",
+	">",
 	
-    "{",
-    "}",
+	"{",
+	"}",
 
-    "\\i0",
-    "\\i",
-    "\\b0",
-    "\\b",
-    "\\u0",
-    "\\u",
+	"\\i0",
+	"\\i",
+	"\\b0",
+	"\\b",
+	"\\u0",
+	"\\u",
 
-    "\\"
+	"\\"
 };
 static const int tag_string_len[TAG_TYPE_NONE][2] =
 {
-    // index 0 is size of ASS tag, index 1 is size of replacement webVTT tag
-    {2,2},
-    {2,2},
-    {1,5},
-    {1,4},
-    {1,4},
+	// index 0 is size of ASS tag, index 1 is size of replacement webVTT tag
+	{2,2},
+	{2,2},
+	{1,5},
+	{1,4},
+	{1,4},
 
-    {1,0},
-    {1,0},
+	{1,0},
+	{1,0},
 
-    {3,4},
-    {2,3},
-    {3,4},
-    {2,3},
-    {3,4},
-    {2,3},
+	{3,4},
+	{2,3},
+	{3,4},
+	{2,3},
+	{3,4},
+	{2,3},
 
-    {1,0}
+	{1,0}
 };
 static const char* tag_replacement_strings[TAG_TYPE_NONE] =
 {
-    "\r\n",
-    "\r\n",
-    "&amp;",
-    "&lt;",
-    "&gt;",
+	"\r\n",
+	"\r\n",
+	"&amp;",
+	"&lt;",
+	"&gt;",
 
-    "",
-    "",
+	"",
+	"",
 
-    "</i>",
-    "<i>",
-    "</b>",
-    "<b>",
-    "</u>",
-    "<u>",
+	"</i>",
+	"<i>",
+	"</b>",
+	"<b>",
+	"</u>",
+	"<u>",
 
-    ""
+	""
 };
 
 void swap_events(ass_event_t* nxt, ass_event_t* cur)
 {
-    ass_event_t tmp;
-    vod_memcpy(&tmp,  nxt, sizeof(ass_event_t));
-    vod_memcpy( nxt,  cur, sizeof(ass_event_t));
-    vod_memcpy( cur, &tmp, sizeof(ass_event_t));
+	ass_event_t tmp;
+	vod_memcpy(&tmp,  nxt, sizeof(ass_event_t));
+	vod_memcpy( nxt,  cur, sizeof(ass_event_t));
+	vod_memcpy( cur, &tmp, sizeof(ass_event_t));
 }
 
 static int split_event_text_to_chunks(char *src, int srclen, bool_t rtl, char **textp, int *evlen, bool_t *ibu_flags, uint32_t *max_run, request_context_t* request_context)
 {
-    // a chunk is part of the text that will be added with a specific voice/style. So we increment chunk only when we need a different style applied
-    // Number of chunks is at least 1 if len is > 0
-    int srcidx = 0, dstidx = 0, tagidx, bBracesOpen = 0, chunkidx = 0;
-    uint32_t cur_run = 0;
+	// a chunk is part of the text that will be added with a specific voice/style. So we increment chunk only when we need a different style applied
+	// Number of chunks is at least 1 if len is > 0
+	int srcidx = 0, dstidx = 0, tagidx, bBracesOpen = 0, chunkidx = 0;
+	uint32_t cur_run = 0;
 
-    // Basic sanity checking for inputs
-    if ((src == NULL) || (srclen < 1) || (srclen > MAX_STR_SIZE_EVNT_CHUNK))
-    {
-        return 0;
-    }
+	if ((src == NULL) || (srclen < 1) || (srclen > MAX_STR_SIZE_EVNT_CHUNK))
+	{
+		return 0;
+	}
 
-    // if right to left language, insert marker before text
-    if (rtl)
-    {
-         vod_memcpy(textp[chunkidx], FIXED_WEBVTT_ESCAPE_FOR_RTL_STR, FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH);
-         dstidx+=FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH;
-    }
+	if (rtl)
+	{
+		 vod_memcpy(textp[chunkidx], FIXED_WEBVTT_ESCAPE_FOR_RTL_STR, FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH);
+		 dstidx+=FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH;
+	}
 
-    // insert openers to currently open modes, ordered as <i><b><u>
-    if (ibu_flags[0])
-    {
-        vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_START], tag_string_len[TAG_TYPE_ITALIC_START][1]);
-        dstidx += tag_string_len[TAG_TYPE_ITALIC_START][1];
-    }
-    if (ibu_flags[1])
-    {
-         vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_START], tag_string_len[TAG_TYPE_BOLD_START][1]);
-         dstidx += tag_string_len[TAG_TYPE_BOLD_START][1];
-    }
-    if (ibu_flags[2])
-    {
-        vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_START], tag_string_len[TAG_TYPE_UNDER_START][1]);
-        dstidx += tag_string_len[TAG_TYPE_UNDER_START][1];
-    }
+	// insert openers to currently open modes, ordered as <i><b><u>
+	if (ibu_flags[0])
+	{
+		vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_START], tag_string_len[TAG_TYPE_ITALIC_START][1]);
+		dstidx += tag_string_len[TAG_TYPE_ITALIC_START][1];
+	}
+	if (ibu_flags[1])
+	{
+		 vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_START], tag_string_len[TAG_TYPE_BOLD_START][1]);
+		 dstidx += tag_string_len[TAG_TYPE_BOLD_START][1];
+	}
+	if (ibu_flags[2])
+	{
+		vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_START], tag_string_len[TAG_TYPE_UNDER_START][1]);
+		dstidx += tag_string_len[TAG_TYPE_UNDER_START][1];
+	}
 
 
-    while (srcidx < srclen)
-    {
-        for (tagidx = 0; tagidx < TAG_TYPE_NONE; tagidx++)
-        {
-            if (vod_strncmp(src+srcidx, tag_strings[tagidx], tag_string_len[tagidx][0]) == 0)
-            {
-                char* curloc;
-                srcidx += tag_string_len[tagidx][0]; //tag got read from input
-                curloc = src + srcidx;
+	while (srcidx < srclen)
+	{
+		for (tagidx = 0; tagidx < TAG_TYPE_NONE; tagidx++)
+		{
+			if (vod_strncmp(src+srcidx, tag_strings[tagidx], tag_string_len[tagidx][0]) == 0)
+			{
+				char* curloc;
+				srcidx += tag_string_len[tagidx][0];
+				curloc = src + srcidx;
 
-                switch (tagidx) {
-                    case (TAG_TYPE_ITALIC_END):
-                    case (TAG_TYPE_BOLD_END):
-                    case (TAG_TYPE_UNDER_END):
-                    case (TAG_TYPE_ITALIC_START):
-                    case (TAG_TYPE_BOLD_START):
-                    case (TAG_TYPE_UNDER_START): {
-                        int ibu_idx = (tagidx - TAG_TYPE_IBU_DATUM) >> 1;
-                        bool_t opposite = (tagidx & 1) == 1;
-                        // Is this toggling one of the 3 flags? otherwise we ignore it
-                        if (ibu_flags[ibu_idx] == opposite)
-                        {
-                            // insert closures to open spans, ordered as </u></b></i>
-                            if (ibu_flags[2])
-                            {
-                                vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_END], tag_string_len[TAG_TYPE_UNDER_END][1]);
-                                dstidx += tag_string_len[TAG_TYPE_UNDER_END][1];
-                            }
-                            if (ibu_flags[1])
-                            {
-                                 vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_END], tag_string_len[TAG_TYPE_BOLD_END][1]);
-                                 dstidx += tag_string_len[TAG_TYPE_BOLD_END][1];
-                            }
-                            if (ibu_flags[0])
-                            {
-                                vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_END], tag_string_len[TAG_TYPE_ITALIC_END][1]);
-                                dstidx += tag_string_len[TAG_TYPE_ITALIC_END][1];
-                            }
-                            // toggle the flag
-                            ibu_flags[ibu_idx] = !ibu_flags[ibu_idx];
-                            // insert openers to currently open modes, ordered as <i><b><u>
-                            if (ibu_flags[0])
-                            {
-                                vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_START], tag_string_len[TAG_TYPE_ITALIC_START][1]);
-                                dstidx += tag_string_len[TAG_TYPE_ITALIC_START][1];
-                            }
-                            if (ibu_flags[1])
-                            {
-                                 vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_START], tag_string_len[TAG_TYPE_BOLD_START][1]);
-                                 dstidx += tag_string_len[TAG_TYPE_BOLD_START][1];
-                            }
-                            if (ibu_flags[2])
-                            {
-                                vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_START], tag_string_len[TAG_TYPE_UNDER_START][1]);
-                                dstidx += tag_string_len[TAG_TYPE_UNDER_START][1];
-                            }
-                        }
-                    } break;
+				switch (tagidx) {
+					case (TAG_TYPE_ITALIC_END):
+					case (TAG_TYPE_BOLD_END):
+					case (TAG_TYPE_UNDER_END):
+					case (TAG_TYPE_ITALIC_START):
+					case (TAG_TYPE_BOLD_START):
+					case (TAG_TYPE_UNDER_START): {
+						int ibu_idx = (tagidx - TAG_TYPE_IBU_DATUM) >> 1;
+						bool_t opposite = (tagidx & 1) == 1;
 
-                    case (TAG_TYPE_NEWLINE_LARGE):
-                    case (TAG_TYPE_NEWLINE_SMALL):
-                    {
-                        if (cur_run > *max_run)
-                        {
-                            *max_run = cur_run; // we don't add the size of \r\n since they are not visible on screen.
-                            cur_run = 0;        // max_run holds the longest run of visible characters on any line.
-                        }
-                        // replace the string with its equivalent in target string
-                        vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
-                        dstidx += tag_string_len[tagidx][1]; //tag got written to output
-                        if (rtl)
-                        {
-                             vod_memcpy(textp[chunkidx] + dstidx, FIXED_WEBVTT_ESCAPE_FOR_RTL_STR, FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH);
-                             dstidx += FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH;
-                        }
-                    } break;
+						if (ibu_flags[ibu_idx] == opposite)
+						{
+							// insert closures to open spans, ordered as </u></b></i>
+							if (ibu_flags[2])
+							{
+								vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_END], tag_string_len[TAG_TYPE_UNDER_END][1]);
+								dstidx += tag_string_len[TAG_TYPE_UNDER_END][1];
+							}
+							if (ibu_flags[1])
+							{
+								 vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_END], tag_string_len[TAG_TYPE_BOLD_END][1]);
+								 dstidx += tag_string_len[TAG_TYPE_BOLD_END][1];
+							}
+							if (ibu_flags[0])
+							{
+								vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_END], tag_string_len[TAG_TYPE_ITALIC_END][1]);
+								dstidx += tag_string_len[TAG_TYPE_ITALIC_END][1];
+							}
 
-                    case (TAG_TYPE_AMPERSANT):
-                    case (TAG_TYPE_BIGGERTHAN):
-                    case (TAG_TYPE_SMALLERTHAN):
-                    {
-                        cur_run++;  // just one single visible character out of this webvtt code word
-                        // replace the string with its equivalent in target string
-                        vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
-                        dstidx += tag_string_len[tagidx][1]; //tag got written to output
-                    } break;
+							ibu_flags[ibu_idx] = !ibu_flags[ibu_idx];
 
-                    case (TAG_TYPE_OPEN_BRACES):
-                    case (TAG_TYPE_CLOSE_BRACES):
-                    {
-                        bBracesOpen = (tagidx & 1);
-                        // replace the string with its equivalent in target string
-                        vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
-                        dstidx += tag_string_len[tagidx][1]; //tag got written to output
-                    } break;
+							if (ibu_flags[0])
+							{
+								vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_START], tag_string_len[TAG_TYPE_ITALIC_START][1]);
+								dstidx += tag_string_len[TAG_TYPE_ITALIC_START][1];
+							}
+							if (ibu_flags[1])
+							{
+								 vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_START], tag_string_len[TAG_TYPE_BOLD_START][1]);
+								 dstidx += tag_string_len[TAG_TYPE_BOLD_START][1];
+							}
+							if (ibu_flags[2])
+							{
+								vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_START], tag_string_len[TAG_TYPE_UNDER_START][1]);
+								dstidx += tag_string_len[TAG_TYPE_UNDER_START][1];
+							}
+						}
+					} break;
 
-                    default:
-                    {
-                        // replace the string with its equivalent in target string
-                        vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
-                        dstidx += tag_string_len[tagidx][1]; //tag got written to output
-                    }
-                }
+					case (TAG_TYPE_NEWLINE_LARGE):
+					case (TAG_TYPE_NEWLINE_SMALL):
+					{
+						if (cur_run > *max_run)
+						{
+							*max_run = cur_run; // we don't add the size of \r\n since they are not visible on screen.
+							cur_run = 0;		// max_run holds the longest run of visible characters on any line.
+						}
 
+						vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
+						dstidx += tag_string_len[tagidx][1];
+						if (rtl)
+						{
+							 vod_memcpy(textp[chunkidx] + dstidx, FIXED_WEBVTT_ESCAPE_FOR_RTL_STR, FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH);
+							 dstidx += FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH;
+						}
+					} break;
 
-                // if the next char is not "\\" or "}", then ignore all characters between here and then
-                // (case of \b400) or unsupported \xxxxxxx tag
-                if (bBracesOpen && (*curloc != '}') && (*curloc != '\\'))
-                {
-                    char*  nearest;
-                    char*  nearslash = vod_strchr(curloc, '\\'); // NULL or value
-                    char*  nearbrace = vod_strchr(curloc, '}');  // NULL or value
-                    if (nearslash == NULL)  nearslash = nearbrace;
-                    if (nearbrace == NULL)  nearbrace = nearslash;
-                    nearest = FFMIN(nearslash, nearbrace);
-                    srcidx = (int)(FFMAX(nearest, curloc+1) - src);
-                }
+					case (TAG_TYPE_AMPERSANT):
+					case (TAG_TYPE_BIGGERTHAN):
+					case (TAG_TYPE_SMALLERTHAN):
+					{
+						cur_run++;
+						vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
+						dstidx += tag_string_len[tagidx][1];
+					} break;
 
-                tagidx = -1; //start all tags again, cause they can come in any order
-            }
-        }
-        // none of the tags matched this character
-        if (tagidx == TAG_TYPE_NONE)
-        {
-            // for Arabic language, we want to increment number of characters only once every 2 bytes
-            // Arabic utf8 chars all start with 0xD8 or 0xD9, different from all western languages
-            unsigned char cur_char = (unsigned char)(*(src + srcidx));
-            if (cur_char != 0xD8 && cur_char != 0xD9)
-                cur_run++;
+					case (TAG_TYPE_OPEN_BRACES):
+					case (TAG_TYPE_CLOSE_BRACES):
+					{
+						bBracesOpen = (tagidx & 1);
+						vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
+						dstidx += tag_string_len[tagidx][1];
+					} break;
 
-            vod_memcpy(textp[chunkidx] + dstidx, src + srcidx, 1);
-            srcidx++;
-            dstidx++;
-        }
-    }
+					default:
+					{
+						vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
+						dstidx += tag_string_len[tagidx][1];
+					}
+				}
 
-    // insert closures to open spans, ordered as </u></b></i>
-    if (ibu_flags[2])
-    {
-        vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_END], tag_string_len[TAG_TYPE_UNDER_END][1]);
-        dstidx += tag_string_len[TAG_TYPE_UNDER_END][1];
-    }
-    if (ibu_flags[1])
-    {
-         vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_END], tag_string_len[TAG_TYPE_BOLD_END][1]);
-         dstidx += tag_string_len[TAG_TYPE_BOLD_END][1];
-    }
-    if (ibu_flags[0])
-    {
-        vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_END], tag_string_len[TAG_TYPE_ITALIC_END][1]);
-        dstidx += tag_string_len[TAG_TYPE_ITALIC_END][1];
-    }
+				// if the next char is not "\\" or "}", then ignore all characters between here and then
+				// (case of \b400) or unsupported \xxxxxxx tag
+				if (bBracesOpen && (*curloc != '}') && (*curloc != '\\'))
+				{
+					char*  nearest;
+					char*  nearslash = vod_strchr(curloc, '\\');
+					char*  nearbrace = vod_strchr(curloc, '}');
+					if (nearslash == NULL)  nearslash = nearbrace;
+					if (nearbrace == NULL)  nearbrace = nearslash;
+					nearest = FFMIN(nearslash, nearbrace);
+					srcidx = (int)(FFMAX(nearest, curloc+1) - src);
+				}
 
-    if (cur_run > *max_run)
-    {
-        *max_run = cur_run; // we don't add the size of \r\n since they are not visible on screen.
-    }
+				tagidx = -1; //start all tags again, cause they can come in any order
+			}
+		}
+		// none of the tags matched this character
+		if (tagidx == TAG_TYPE_NONE)
+		{
+			// for Arabic language, we want to increment number of characters only once every 2 bytes
+			// Arabic utf8 chars all start with 0xD8 or 0xD9, different from all western languages
+			unsigned char cur_char = (unsigned char)(*(src + srcidx));
+			if (cur_char != 0xD8 && cur_char != 0xD9)
+				cur_run++;
 
-    evlen[chunkidx] = dstidx;
+			vod_memcpy(textp[chunkidx] + dstidx, src + srcidx, 1);
+			srcidx++;
+			dstidx++;
+		}
+	}
 
-    return chunkidx + 1;
+	if (ibu_flags[2])
+	{
+		vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_END], tag_string_len[TAG_TYPE_UNDER_END][1]);
+		dstidx += tag_string_len[TAG_TYPE_UNDER_END][1];
+	}
+	if (ibu_flags[1])
+	{
+		 vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_END], tag_string_len[TAG_TYPE_BOLD_END][1]);
+		 dstidx += tag_string_len[TAG_TYPE_BOLD_END][1];
+	}
+	if (ibu_flags[0])
+	{
+		vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_END], tag_string_len[TAG_TYPE_ITALIC_END][1]);
+		dstidx += tag_string_len[TAG_TYPE_ITALIC_END][1];
+	}
+
+	if (cur_run > *max_run)
+	{
+		*max_run = cur_run;
+	}
+
+	evlen[chunkidx] = dstidx;
+
+	return chunkidx + 1;
 }
 
 static void ass_clean_known_mem(request_context_t* request_context, ass_track_t *ass_track, char** event_textp)
 {
-    int chunkidx;
-    if (ass_track != NULL)
-        ass_free_track(request_context->pool, ass_track);
+	int chunkidx;
+	if (ass_track != NULL)
+		ass_free_track(request_context->pool, ass_track);
 
-    if (event_textp != NULL)
-    {
-        for (chunkidx = 0; chunkidx < NUM_OF_TAGS_ALLOWED_PER_LINE; chunkidx++)
-        {
-            if (event_textp[chunkidx] != NULL)
-                vod_free(request_context->pool, event_textp[chunkidx]);
-        }
-    }
+	if (event_textp != NULL)
+	{
+		for (chunkidx = 0; chunkidx < NUM_OF_TAGS_ALLOWED_PER_LINE; chunkidx++)
+		{
+			if (event_textp[chunkidx] != NULL)
+				vod_free(request_context->pool, event_textp[chunkidx]);
+		}
+	}
 
-    return;
+	return;
 }
 
 #ifdef ASSUME_STYLE_SUPPORT
 static char* output_one_style(ass_style_t* cur_style, char* p)
 {
-        int len;
+		int len;
 
-        vod_memcpy(p, FIXED_WEBVTT_STYLE_START_STR, FIXED_WEBVTT_STYLE_START_WIDTH);           p += FIXED_WEBVTT_STYLE_START_WIDTH;
-        len = vod_strlen(cur_style->name); vod_memcpy(p, cur_style->name, len);                p += len;
-        vod_memcpy(p, FIXED_WEBVTT_STYLE_END_STR, FIXED_WEBVTT_STYLE_END_WIDTH);               p += FIXED_WEBVTT_STYLE_END_WIDTH;
-        vod_memcpy(p, FIXED_WEBVTT_BRACES_START_STR, FIXED_WEBVTT_BRACES_START_WIDTH);         p += FIXED_WEBVTT_BRACES_START_WIDTH;
+		vod_memcpy(p, FIXED_WEBVTT_STYLE_START_STR, FIXED_WEBVTT_STYLE_START_WIDTH);		p += FIXED_WEBVTT_STYLE_START_WIDTH;
+		len = vod_strlen(cur_style->name); vod_memcpy(p, cur_style->name, len);				p += len;
+		vod_memcpy(p, FIXED_WEBVTT_STYLE_END_STR, FIXED_WEBVTT_STYLE_END_WIDTH);			p += FIXED_WEBVTT_STYLE_END_WIDTH;
+		vod_memcpy(p, FIXED_WEBVTT_BRACES_START_STR, FIXED_WEBVTT_BRACES_START_WIDTH);		p += FIXED_WEBVTT_BRACES_START_WIDTH;
 
-        len = 8; vod_memcpy(p, "color: #", len);                                               p += len;
-        vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->primary_colour);                     p += 11;
+		len = 8; vod_memcpy(p, "color: #", len);											p += len;
+		vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->primary_colour);					p += 11;
 
 
-        len = 14; vod_memcpy(p, "font-family: \"", len);                                       p += len;
-        len = vod_strlen(cur_style->font_name); vod_memcpy(p, cur_style->font_name, len);      p += len;
-        len = 16; vod_memcpy(p, "\", sans-serif;\r\n", len);                                   p += len;
-        vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", cur_style->font_size);              p += 19;
+		len = 14; vod_memcpy(p, "font-family: \"", len);									p += len;
+		len = vod_strlen(cur_style->font_name); vod_memcpy(p, cur_style->font_name, len);	p += len;
+		len = 16; vod_memcpy(p, "\", sans-serif;\r\n", len);								p += len;
+		vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", cur_style->font_size);			p += 19;
 
-        /*if (cur_style->bold)
-        {
-            len = 20; vod_memcpy(p, "font-weight: bold;\r\n", len);                            p += len;
-        }
-        if (cur_style->italic)
-        {
-            len = 21; vod_memcpy(p, "font-style: italic;\r\n", len);                           p += len;
-        }
-        // This will inherit the outline_colour (and shadow) if border_style==1, otherwise it inherits primary_colour
-        if (cur_style->underline)
-        {
-            // available styles are: solid | double | dotted | dashed | wavy
-            // available lines are: underline || overline || line-through || blink
-            len = 35; vod_memcpy(p, "text-decoration: solid underline;\r\n", len);             p += len;
-        }
-        else if (cur_style->strike_out)
-        {
-            // available lines are: underline || overline || line-through || blink
-            len = 38; vod_memcpy(p, "text-decoration: solid line-through;\r\n", len);          p += len;
-        }*/
+		/*if (cur_style->bold)
+		{
+			len = 20; vod_memcpy(p, "font-weight: bold;\r\n", len);							p += len;
+		}
+		if (cur_style->italic)
+		{
+			len = 21; vod_memcpy(p, "font-style: italic;\r\n", len);						p += len;
+		}
+		// This will inherit the outline_colour (and shadow) if border_style==1, otherwise it inherits primary_colour
+		if (cur_style->underline)
+		{
+			// available styles are: solid | double | dotted | dashed | wavy
+			// available lines are: underline || overline || line-through || blink
+			len = 35; vod_memcpy(p, "text-decoration: solid underline;\r\n", len);			p += len;
+		}
+		else if (cur_style->strike_out)
+		{
+			// available lines are: underline || overline || line-through || blink
+			len = 38; vod_memcpy(p, "text-decoration: solid line-through;\r\n", len);		p += len;
+		}*/
 
-        if (cur_style->border_style == 1 /*&& ass_track->type == TRACK_TYPE_ASS*/)
-        {
-            // webkit is not supported by all players, stick to adding outline using text-shadow
-            len = 13; vod_memcpy(p, "text-shadow: ", len);                                     p += len;
-            // add outline in 4 directions with the outline color
-            vod_sprintf((u_char*)p, "#%08uxD -%01uDpx 0px, #%08uxD 0px %01uDpx, #%08uxD 0px -%01uDpx, #%08uxD %01uDpx 0px, #%08uxD %01uDpx %01uDpx 0px;\r\n",
-                         cur_style->outline_colour, cur_style->outline,
-                         cur_style->outline_colour, cur_style->outline,
-                         cur_style->outline_colour, cur_style->outline,
-                         cur_style->outline_colour, cur_style->outline,
-                         cur_style->back_colour, cur_style->shadow, cur_style->shadow);        p += 102;
+		if (cur_style->border_style == 1 /*&& ass_track->type == TRACK_TYPE_ASS*/)
+		{
+			// webkit is not supported by all players, stick to adding outline using text-shadow
+			len = 13; vod_memcpy(p, "text-shadow: ", len);									p += len;
+			// add outline in 4 directions with the outline color
+			vod_sprintf((u_char*)p, "#%08uxD -%01uDpx 0px, #%08uxD 0px %01uDpx, #%08uxD 0px -%01uDpx, #%08uxD %01uDpx 0px, #%08uxD %01uDpx %01uDpx 0px;\r\n",
+				cur_style->outline_colour, cur_style->outline,
+				cur_style->outline_colour, cur_style->outline,
+				cur_style->outline_colour, cur_style->outline,
+				cur_style->outline_colour, cur_style->outline,
+				cur_style->back_colour, cur_style->shadow, cur_style->shadow);				p += 102;
+		}
+		else
+		{
+			len = 19; vod_memcpy(p, "background-color: #", len);							p += len;
+			vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->back_colour);					p += 11;
+		}
+		vod_memcpy(p, FIXED_WEBVTT_BRACES_END_STR, FIXED_WEBVTT_BRACES_END_WIDTH);			p += FIXED_WEBVTT_BRACES_END_WIDTH;
+		len = 2; vod_memcpy(p, "\r\n", len);												p += len;
 
-        }
-        else
-        {
-            len = 19; vod_memcpy(p, "background-color: #", len);                               p += len;
-            vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->back_colour);                    p += 11;
-        }
-        vod_memcpy(p, FIXED_WEBVTT_BRACES_END_STR, FIXED_WEBVTT_BRACES_END_WIDTH);             p += FIXED_WEBVTT_BRACES_END_WIDTH;
-        len = 2; vod_memcpy(p, "\r\n", len);                                                   p += len;
-
-        return p;
+		return p;
 }
 #endif //ASSUME_STYLE_SUPPORT
 
 static vod_status_t
 ass_reader_init(
-    request_context_t* request_context,
-    vod_str_t* buffer,
-    size_t initial_read_size,
-    size_t max_metadata_size,
-    void** ctx)
+	request_context_t* request_context,
+	vod_str_t* buffer,
+	size_t initial_read_size,
+	size_t max_metadata_size,
+	void** ctx)
 {
-    u_char* p = buffer->data;
+	u_char* p = buffer->data;
 
-    if (vod_strncmp(p, UTF8_BOM, sizeof(UTF8_BOM) - 1) == 0)
-    {
-        p += sizeof(UTF8_BOM) - 1;
-    }
+	if (vod_strncmp(p, UTF8_BOM, sizeof(UTF8_BOM) - 1) == 0)
+	{
+		p += sizeof(UTF8_BOM) - 1;
+	}
 
-    // The line that says “[Script Info]” must be the first line in a v4/v4+ script.
-    if (buffer->len > 0 && vod_strncmp(p, ASS_SCRIPT_INFO_HEADER, sizeof(ASS_SCRIPT_INFO_HEADER) - 1) != 0)
-    {
-        return VOD_NOT_FOUND;
-    }
+	// The line that says “[Script Info]” must be the first line in a v4/v4+ script.
+	if (buffer->len > 0 && vod_strncmp(p, ASS_SCRIPT_INFO_HEADER, sizeof(ASS_SCRIPT_INFO_HEADER) - 1) != 0)
+	{
+		return VOD_NOT_FOUND;
+	}
 
-    return subtitle_reader_init(
-        request_context,
-        initial_read_size,
-        ctx);
+	return subtitle_reader_init(
+		request_context,
+		initial_read_size,
+		ctx);
 }
 
 static vod_status_t
 ass_parse(
-    request_context_t* request_context,
-    media_parse_params_t* parse_params,
-    vod_str_t* source,
-    size_t metadata_part_count,
-    media_base_metadata_t** result)
+	request_context_t* request_context,
+	media_parse_params_t* parse_params,
+	vod_str_t* source,
+	size_t metadata_part_count,
+	media_base_metadata_t** result)
 {
-    ass_track_t *ass_track;
-    vod_status_t ret_status;
-    ass_track = parse_memory((char *)(source->data), source->len, request_context);
+	ass_track_t *ass_track;
+	vod_status_t ret_status;
+	ass_track = parse_memory((char *)(source->data), source->len, request_context);
 
-    if (ass_track == NULL)
-    {
-        // ass_track was de-allocated already inside the function, for failure cases
-        vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
-            "ass_parse failed");
-        return VOD_BAD_DATA;
-    }
+	if (ass_track == NULL)
+	{
+		// ass_track was de-allocated already inside the function, for failure cases
+		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+			"ass_parse failed");
+		return VOD_BAD_DATA;
+	}
 
-    ret_status = subtitle_parse(
-        request_context,
-        parse_params,
-        source,
-        NULL,
-        (uint64_t)(ass_track->max_duration),
-        metadata_part_count,
-        result);
+	ret_status = subtitle_parse(
+		request_context,
+		parse_params,
+		source,
+		NULL,
+		(uint64_t)(ass_track->max_duration),
+		metadata_part_count,
+		result);
 
-    // now that we used max_duration, we need to free the memory used by the track
-    ass_free_track(request_context->pool, ass_track);
-    return ret_status;
+	// now that we used max_duration, we need to free the memory used by the track
+	ass_free_track(request_context->pool, ass_track);
+	return ret_status;
 }
 
 /**
  * \brief Parse the .ass/.ssa file, convert to webvtt, output all cues as frames
  * In the following function event == frame == cue. All words point to the text in ASS/media-struct/WebVTT.
  *
- * \output vtt_track->media_info.extra_data   (WEBVTT header + all STYLE cues)
- * \output vtt_track->total_frames_duration   (sum of output frame durations)
- * \output vtt_track->first_frame_index       (event index for very first event output in this segment)
- * \output vtt_track->first_frame_time_offset (Start time of the very first event output in this segment)
- * \output vtt_track->total_frames_size       (Number of String Bytes used in all events that were output)
- * \output vtt_track->frame_count             (Number of events output in this segment)
- * \output vtt_track->frames.clip_to          (the upper clipping bound of this segment)
- * \output vtt_track->frames.first_frame      (pointer to first frame structure in the linked list)
- * \output vtt_track->frames.last_frame       (pointer to last frame structure in the linked list)
- * \output result (media track in the track array)
+ * \output vtt_track->media_info.extra_data		(WEBVTT header + all STYLE cues)
+ * \output vtt_track->total_frames_duration		(sum of output frame durations)
+ * \output vtt_track->first_frame_index			(event index for very first event output in this segment)
+ * \output vtt_track->first_frame_time_offset	(Start time of the very first event output in this segment)
+ * \output vtt_track->total_frames_size			(Number of String Bytes used in all events that were output)
+ * \output vtt_track->frame_count				(Number of events output in this segment)
+ * \output vtt_track->frames.clip_to			(the upper clipping bound of this segment)
+ * \output vtt_track->frames.first_frame		(pointer to first frame structure in the linked list)
+ * \output vtt_track->frames.last_frame			(pointer to last frame structure in the linked list)
+ * \output result								(media track in the track array)
  *
  * individual cues in the frames array
- * \output cur_frame->duration                      (start time of next  output event - start time of current event)
- * if last event to be output but not last in file: (start time of next         event - start time of current event)
- * if last event in whole file:                     (end time of current output event - start time of current event)
+ * \output cur_frame->duration					(start time of next  output event - start time of current event)
+ * if last event to be output but not last in file:	(start time of next		 event - start time of current event)
+ * if last event in whole file:					(end time of current output event - start time of current event)
  * \output cur_frame->offset
  * \output cur_frame->size
  * \output cur_frame->pts_delay
@@ -505,364 +512,364 @@ ass_parse(
 */
 static vod_status_t
 ass_parse_frames(
-    request_context_t* request_context,
-    media_base_metadata_t* base,
-    media_parse_params_t* parse_params,
-    struct segmenter_conf_s* segmenter,     // unused
-    read_cache_state_t* read_cache_state,   // unused
-    vod_str_t* frame_data,                  // unused
-    media_format_read_request_t* read_req,  // unused
-    media_track_array_t* result)
+	request_context_t* request_context,
+	media_base_metadata_t* base,
+	media_parse_params_t* parse_params,
+	struct segmenter_conf_s* segmenter,		// unused
+	read_cache_state_t* read_cache_state,	// unused
+	vod_str_t* frame_data,					// unused
+	media_format_read_request_t* read_req,	// unused
+	media_track_array_t* result)
 {
-    ass_track_t *ass_track;
-    vod_array_t frames;
-    subtitle_base_metadata_t* metadata
-                              = vod_container_of(base, subtitle_base_metadata_t, base);
-    vod_str_t*     source     = &metadata->source;
-    media_track_t* vtt_track  = base->tracks.elts;
-    input_frame_t* cur_frame  = NULL;
-    ass_event_t*   cur_event  = NULL;
-    vod_str_t* header         = &vtt_track->media_info.extra_data;
-    char *p, *pfixed;
-    int len, evntcounter, chunkcounter;
-    uint64_t base_time, clip_to, seg_start, seg_end, last_start_time;
+	ass_track_t *ass_track;
+	vod_array_t frames;
+	subtitle_base_metadata_t* metadata
+								= vod_container_of(base, subtitle_base_metadata_t, base);
+	vod_str_t*	 source	 = &metadata->source;
+	media_track_t* vtt_track	= base->tracks.elts;
+	input_frame_t* cur_frame	= NULL;
+	ass_event_t*   cur_event	= NULL;
+	vod_str_t* header			= &vtt_track->media_info.extra_data;
+	char *p, *pfixed;
+	int len, evntcounter, chunkcounter;
+	uint64_t base_time, clip_to, seg_start, seg_end, last_start_time;
 
-    vod_memzero(result, sizeof(*result));
-    result->first_track       = vtt_track;
-    result->last_track        = vtt_track + 1;
-    result->track_count[MEDIA_TYPE_SUBTITLE] = 1;
-    result->total_track_count = 1;
+	vod_memzero(result, sizeof(*result));
+	result->first_track			= vtt_track;
+	result->last_track			= vtt_track + 1;
+	result->track_count[MEDIA_TYPE_SUBTITLE] = 1;
+	result->total_track_count	= 1;
 
-    vtt_track->first_frame_index       = 0;
-    vtt_track->first_frame_time_offset = -1;
-    vtt_track->total_frames_size       = 0;
-    vtt_track->total_frames_duration   = 0;
-    last_start_time = 0;
+	vtt_track->first_frame_index		= 0;
+	vtt_track->first_frame_time_offset	= -1;
+	vtt_track->total_frames_size		= 0;
+	vtt_track->total_frames_duration 	= 0;
+	last_start_time = 0;
 
-    if ((parse_params->parse_type & (PARSE_FLAG_FRAMES_ALL | PARSE_FLAG_EXTRA_DATA | PARSE_FLAG_EXTRA_DATA_SIZE)) == 0)
-    {
-        return VOD_OK;
-    }
+	if ((parse_params->parse_type & (PARSE_FLAG_FRAMES_ALL | PARSE_FLAG_EXTRA_DATA | PARSE_FLAG_EXTRA_DATA_SIZE)) == 0)
+	{
+		return VOD_OK;
+	}
 
-    ass_track = parse_memory((char *)(source->data), source->len, request_context);
-    if (ass_track == NULL)
-    {
-        // ass_track was de-allocated already inside the function, for failure cases
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "ass_parse_frames: failed to parse memory into ass track");
-        return VOD_BAD_MAPPING;
-    }
+	ass_track = parse_memory((char *)(source->data), source->len, request_context);
+	if (ass_track == NULL)
+	{
+		// ass_track was de-allocated already inside the function, for failure cases
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"ass_parse_frames: failed to parse memory into ass track");
+		return VOD_BAD_MAPPING;
+	}
 
-    // Re-order events so that each event has a starting time that is bigger than or equal than the one before it.
-    // This matches WebVTT expectations of cue order. And allows us to calculate frame duration correctly.
-    // We don't sort it inside parse_memory() because that function is called twice, and first time no sorting is needed.
-    // BUBBLE SORT was chosen to optimize the best-case scenario O(n), since most scripts are already ordered.
-    for (evntcounter = 0; evntcounter < ass_track->n_events - 1; evntcounter++)
-    {
-        // Last evntcounter elements are already in place
-        for (chunkcounter = 0; chunkcounter < ass_track->n_events - evntcounter - 1; chunkcounter++)
-        {
-            ass_event_t*   next_event = ass_track->events + chunkcounter + 1;
-                           cur_event  = ass_track->events + chunkcounter;
-            if (cur_event->start > next_event->start)
-            {
-                //  Swap the two events
-                swap_events(next_event, cur_event);
-            }
-        }
-    }
-    // allocate initial array of cues/styles, to be augmented as needed after the first 5
-    if (vod_array_init(&frames, request_context->pool, 5, sizeof(input_frame_t)) != VOD_OK)
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "ass_parse_frames: vod_array_init failed");
-        ass_free_track(request_context->pool, ass_track);
-        return VOD_ALLOC_FAILED;
-    }
+	// Re-order events so that each event has a starting time that is bigger than or equal than the one before it.
+	// This matches WebVTT expectations of cue order. And allows us to calculate frame duration correctly.
+	// We don't sort it inside parse_memory() because that function is called twice, and first time no sorting is needed.
+	// BUBBLE SORT was chosen to optimize the best-case scenario O(n), since most scripts are already ordered.
+	for (evntcounter = 0; evntcounter < ass_track->n_events - 1; evntcounter++)
+	{
+		// Last evntcounter elements are already in place
+		for (chunkcounter = 0; chunkcounter < ass_track->n_events - evntcounter - 1; chunkcounter++)
+		{
+			ass_event_t* next_event = ass_track->events + chunkcounter + 1;
+						 cur_event  = ass_track->events + chunkcounter;
+			if (cur_event->start > next_event->start)
+			{
+				//  Swap the two events
+				swap_events(next_event, cur_event);
+			}
+		}
+	}
+	// allocate initial array of cues/styles, to be augmented as needed after the first 5
+	if (vod_array_init(&frames, request_context->pool, 5, sizeof(input_frame_t)) != VOD_OK)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"ass_parse_frames: vod_array_init failed");
+		ass_free_track(request_context->pool, ass_track);
+		return VOD_ALLOC_FAILED;
+	}
 
-    seg_start = parse_params->range->start + parse_params->clip_from;
+	seg_start = parse_params->range->start + parse_params->clip_from;
 
-    if ((parse_params->parse_type & PARSE_FLAG_RELATIVE_TIMESTAMPS) != 0)
-    {
-        base_time = seg_start;
-        clip_to = parse_params->range->end - parse_params->range->start;
-        seg_end = clip_to;
-    }
-    else
-    {
-        base_time = parse_params->clip_from;
-        clip_to = parse_params->clip_to;
-        seg_end = parse_params->range->end;
-    }
+	if ((parse_params->parse_type & PARSE_FLAG_RELATIVE_TIMESTAMPS) != 0)
+	{
+		base_time = seg_start;
+		clip_to = parse_params->range->end - parse_params->range->start;
+		seg_end = clip_to;
+	}
+	else
+	{
+		base_time = parse_params->clip_from;
+		clip_to = parse_params->clip_to;
+		seg_end = parse_params->range->end;
+	}
 
-    // We now insert all cues that include their positioning info
-    // Events are assumed already ordered by their start time. As required for WebVTT output Cues.
-    for (evntcounter = 0; evntcounter < ass_track->n_events; evntcounter++)
-    {
-        cur_event = ass_track->events + evntcounter;
-        ass_style_t*   cur_style = ass_track->styles + cur_event->style; //cur_event->style will be zero for an unknown style name
+	// We now insert all cues that include their positioning info
+	// Events are assumed already ordered by their start time. As required for WebVTT output Cues.
+	for (evntcounter = 0; evntcounter < ass_track->n_events; evntcounter++)
+	{
+		cur_event = ass_track->events + evntcounter;
+		ass_style_t* cur_style = ass_track->styles + cur_event->style; //cur_event->style will be zero for an unknown style name
 
-        // make all timing checks and clipping, before we decide to read the text or output it.
-        // to make sure this event should be included in the segment.
-        if (cur_event->end < 0 || cur_event->start < 0 || cur_event->start >= cur_event->end)
-        {
-            continue;
-        }
-        if ((uint64_t)cur_event->end < seg_start)
-        {
-            continue;
-        }
+		// make all timing checks and clipping, before we decide to read the text or output it.
+		// to make sure this event should be included in the segment.
+		if (cur_event->end < 0 || cur_event->start < 0 || cur_event->start >= cur_event->end)
+		{
+			continue;
+		}
+		if ((uint64_t)cur_event->end < seg_start)
+		{
+			continue;
+		}
 
-        // apply clipping
-        if (cur_event->start >= (int64_t)base_time)
-        {
-            cur_event->start -= base_time;
-            if ((uint64_t)cur_event->start > clip_to)
-            {
-                cur_event->start = (long long)(clip_to);
-            }
-        }
-        else
-        {
-            cur_event->start = 0;
-        }
+		// apply clipping
+		if (cur_event->start >= (int64_t)base_time)
+		{
+			cur_event->start -= base_time;
+			if ((uint64_t)cur_event->start > clip_to)
+			{
+				cur_event->start = (long long)(clip_to);
+			}
+		}
+		else
+		{
+			cur_event->start = 0;
+		}
 
-        cur_event->end -= base_time;
-        if ((uint64_t)cur_event->end > clip_to)
-        {
-            cur_event->end = (long long)(clip_to);
-        }
+		cur_event->end -= base_time;
+		if ((uint64_t)cur_event->end > clip_to)
+		{
+			cur_event->end = (long long)(clip_to);
+		}
 
-        if (cur_frame != NULL)
-        {
-            cur_frame->duration = cur_event->start - last_start_time;
-            vtt_track->total_frames_duration += cur_frame->duration;
-        }
-        else
-        {
-            // if this is the very first event intersecting with segment, this is the first start in the segment
-            vtt_track->first_frame_time_offset = cur_event->start;
-            vtt_track->first_frame_index       = evntcounter;
-        }
+		if (cur_frame != NULL)
+		{
+			cur_frame->duration = cur_event->start - last_start_time;
+			vtt_track->total_frames_duration += cur_frame->duration;
+		}
+		else
+		{
+			// if this is the very first event intersecting with segment, this is the first start in the segment
+			vtt_track->first_frame_time_offset	= cur_event->start;
+			vtt_track->first_frame_index		= evntcounter;
+		}
 
-        if ((uint64_t)cur_event->start >= seg_end)
-        {
-            // events are already ordered by start-time
-            break;
-        }
+		if ((uint64_t)cur_event->start >= seg_end)
+		{
+			// events are already ordered by start-time
+			break;
+		}
 
 
-        ///// This EVENT is within the segment duration. Parse its text, and output it after conversion to WebVTT valid tags./////
+		///// This EVENT is within the segment duration. Parse its text, and output it after conversion to WebVTT valid tags./////
 
-        // Split the event text into multiple chunks so we can insert each chunk as a separate frame in webVTT, all under a single cue
-        char*          event_textp[NUM_OF_TAGS_ALLOWED_PER_LINE];
-        int            event_len  [NUM_OF_TAGS_ALLOWED_PER_LINE];
-        int            margL, margR, margV; // all of these are integer percentage values
+		// Split the event text into multiple chunks so we can insert each chunk as a separate frame in webVTT, all under a single cue
+		char*	event_textp[NUM_OF_TAGS_ALLOWED_PER_LINE];
+		int		event_len  [NUM_OF_TAGS_ALLOWED_PER_LINE];
+		int		marg_l, marg_r, marg_v; // all of these are integer percentage values
 
-        // allocate memory for the chunk pointer itself first
-        for (chunkcounter = 0; chunkcounter < NUM_OF_TAGS_ALLOWED_PER_LINE; chunkcounter++)
-        {
-            // now allocate string memory for each chunk
-            event_textp[chunkcounter] = vod_alloc(request_context->pool, MAX_STR_SIZE_EVNT_CHUNK);
-            if (event_textp[chunkcounter] == NULL)
-            {
-                vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-                    "ass_parse_frames: vod_alloc failed");
-                ass_clean_known_mem(request_context, ass_track, event_textp);
-                return VOD_ALLOC_FAILED;
-            }
-            event_len[chunkcounter] = 0;
-        }
+		// allocate memory for the chunk pointer itself first
+		for (chunkcounter = 0; chunkcounter < NUM_OF_TAGS_ALLOWED_PER_LINE; chunkcounter++)
+		{
+			// now allocate string memory for each chunk
+			event_textp[chunkcounter] = vod_alloc(request_context->pool, MAX_STR_SIZE_EVNT_CHUNK);
+			if (event_textp[chunkcounter] == NULL)
+			{
+				vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+					"ass_parse_frames: vod_alloc failed");
+				ass_clean_known_mem(request_context, ass_track, event_textp);
+				return VOD_ALLOC_FAILED;
+			}
+			event_len[chunkcounter] = 0;
+		}
 
-        bool_t  ibu_flags[NUM_OF_INLINE_TAGS_SUPPORTED] = {cur_style->italic, cur_style->bold, cur_style->underline};
-        uint32_t max_run = 0;
-        int  num_chunks_in_text = split_event_text_to_chunks(cur_event->text, vod_strlen(cur_event->text),
-                                  cur_style->right_to_left_language, event_textp, event_len,
-                                  ibu_flags, &max_run, request_context);
+		bool_t  ibu_flags[NUM_OF_INLINE_TAGS_SUPPORTED] = {cur_style->italic, cur_style->bold, cur_style->underline};
+		uint32_t max_run = 0;
+		int  num_chunks_in_text =	split_event_text_to_chunks(cur_event->text, vod_strlen(cur_event->text),
+									cur_style->right_to_left_language, event_textp, event_len,
+									ibu_flags, &max_run, request_context);
 
-        // allocate the output frame
-        cur_frame = vod_array_push(&frames);
-        if (cur_frame == NULL)
-        {
-            vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-                "ass_parse_frames: vod_array_push failed");
-            ass_clean_known_mem(request_context, ass_track, event_textp);
-            return VOD_ALLOC_FAILED;
-        }
-        // allocate the text of output frame
-        p = pfixed = vod_alloc(request_context->pool, MAX_STR_SIZE_EVNT_CHUNK);
-        if (p == NULL)
-        {
-            vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-                "ass_parse_frames: vod_alloc failed");
-            ass_clean_known_mem(request_context, ass_track, event_textp);
-            return VOD_ALLOC_FAILED;
-        }
+		// allocate the output frame
+		cur_frame = vod_array_push(&frames);
+		if (cur_frame == NULL)
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"ass_parse_frames: vod_array_push failed");
+			ass_clean_known_mem(request_context, ass_track, event_textp);
+			return VOD_ALLOC_FAILED;
+		}
+		// allocate the text of output frame
+		p = pfixed = vod_alloc(request_context->pool, MAX_STR_SIZE_EVNT_CHUNK);
+		if (p == NULL)
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"ass_parse_frames: vod_alloc failed");
+			ass_clean_known_mem(request_context, ass_track, event_textp);
+			return VOD_ALLOC_FAILED;
+		}
 
-        if (evntcounter == (ass_track->n_events - 1))
-        {
-            cur_frame->duration = cur_event->end - cur_event->start;
-            vtt_track->total_frames_duration += cur_frame->duration;
-        }
+		if (evntcounter == (ass_track->n_events - 1))
+		{
+			cur_frame->duration = cur_event->end - cur_event->start;
+			vtt_track->total_frames_duration += cur_frame->duration;
+		}
 
-        // Cues are named "c<iteration_number_in_7_digits>" starting from c0000000
-        vod_sprintf((u_char*)p, FIXED_WEBVTT_CUE_FORMAT_STR, evntcounter);      p += FIXED_WEBVTT_CUE_NAME_WIDTH;
-        len = 2; vod_memcpy(p, "\r\n", len);                                    p += len;
-        // timestamps will be inserted here, we now insert positioning and alignment changes
-        {
-            bool_t    bleft = FALSE, bright = FALSE;
-            if ((cur_style->alignment & 1) == 0)              //center alignment  2/6/10
-            {
-                // do nothing
-            }
-            else if (((cur_style->alignment - 1) & 3) == 0)  //left   alignment  1/5/9
-            {
-                 bleft  = TRUE;
-            }
-            else
-            {                                                //right  alignment  3/7/11
-                 bright = TRUE;
-            }
+		// Cues are named "c<iteration_number_in_7_digits>" starting from c0000000
+		vod_sprintf((u_char*)p, FIXED_WEBVTT_CUE_NAME_STR, evntcounter);		p += FIXED_WEBVTT_CUE_NAME_WIDTH;
+		len = 2; vod_memcpy(p, "\r\n", len);									p += len;
+		// timestamps will be inserted here, we now insert positioning and alignment changes
+		{
+			bool_t	bleft = FALSE, bright = FALSE;
+			if ((cur_style->alignment & 1) == 0)			//center alignment  2/6/10
+			{
+				// do nothing
+			}
+			else if (((cur_style->alignment - 1) & 3) == 0)	//left	 alignment  1/5/9
+			{
+				bleft  = TRUE;
+			}
+			else
+			{												//right	 alignment  3/7/11
+				bright = TRUE;
+			}
 
-            margL = ((cur_event->margin_l > 0) ? cur_event->margin_l : cur_style->margin_l) * 100 / ass_track->play_res_x;
-            margR = (ass_track->play_res_x - ((cur_event->margin_r > 0) ? cur_event->margin_r : cur_style->margin_r)) * 100 / ass_track->play_res_x;
-            margV = ((cur_event->margin_v > 0) ? cur_event->margin_v : cur_style->margin_v) * 100 / ass_track->play_res_y; // top assumed
-            // All the margX variables are percentages in rounded integer values.
-            // line is integer in range of [0 - 12] given 16 rows of lines in the frame.
-            if (margL || margR || margV)
-            {
-                // center/middle means we are giving the coordinate of the center/middle point
-                int line, sizeH, pos;
+			marg_l = ((cur_event->margin_l > 0) ? cur_event->margin_l : cur_style->margin_l) * 100 / ass_track->play_res_x;
+			marg_r = (ass_track->play_res_x - ((cur_event->margin_r > 0) ? cur_event->margin_r : cur_style->margin_r)) * 100 / ass_track->play_res_x;
+			marg_v = ((cur_event->margin_v > 0) ? cur_event->margin_v : cur_style->margin_v) * 100 / ass_track->play_res_y; // top assumed
+			// All the margX variables are percentages in rounded integer values.
+			// line is integer in range of [0 - 12] given 16 rows of lines in the frame.
+			if (marg_l || marg_r || marg_v)
+			{
+				// center/middle means we are giving the coordinate of the center/middle point
+				int line, sizeH, pos;
 
-                if (cur_style->alignment >= VALIGN_CENTER)    //middle alignment  for values 9,10,11
-                {
-                    line = 7;
-                } else if (cur_style->alignment < VALIGN_TOP) //bottom alignment  for values 1, 2, 3
-                {
-                    margV = 100 - margV;
-                    line = FFMINMAX((margV+4) >> 3, 0, 12);
-                }
-                else                                          //top alignment is the default assumption
-                {
-                    line = FFMINMAX((margV+4) >> 3, 0, 12);
-                }
+				if (cur_style->alignment >= VALIGN_CENTER)		//middle alignment  for values 9,10,11
+				{
+					line = 7;
+				} else if (cur_style->alignment < VALIGN_TOP)	//bottom alignment  for values 1, 2, 3
+				{
+					marg_v = 100 - marg_v;
+					line = FFMINMAX((marg_v+4) >> 3, 0, 12);
+				}
+				else											//top alignment is the default assumption
+				{
+					line = FFMINMAX((marg_v+4) >> 3, 0, 12);
+				}
 
-                // cap horizontal size to more than 2x to make sure we don't break lines with generic font
-                // cap horizontal size to no more than 3x to make sure we allow right and left aligned events on same line
-                sizeH = FFMINMAX(margR - margL, (int)(max_run*2), (int)(max_run*3));
-                if ((!bleft) && (!bright))                        //center alignment  2/6/10
-                {
-                    pos = FFMINMAX((margR + margL + 1)/2, sizeH/2, 100 - sizeH/2);
-                }
-                else if (bleft)                                   //left   alignment  1/5/9
-                {
-                    pos = FFMINMAX(margL, 0, 100 - sizeH);
-                }
-                else                                              //right  alignment  3/7/11
-                {
-                    pos = FFMINMAX(margR, sizeH, 100);
-                }
+				// cap horizontal size to more than 2x to make sure we don't break lines with generic font
+				// cap horizontal size to no more than 3x to make sure we allow right and left aligned events on same line
+				sizeH = FFMINMAX(marg_r - marg_l, (int)(max_run*2), (int)(max_run*3));
+				if ((!bleft) && (!bright))						//center alignment  2/6/10
+				{
+					pos = FFMINMAX((marg_r + marg_l + 1)/2, sizeH/2, 100 - sizeH/2);
+				}
+				else if (bleft)									//left   alignment  1/5/9
+				{
+					pos = FFMINMAX(marg_l, 0, 100 - sizeH);
+				}
+				else											//right  alignment  3/7/11
+				{
+					pos = FFMINMAX(marg_r, sizeH, 100);
+				}
 
-                len = 10; vod_memcpy(p, " position:", len);                     p += len;
-                vod_sprintf((u_char*)p, "%03uD", pos);                          p += 3;
-                len =  7; vod_memcpy(p, "% size:", len);                        p += len;
-                vod_sprintf((u_char*)p, "%03uD", sizeH);                        p += 3;
-                len =  7; vod_memcpy(p, "% line:", len);                        p += len;
-                vod_sprintf((u_char*)p, "%02uD", line);                         p += 2;
-            }
-            // We should only insert this if an alignment override tag {\a...}is in the text, otherwise follow the style's alignment
-            // but for now, insert it all the time till all players can read styles
-            len =  7; vod_memcpy(p, " align:", len);                            p += len;
-            if ((!bleft) && (!bright))                               //center alignment  2/6/10
-            {
-                len =  6; vod_memcpy(p, "center", len);                         p += len;
-            }
-            else if (bleft)                                          //left   alignment  1/5/9
-            {
-                len =  4; vod_memcpy(p, "left", len);                           p += len;
-            }
-            else                                                     //right  alignment  3/7/11
-            {
-                len =  5; vod_memcpy(p, "right", len);                          p += len;
-            }
-            len = 2; vod_memcpy(p, "\r\n", len);                                p += len;
-        }
+				len = 10; vod_memcpy(p, " position:", len);	p += len;
+				vod_sprintf((u_char*)p, "%03uD", pos);		p += 3;
+				len =  7; vod_memcpy(p, "% size:", len);	p += len;
+				vod_sprintf((u_char*)p, "%03uD", sizeH);	p += 3;
+				len =  7; vod_memcpy(p, "% line:", len);	p += len;
+				vod_sprintf((u_char*)p, "%02uD", line);		p += 2;
+			}
+			// We should only insert this if an alignment override tag {\a...}is in the text, otherwise follow the style's alignment
+			// but for now, insert it all the time till all players can read styles
+			len =  7; vod_memcpy(p, " align:", len);		p += len;
+			if ((!bleft) && (!bright))							//center alignment  2/6/10
+			{
+				len =  6; vod_memcpy(p, "center", len);		p += len;
+			}
+			else if (bleft)										//left	 alignment  1/5/9
+			{
+				len =  4; vod_memcpy(p, "left", len);		p += len;
+			}
+			else												//right  alignment  3/7/11
+			{
+				len =  5; vod_memcpy(p, "right", len);		p += len;
+			}
+			len = 2; vod_memcpy(p, "\r\n", len);			p += len;
+		}
 #ifdef ASSUME_STYLE_SUPPORT
-        vod_memcpy(p, FIXED_WEBVTT_VOICE_START_STR, FIXED_WEBVTT_VOICE_START_WIDTH);       p += FIXED_WEBVTT_VOICE_START_WIDTH;
-        len = vod_strlen(cur_style->name); vod_sprintf((u_char*)p, cur_style->name, len);  p += len;
-        vod_memcpy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);           p += FIXED_WEBVTT_VOICE_END_WIDTH;
+		vod_memcpy(p, FIXED_WEBVTT_VOICE_START_STR, FIXED_WEBVTT_VOICE_START_WIDTH);		p += FIXED_WEBVTT_VOICE_START_WIDTH;
+		len = vod_strlen(cur_style->name); vod_sprintf((u_char*)p, cur_style->name, len);	p += len;
+		vod_memcpy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);			p += FIXED_WEBVTT_VOICE_END_WIDTH;
 #endif //ASSUME_STYLE_SUPPORT
 
-        for (chunkcounter = 0; chunkcounter < num_chunks_in_text; chunkcounter++)
-        {
-             vod_memcpy(p, event_textp[chunkcounter], event_len[chunkcounter]); p += event_len[chunkcounter];
-        }
+		for (chunkcounter = 0; chunkcounter < num_chunks_in_text; chunkcounter++)
+		{
+			 vod_memcpy(p, event_textp[chunkcounter], event_len[chunkcounter]); p += event_len[chunkcounter];
+		}
 
-        len = 2; vod_memcpy(p, "\r\n", len);                                    p += len;
-        // we still need an empty line after each event/cue
-        len = 2; vod_memcpy(p, "\r\n", len);                                    p += len;
+		len = 2; vod_memcpy(p, "\r\n", len);				p += len;
+		// we still need an empty line after each event/cue
+		len = 2; vod_memcpy(p, "\r\n", len);				p += len;
 
-        // Note: mapping of cue into input_frame_t:
-        // - offset = pointer to buffer containing: cue id, cue settings list, cue payload
-        // - size = size of data pointed by offset
-        // - key_frame = cue id length
-        // - duration = start time of next event - start time of current event
-        // - pts_delay = end time - start time = duration this subtitle event is on screen
+		// Note: mapping of cue into input_frame_t:
+		// - offset = pointer to buffer containing: cue id, cue settings list, cue payload
+		// - size = size of data pointed by offset
+		// - key_frame = cue id length
+		// - duration = start time of next event - start time of current event
+		// - pts_delay = end time - start time = duration this subtitle event is on screen
 
-        cur_frame->offset    = (uintptr_t)pfixed;
-        cur_frame->size      = (uint32_t)(p - pfixed);
-        cur_frame->key_frame = FIXED_WEBVTT_CUE_NAME_WIDTH + 2; // cue name + \r\n
-        cur_frame->pts_delay = cur_event->end - cur_event->start;
+		cur_frame->offset	= (uintptr_t)pfixed;
+		cur_frame->size	  = (uint32_t)(p - pfixed);
+		cur_frame->key_frame = FIXED_WEBVTT_CUE_NAME_WIDTH + 2; // cue name + \r\n
+		cur_frame->pts_delay = cur_event->end - cur_event->start;
 
-        vtt_track->total_frames_size += cur_frame->size;
-        cur_style->output_in_cur_segment = TRUE; // output this style as part of this segment
+		vtt_track->total_frames_size += cur_frame->size;
+		cur_style->output_in_cur_segment = TRUE; // output this style as part of this segment
 
-        last_start_time = cur_event->start;
-    }
+		last_start_time = cur_event->start;
+	}
 
-    //allocate memory for the style's text string
-    p = pfixed = vod_alloc(request_context->pool, MAX_STR_SIZE_ALL_WEBVTT_STYLES);
-    if (p == NULL)
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "ass_parse_frames: vod_alloc failed");
-        ass_free_track(request_context->pool, ass_track);
-        return VOD_ALLOC_FAILED;
-    }
+	//allocate memory for the style's text string
+	p = pfixed = vod_alloc(request_context->pool, MAX_STR_SIZE_ALL_WEBVTT_STYLES);
+	if (p == NULL)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"ass_parse_frames: vod_alloc failed");
+		ass_free_track(request_context->pool, ass_track);
+		return VOD_ALLOC_FAILED;
+	}
 
-    // We now insert header and all style definitions
-    header->data              = (u_char*)pfixed;
-    len = sizeof(WEBVTT_HEADER_NEWLINES) - 1; vod_memcpy(p, WEBVTT_HEADER_NEWLINES, len);  p+=len;
+	// We now insert header and all style definitions
+	header->data			  = (u_char*)pfixed;
+	len = sizeof(WEBVTT_HEADER_NEWLINES) - 1; vod_memcpy(p, WEBVTT_HEADER_NEWLINES, len);  p+=len;
 #ifdef ASSUME_STYLE_SUPPORT
-    int stylecounter;
-    for (stylecounter = (ass_track->default_style ? 1 : 0); (stylecounter < ass_track->n_styles); stylecounter++)
-    {
-        ass_style_t* cur_style = ass_track->styles + stylecounter;
-        if (cur_style->output_in_cur_segment)
-            p = output_one_style(cur_style, p);
+	int stylecounter;
+	for (stylecounter = (ass_track->default_style ? 1 : 0); (stylecounter < ass_track->n_styles); stylecounter++)
+	{
+		ass_style_t* cur_style = ass_track->styles + stylecounter;
+		if (cur_style->output_in_cur_segment)
+			p = output_one_style(cur_style, p);
 
-    }
+	}
 #endif //ASSUME_STYLE_SUPPORT
-    header->len               = (size_t)(p - pfixed);
+	header->len						= (size_t)(p - pfixed);
 
-    // now we got all the info from ass_track, deallocate its memory
-    ass_free_track(request_context->pool, ass_track);
+	// now we got all the info from ass_track, deallocate its memory
+	ass_free_track(request_context->pool, ass_track);
 
-    vtt_track->frame_count        = frames.nelts;
-    vtt_track->frames.clip_to     = clip_to;
-    vtt_track->frames.first_frame = frames.elts;
-    vtt_track->frames.last_frame  = vtt_track->frames.first_frame + frames.nelts;
+	vtt_track->frame_count			= frames.nelts;
+	vtt_track->frames.clip_to		= clip_to;
+	vtt_track->frames.first_frame	= frames.elts;
+	vtt_track->frames.last_frame	= vtt_track->frames.first_frame + frames.nelts;
 
-    return VOD_OK;
+	return VOD_OK;
 }
 
 media_format_t ass_format = {
-    FORMAT_ID_ASS,
-    vod_string("ass_or_ssa"),
-    ass_reader_init,
-    subtitle_reader_read,
-    NULL,
-    NULL,
-    ass_parse,
-    ass_parse_frames,
+	FORMAT_ID_ASS,
+	vod_string("ass_or_ssa"),
+	ass_reader_init,
+	subtitle_reader_read,
+	NULL,
+	NULL,
+	ass_parse,
+	ass_parse_frames,
 };

--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -36,11 +36,10 @@
 #define NUM_OF_INLINE_TAGS_SUPPORTED 3     //ibu
 #define NUM_OF_TAGS_ALLOWED_PER_LINE 1
 
-
 //#define ASSUME_STYLE_SUPPORT
 
-
-typedef enum {
+typedef enum
+{
     TAG_TYPE_NEWLINE_SMALL  = 0,
     TAG_TYPE_NEWLINE_LARGE  = 1,
     TAG_TYPE_AMPERSANT      = 2,
@@ -62,7 +61,9 @@ typedef enum {
     TAG_TYPE_UNKNOWN_TAG    = 13, // has to be after all known braces types
     TAG_TYPE_NONE           = 14
 } ass_tag_idx_t;
-static const char* const tag_strings[TAG_TYPE_NONE] = {
+
+static const char* const tag_strings[TAG_TYPE_NONE] =
+{
     "\\n",
     "\\N",
     "&",
@@ -81,7 +82,8 @@ static const char* const tag_strings[TAG_TYPE_NONE] = {
 
     "\\"
 };
-static const int tag_string_len[TAG_TYPE_NONE][2] = {
+static const int tag_string_len[TAG_TYPE_NONE][2] =
+{
     // index 0 is size of ASS tag, index 1 is size of replacement webVTT tag
     {2,2},
     {2,2},
@@ -101,7 +103,8 @@ static const int tag_string_len[TAG_TYPE_NONE][2] = {
 
     {1,0}
 };
-static const char* tag_replacement_strings[TAG_TYPE_NONE] = {
+static const char* tag_replacement_strings[TAG_TYPE_NONE] =
+{
     "\r\n",
     "\r\n",
     "&amp;",
@@ -143,21 +146,25 @@ static int split_event_text_to_chunks(char *src, int srclen, bool_t rtl, char **
     }
 
     // if right to left language, insert marker before text
-    if (rtl == TRUE) {
+    if (rtl)
+    {
          vod_memcpy(textp[chunkidx], FIXED_WEBVTT_ESCAPE_FOR_RTL_STR, FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH);
          dstidx+=FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH;
     }
 
     // insert openers to currently open modes, ordered as <i><b><u>
-    if (ibu_flags[0] == TRUE) {
+    if (ibu_flags[0])
+    {
         vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_START], tag_string_len[TAG_TYPE_ITALIC_START][1]);
         dstidx += tag_string_len[TAG_TYPE_ITALIC_START][1];
     }
-    if (ibu_flags[1] == TRUE) {
+    if (ibu_flags[1])
+    {
          vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_START], tag_string_len[TAG_TYPE_BOLD_START][1]);
          dstidx += tag_string_len[TAG_TYPE_BOLD_START][1];
     }
-    if (ibu_flags[2] == TRUE) {
+    if (ibu_flags[2])
+    {
         vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_START], tag_string_len[TAG_TYPE_UNDER_START][1]);
         dstidx += tag_string_len[TAG_TYPE_UNDER_START][1];
     }
@@ -186,30 +193,36 @@ static int split_event_text_to_chunks(char *src, int srclen, bool_t rtl, char **
                         if (ibu_flags[ibu_idx] == opposite)
                         {
                             // insert closures to open spans, ordered as </u></b></i>
-                            if (ibu_flags[2] == TRUE) {
+                            if (ibu_flags[2])
+                            {
                                 vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_END], tag_string_len[TAG_TYPE_UNDER_END][1]);
                                 dstidx += tag_string_len[TAG_TYPE_UNDER_END][1];
                             }
-                            if (ibu_flags[1] == TRUE) {
+                            if (ibu_flags[1])
+                            {
                                  vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_END], tag_string_len[TAG_TYPE_BOLD_END][1]);
                                  dstidx += tag_string_len[TAG_TYPE_BOLD_END][1];
                             }
-                            if (ibu_flags[0] == TRUE) {
+                            if (ibu_flags[0])
+                            {
                                 vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_END], tag_string_len[TAG_TYPE_ITALIC_END][1]);
                                 dstidx += tag_string_len[TAG_TYPE_ITALIC_END][1];
                             }
                             // toggle the flag
                             ibu_flags[ibu_idx] = !ibu_flags[ibu_idx];
                             // insert openers to currently open modes, ordered as <i><b><u>
-                            if (ibu_flags[0] == TRUE) {
+                            if (ibu_flags[0])
+                            {
                                 vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_START], tag_string_len[TAG_TYPE_ITALIC_START][1]);
                                 dstidx += tag_string_len[TAG_TYPE_ITALIC_START][1];
                             }
-                            if (ibu_flags[1] == TRUE) {
+                            if (ibu_flags[1])
+                            {
                                  vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_START], tag_string_len[TAG_TYPE_BOLD_START][1]);
                                  dstidx += tag_string_len[TAG_TYPE_BOLD_START][1];
                             }
-                            if (ibu_flags[2] == TRUE) {
+                            if (ibu_flags[2])
+                            {
                                 vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_START], tag_string_len[TAG_TYPE_UNDER_START][1]);
                                 dstidx += tag_string_len[TAG_TYPE_UNDER_START][1];
                             }
@@ -217,23 +230,27 @@ static int split_event_text_to_chunks(char *src, int srclen, bool_t rtl, char **
                     } break;
 
                     case (TAG_TYPE_NEWLINE_LARGE):
-                    case (TAG_TYPE_NEWLINE_SMALL): {
-                        if (cur_run > *max_run) {
+                    case (TAG_TYPE_NEWLINE_SMALL):
+                    {
+                        if (cur_run > *max_run)
+                        {
                             *max_run = cur_run; // we don't add the size of \r\n since they are not visible on screen.
                             cur_run = 0;        // max_run holds the longest run of visible characters on any line.
                         }
                         // replace the string with its equivalent in target string
                         vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
                         dstidx += tag_string_len[tagidx][1]; //tag got written to output
-                        if (rtl == TRUE) {
+                        if (rtl)
+                        {
                              vod_memcpy(textp[chunkidx] + dstidx, FIXED_WEBVTT_ESCAPE_FOR_RTL_STR, FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH);
-                             dstidx+=FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH;
+                             dstidx += FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH;
                         }
                     } break;
 
                     case (TAG_TYPE_AMPERSANT):
                     case (TAG_TYPE_BIGGERTHAN):
-                    case (TAG_TYPE_SMALLERTHAN): {
+                    case (TAG_TYPE_SMALLERTHAN):
+                    {
                         cur_run++;  // just one single visible character out of this webvtt code word
                         // replace the string with its equivalent in target string
                         vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
@@ -241,14 +258,16 @@ static int split_event_text_to_chunks(char *src, int srclen, bool_t rtl, char **
                     } break;
 
                     case (TAG_TYPE_OPEN_BRACES):
-                    case (TAG_TYPE_CLOSE_BRACES): {
+                    case (TAG_TYPE_CLOSE_BRACES):
+                    {
                         bBracesOpen = (tagidx & 1);
                         // replace the string with its equivalent in target string
                         vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
                         dstidx += tag_string_len[tagidx][1]; //tag got written to output
                     } break;
 
-                    default: {
+                    default:
+                    {
                         // replace the string with its equivalent in target string
                         vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[tagidx], tag_string_len[tagidx][1]);
                         dstidx += tag_string_len[tagidx][1]; //tag got written to output
@@ -288,24 +307,28 @@ static int split_event_text_to_chunks(char *src, int srclen, bool_t rtl, char **
     }
 
     // insert closures to open spans, ordered as </u></b></i>
-    if (ibu_flags[2] == TRUE) {
+    if (ibu_flags[2])
+    {
         vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_UNDER_END], tag_string_len[TAG_TYPE_UNDER_END][1]);
         dstidx += tag_string_len[TAG_TYPE_UNDER_END][1];
     }
-    if (ibu_flags[1] == TRUE) {
+    if (ibu_flags[1])
+    {
          vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_BOLD_END], tag_string_len[TAG_TYPE_BOLD_END][1]);
          dstidx += tag_string_len[TAG_TYPE_BOLD_END][1];
     }
-    if (ibu_flags[0] == TRUE) {
+    if (ibu_flags[0])
+    {
         vod_memcpy(textp[chunkidx] + dstidx, tag_replacement_strings[TAG_TYPE_ITALIC_END], tag_string_len[TAG_TYPE_ITALIC_END][1]);
         dstidx += tag_string_len[TAG_TYPE_ITALIC_END][1];
     }
 
-    if (cur_run > *max_run) {
+    if (cur_run > *max_run)
+    {
         *max_run = cur_run; // we don't add the size of \r\n since they are not visible on screen.
     }
 
-    evlen[chunkidx]   = dstidx;
+    evlen[chunkidx] = dstidx;
 
     return chunkidx + 1;
 }
@@ -333,55 +356,61 @@ static char* output_one_style(ass_style_t* cur_style, char* p)
 {
         int len;
 
-        vod_memcpy(p, FIXED_WEBVTT_STYLE_START_STR, FIXED_WEBVTT_STYLE_START_WIDTH);           p+=FIXED_WEBVTT_STYLE_START_WIDTH;
-        len = vod_strlen(cur_style->name); vod_memcpy(p, cur_style->name, len);                p+=len;
-        vod_memcpy(p, FIXED_WEBVTT_STYLE_END_STR, FIXED_WEBVTT_STYLE_END_WIDTH);               p+=FIXED_WEBVTT_STYLE_END_WIDTH;
-        vod_memcpy(p, FIXED_WEBVTT_BRACES_START_STR, FIXED_WEBVTT_BRACES_START_WIDTH);         p+=FIXED_WEBVTT_BRACES_START_WIDTH;
+        vod_memcpy(p, FIXED_WEBVTT_STYLE_START_STR, FIXED_WEBVTT_STYLE_START_WIDTH);           p += FIXED_WEBVTT_STYLE_START_WIDTH;
+        len = vod_strlen(cur_style->name); vod_memcpy(p, cur_style->name, len);                p += len;
+        vod_memcpy(p, FIXED_WEBVTT_STYLE_END_STR, FIXED_WEBVTT_STYLE_END_WIDTH);               p += FIXED_WEBVTT_STYLE_END_WIDTH;
+        vod_memcpy(p, FIXED_WEBVTT_BRACES_START_STR, FIXED_WEBVTT_BRACES_START_WIDTH);         p += FIXED_WEBVTT_BRACES_START_WIDTH;
 
-        len = 8; vod_memcpy(p, "color: #", len);                                               p+=len;
-        vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->primary_colour);                     p+=11;
+        len = 8; vod_memcpy(p, "color: #", len);                                               p += len;
+        vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->primary_colour);                     p += 11;
 
 
-        len = 14; vod_memcpy(p, "font-family: \"", len);                                       p+=len;
-        len = vod_strlen(cur_style->font_name); vod_memcpy(p, cur_style->font_name, len);      p+=len;
-        len = 16; vod_memcpy(p, "\", sans-serif;\r\n", len);                                   p+=len;
-        vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", cur_style->font_size);              p+=19;
+        len = 14; vod_memcpy(p, "font-family: \"", len);                                       p += len;
+        len = vod_strlen(cur_style->font_name); vod_memcpy(p, cur_style->font_name, len);      p += len;
+        len = 16; vod_memcpy(p, "\", sans-serif;\r\n", len);                                   p += len;
+        vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", cur_style->font_size);              p += 19;
 
-        /*if (cur_style->bold) {
-            len = 20; vod_memcpy(p, "font-weight: bold;\r\n", len);                            p+=len;
+        /*if (cur_style->bold)
+        {
+            len = 20; vod_memcpy(p, "font-weight: bold;\r\n", len);                            p += len;
         }
-        if (cur_style->italic) {
-            len = 21; vod_memcpy(p, "font-style: italic;\r\n", len);                           p+=len;
+        if (cur_style->italic)
+        {
+            len = 21; vod_memcpy(p, "font-style: italic;\r\n", len);                           p += len;
         }
         // This will inherit the outline_colour (and shadow) if border_style==1, otherwise it inherits primary_colour
-        if (cur_style->underline) {
+        if (cur_style->underline)
+        {
             // available styles are: solid | double | dotted | dashed | wavy
             // available lines are: underline || overline || line-through || blink
-            len = 35; vod_memcpy(p, "text-decoration: solid underline;\r\n", len);             p+=len;
+            len = 35; vod_memcpy(p, "text-decoration: solid underline;\r\n", len);             p += len;
         }
-        else if (cur_style->strike_out) {
+        else if (cur_style->strike_out)
+        {
             // available lines are: underline || overline || line-through || blink
-            len = 38; vod_memcpy(p, "text-decoration: solid line-through;\r\n", len);          p+=len;
+            len = 38; vod_memcpy(p, "text-decoration: solid line-through;\r\n", len);          p += len;
         }*/
 
         if (cur_style->border_style == 1 /*&& ass_track->type == TRACK_TYPE_ASS*/)
         {
             // webkit is not supported by all players, stick to adding outline using text-shadow
-            len = 13; vod_memcpy(p, "text-shadow: ", len);                                     p+=len;
+            len = 13; vod_memcpy(p, "text-shadow: ", len);                                     p += len;
             // add outline in 4 directions with the outline color
             vod_sprintf((u_char*)p, "#%08uxD -%01uDpx 0px, #%08uxD 0px %01uDpx, #%08uxD 0px -%01uDpx, #%08uxD %01uDpx 0px, #%08uxD %01uDpx %01uDpx 0px;\r\n",
                          cur_style->outline_colour, cur_style->outline,
                          cur_style->outline_colour, cur_style->outline,
                          cur_style->outline_colour, cur_style->outline,
                          cur_style->outline_colour, cur_style->outline,
-                         cur_style->back_colour, cur_style->shadow, cur_style->shadow);        p+=102;
+                         cur_style->back_colour, cur_style->shadow, cur_style->shadow);        p += 102;
 
-        } else {
-            len = 19; vod_memcpy(p, "background-color: #", len);                               p+=len;
-            vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->back_colour);                    p+=11;
         }
-        vod_memcpy(p, FIXED_WEBVTT_BRACES_END_STR, FIXED_WEBVTT_BRACES_END_WIDTH);             p+=FIXED_WEBVTT_BRACES_END_WIDTH;
-        len = 2; vod_memcpy(p, "\r\n", len);                                                   p+=len;
+        else
+        {
+            len = 19; vod_memcpy(p, "background-color: #", len);                               p += len;
+            vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->back_colour);                    p += 11;
+        }
+        vod_memcpy(p, FIXED_WEBVTT_BRACES_END_STR, FIXED_WEBVTT_BRACES_END_WIDTH);             p += FIXED_WEBVTT_BRACES_END_WIDTH;
+        len = 2; vod_memcpy(p, "\r\n", len);                                                   p += len;
 
         return p;
 }
@@ -631,7 +660,7 @@ ass_parse_frames(
         int            margL, margR, margV; // all of these are integer percentage values
 
         // allocate memory for the chunk pointer itself first
-        for (chunkcounter = 0; chunkcounter<NUM_OF_TAGS_ALLOWED_PER_LINE; chunkcounter++)
+        for (chunkcounter = 0; chunkcounter < NUM_OF_TAGS_ALLOWED_PER_LINE; chunkcounter++)
         {
             // now allocate string memory for each chunk
             event_textp[chunkcounter] = vod_alloc(request_context->pool, MAX_STR_SIZE_EVNT_CHUNK);
@@ -677,16 +706,21 @@ ass_parse_frames(
         }
 
         // Cues are named "c<iteration_number_in_7_digits>" starting from c0000000
-        vod_sprintf((u_char*)p, FIXED_WEBVTT_CUE_FORMAT_STR, evntcounter);      p+=FIXED_WEBVTT_CUE_NAME_WIDTH;
-        len = 2; vod_memcpy(p, "\r\n", len);                                    p+=len;
+        vod_sprintf((u_char*)p, FIXED_WEBVTT_CUE_FORMAT_STR, evntcounter);      p += FIXED_WEBVTT_CUE_NAME_WIDTH;
+        len = 2; vod_memcpy(p, "\r\n", len);                                    p += len;
         // timestamps will be inserted here, we now insert positioning and alignment changes
         {
             bool_t    bleft = FALSE, bright = FALSE;
-            if ((cur_style->alignment & 1) == 0) {              //center alignment  2/6/10
+            if ((cur_style->alignment & 1) == 0)              //center alignment  2/6/10
+            {
                 // do nothing
-            } else if (((cur_style->alignment - 1) & 3) == 0) { //left   alignment  1/5/9
+            }
+            else if (((cur_style->alignment - 1) & 3) == 0)  //left   alignment  1/5/9
+            {
                  bleft  = TRUE;
-            } else {                                            //right  alignment  3/7/11
+            }
+            else
+            {                                                //right  alignment  3/7/11
                  bright = TRUE;
             }
 
@@ -700,59 +734,73 @@ ass_parse_frames(
                 // center/middle means we are giving the coordinate of the center/middle point
                 int line, sizeH, pos;
 
-                if (cur_style->alignment >= VALIGN_CENTER) {   //middle alignment  for values 9,10,11
+                if (cur_style->alignment >= VALIGN_CENTER)    //middle alignment  for values 9,10,11
+                {
                     line = 7;
-                } else if (cur_style->alignment < VALIGN_TOP) { //bottom alignment  for values 1, 2, 3
+                } else if (cur_style->alignment < VALIGN_TOP) //bottom alignment  for values 1, 2, 3
+                {
                     margV = 100 - margV;
                     line = FFMINMAX((margV+4) >> 3, 0, 12);
-                } else {                                        //top alignment is the default assumption
+                }
+                else                                          //top alignment is the default assumption
+                {
                     line = FFMINMAX((margV+4) >> 3, 0, 12);
                 }
 
                 // cap horizontal size to more than 2x to make sure we don't break lines with generic font
                 // cap horizontal size to no more than 3x to make sure we allow right and left aligned events on same line
                 sizeH = FFMINMAX(margR - margL, (int)(max_run*2), (int)(max_run*3));
-                if ((bleft == FALSE) && (bright == FALSE)) {        //center alignment  2/6/10
+                if ((!bleft) && (!bright))                        //center alignment  2/6/10
+                {
                     pos = FFMINMAX((margR + margL + 1)/2, sizeH/2, 100 - sizeH/2);
-                } else if (bleft == TRUE) {                         //left   alignment  1/5/9
+                }
+                else if (bleft)                                   //left   alignment  1/5/9
+                {
                     pos = FFMINMAX(margL, 0, 100 - sizeH);
-                } else {                                            //right  alignment  3/7/11
+                }
+                else                                              //right  alignment  3/7/11
+                {
                     pos = FFMINMAX(margR, sizeH, 100);
                 }
 
-                len = 10; vod_memcpy(p, " position:", len);                     p+=len;
-                vod_sprintf((u_char*)p, "%03uD", pos);                          p+=3;
-                len =  7; vod_memcpy(p, "% size:", len);                        p+=len;
-                vod_sprintf((u_char*)p, "%03uD", sizeH);                        p+=3;
-                len =  7; vod_memcpy(p, "% line:", len);                        p+=len;
-                vod_sprintf((u_char*)p, "%02uD", line);                         p+=2;
+                len = 10; vod_memcpy(p, " position:", len);                     p += len;
+                vod_sprintf((u_char*)p, "%03uD", pos);                          p += 3;
+                len =  7; vod_memcpy(p, "% size:", len);                        p += len;
+                vod_sprintf((u_char*)p, "%03uD", sizeH);                        p += 3;
+                len =  7; vod_memcpy(p, "% line:", len);                        p += len;
+                vod_sprintf((u_char*)p, "%02uD", line);                         p += 2;
             }
             // We should only insert this if an alignment override tag {\a...}is in the text, otherwise follow the style's alignment
             // but for now, insert it all the time till all players can read styles
-            len =  7; vod_memcpy(p, " align:", len);                            p+=len;
-            if ((bleft == FALSE) && (bright == FALSE)) {            //center alignment  2/6/10
-                len =  6; vod_memcpy(p, "center", len);                         p+=len;
-            } else if (bleft == TRUE) {                             //left   alignment  1/5/9
-                len =  4; vod_memcpy(p, "left", len);                           p+=len;
-            } else {                                                //right  alignment  3/7/11
-                len =  5; vod_memcpy(p, "right", len);                          p+=len;
+            len =  7; vod_memcpy(p, " align:", len);                            p += len;
+            if ((!bleft) && (!bright))                               //center alignment  2/6/10
+            {
+                len =  6; vod_memcpy(p, "center", len);                         p += len;
             }
-            len = 2; vod_memcpy(p, "\r\n", len);                                p+=len;
+            else if (bleft)                                          //left   alignment  1/5/9
+            {
+                len =  4; vod_memcpy(p, "left", len);                           p += len;
+            }
+            else                                                     //right  alignment  3/7/11
+            {
+                len =  5; vod_memcpy(p, "right", len);                          p += len;
+            }
+            len = 2; vod_memcpy(p, "\r\n", len);                                p += len;
         }
 #ifdef ASSUME_STYLE_SUPPORT
-        vod_memcpy(p, FIXED_WEBVTT_VOICE_START_STR, FIXED_WEBVTT_VOICE_START_WIDTH);       p+=FIXED_WEBVTT_VOICE_START_WIDTH;
-        len = vod_strlen(cur_style->name); vod_sprintf((u_char*)p, cur_style->name, len);  p+=len;
-        vod_memcpy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);           p+=FIXED_WEBVTT_VOICE_END_WIDTH;
+        vod_memcpy(p, FIXED_WEBVTT_VOICE_START_STR, FIXED_WEBVTT_VOICE_START_WIDTH);       p += FIXED_WEBVTT_VOICE_START_WIDTH;
+        len = vod_strlen(cur_style->name); vod_sprintf((u_char*)p, cur_style->name, len);  p += len;
+        vod_memcpy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);           p += FIXED_WEBVTT_VOICE_END_WIDTH;
 #endif //ASSUME_STYLE_SUPPORT
 
         for (chunkcounter = 0; chunkcounter < num_chunks_in_text; chunkcounter++)
         {
-             vod_memcpy(p, event_textp[chunkcounter], event_len[chunkcounter]);  p+=event_len[chunkcounter];
+             vod_memcpy(p, event_textp[chunkcounter], event_len[chunkcounter]); p += event_len[chunkcounter];
         }
 
-        len = 2; vod_memcpy(p, "\r\n", len);                                    p+=len;
+        len = 2; vod_memcpy(p, "\r\n", len);                                    p += len;
         // we still need an empty line after each event/cue
-        len = 2; vod_memcpy(p, "\r\n", len);                                    p+=len;
+        len = 2; vod_memcpy(p, "\r\n", len);                                    p += len;
 
         // Note: mapping of cue into input_frame_t:
         // - offset = pointer to buffer containing: cue id, cue settings list, cue payload
@@ -790,7 +838,7 @@ ass_parse_frames(
     for (stylecounter = (ass_track->default_style ? 1 : 0); (stylecounter < ass_track->n_styles); stylecounter++)
     {
         ass_style_t* cur_style = ass_track->styles + stylecounter;
-        if (cur_style->output_in_cur_segment == TRUE)
+        if (cur_style->output_in_cur_segment)
             p = output_one_style(cur_style, p);
 
     }

--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -37,7 +37,6 @@
 #define NUM_OF_TAGS_ALLOWED_PER_LINE 1
 
 
-//#define TEMP_VERBOSITY
 //#define ASSUME_STYLE_SUPPORT
 
 
@@ -335,51 +334,51 @@ static char* output_one_style(ass_style_t* cur_style, char* p)
         int len;
 
         vod_memcpy(p, FIXED_WEBVTT_STYLE_START_STR, FIXED_WEBVTT_STYLE_START_WIDTH);           p+=FIXED_WEBVTT_STYLE_START_WIDTH;
-        len = vod_strlen(cur_style->Name); vod_memcpy(p, cur_style->Name, len);                p+=len;
+        len = vod_strlen(cur_style->name); vod_memcpy(p, cur_style->name, len);                p+=len;
         vod_memcpy(p, FIXED_WEBVTT_STYLE_END_STR, FIXED_WEBVTT_STYLE_END_WIDTH);               p+=FIXED_WEBVTT_STYLE_END_WIDTH;
         vod_memcpy(p, FIXED_WEBVTT_BRACES_START_STR, FIXED_WEBVTT_BRACES_START_WIDTH);         p+=FIXED_WEBVTT_BRACES_START_WIDTH;
 
         len = 8; vod_memcpy(p, "color: #", len);                                               p+=len;
-        vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->PrimaryColour);                      p+=11;
+        vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->primary_colour);                     p+=11;
 
 
         len = 14; vod_memcpy(p, "font-family: \"", len);                                       p+=len;
-        len = vod_strlen(cur_style->FontName); vod_memcpy(p, cur_style->FontName, len);        p+=len;
+        len = vod_strlen(cur_style->font_name); vod_memcpy(p, cur_style->font_name, len);      p+=len;
         len = 16; vod_memcpy(p, "\", sans-serif;\r\n", len);                                   p+=len;
-        vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", cur_style->FontSize);               p+=19;
+        vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", cur_style->font_size);              p+=19;
 
-        /*if (cur_style->Bold) {
+        /*if (cur_style->bold) {
             len = 20; vod_memcpy(p, "font-weight: bold;\r\n", len);                            p+=len;
         }
-        if (cur_style->Italic) {
+        if (cur_style->italic) {
             len = 21; vod_memcpy(p, "font-style: italic;\r\n", len);                           p+=len;
         }
-        // This will inherit the OutlineColour (and shadow) if BorderStyle==1, otherwise it inherits PrimaryColour
-        if (cur_style->Underline) {
+        // This will inherit the outline_colour (and shadow) if border_style==1, otherwise it inherits primary_colour
+        if (cur_style->underline) {
             // available styles are: solid | double | dotted | dashed | wavy
             // available lines are: underline || overline || line-through || blink
             len = 35; vod_memcpy(p, "text-decoration: solid underline;\r\n", len);             p+=len;
         }
-        else if (cur_style->StrikeOut) {
+        else if (cur_style->strike_out) {
             // available lines are: underline || overline || line-through || blink
             len = 38; vod_memcpy(p, "text-decoration: solid line-through;\r\n", len);          p+=len;
         }*/
 
-        if (cur_style->BorderStyle == 1 /*&& ass_track->type == TRACK_TYPE_ASS*/)
+        if (cur_style->border_style == 1 /*&& ass_track->type == TRACK_TYPE_ASS*/)
         {
             // webkit is not supported by all players, stick to adding outline using text-shadow
             len = 13; vod_memcpy(p, "text-shadow: ", len);                                     p+=len;
             // add outline in 4 directions with the outline color
             vod_sprintf((u_char*)p, "#%08uxD -%01uDpx 0px, #%08uxD 0px %01uDpx, #%08uxD 0px -%01uDpx, #%08uxD %01uDpx 0px, #%08uxD %01uDpx %01uDpx 0px;\r\n",
-                         cur_style->OutlineColour, cur_style->Outline,
-                         cur_style->OutlineColour, cur_style->Outline,
-                         cur_style->OutlineColour, cur_style->Outline,
-                         cur_style->OutlineColour, cur_style->Outline,
-                         cur_style->BackColour, cur_style->Shadow, cur_style->Shadow);         p+=102;
+                         cur_style->outline_colour, cur_style->outline,
+                         cur_style->outline_colour, cur_style->outline,
+                         cur_style->outline_colour, cur_style->outline,
+                         cur_style->outline_colour, cur_style->outline,
+                         cur_style->back_colour, cur_style->shadow, cur_style->shadow);        p+=102;
 
         } else {
             len = 19; vod_memcpy(p, "background-color: #", len);                               p+=len;
-            vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->BackColour);                     p+=11;
+            vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->back_colour);                    p+=11;
         }
         vod_memcpy(p, FIXED_WEBVTT_BRACES_END_STR, FIXED_WEBVTT_BRACES_END_WIDTH);             p+=FIXED_WEBVTT_BRACES_END_WIDTH;
         len = 2; vod_memcpy(p, "\r\n", len);                                                   p+=len;
@@ -440,15 +439,11 @@ ass_parse(
         parse_params,
         source,
         NULL,
-        (uint64_t)(ass_track->maxDuration),
+        (uint64_t)(ass_track->max_duration),
         metadata_part_count,
         result);
-#ifdef  TEMP_VERBOSITY
-    vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-        "ass_parse(): parse_memory() succeeded, sub_parse succeeded, len of data = %d, maxDuration = %D, nEvents = %d, nStyles = %d",
-        source->len, ass_track->maxDuration, ass_track->n_events, ass_track->n_styles);
-#endif
-    // now that we used maxDuration, we need to free the memory used by the track
+
+    // now that we used max_duration, we need to free the memory used by the track
     ass_free_track(request_context->pool, ass_track);
     return ret_status;
 }
@@ -528,14 +523,6 @@ ass_parse_frames(
             "ass_parse_frames: failed to parse memory into ass track");
         return VOD_BAD_MAPPING;
     }
-#ifdef  TEMP_VERBOSITY
-    else
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "frames parse_memory() succeeded, len of data = %d, maxDuration = %D, nEvents = %d, nStyles = %d",
-            source->len, ass_track->maxDuration, ass_track->n_events, ass_track->n_styles);
-    }
-#endif
 
     // Re-order events so that each event has a starting time that is bigger than or equal than the one before it.
     // This matches WebVTT expectations of cue order. And allows us to calculate frame duration correctly.
@@ -548,7 +535,7 @@ ass_parse_frames(
         {
             ass_event_t*   next_event = ass_track->events + chunkcounter + 1;
                            cur_event  = ass_track->events + chunkcounter;
-            if (cur_event->Start > next_event->Start)
+            if (cur_event->start > next_event->start)
             {
                 //  Swap the two events
                 swap_events(next_event, cur_event);
@@ -584,52 +571,52 @@ ass_parse_frames(
     for (evntcounter = 0; evntcounter < ass_track->n_events; evntcounter++)
     {
         cur_event = ass_track->events + evntcounter;
-        ass_style_t*   cur_style = ass_track->styles + cur_event->Style; //cur_event->Style will be zero for an unknown Style name
+        ass_style_t*   cur_style = ass_track->styles + cur_event->style; //cur_event->style will be zero for an unknown style name
 
         // make all timing checks and clipping, before we decide to read the text or output it.
         // to make sure this event should be included in the segment.
-        if (cur_event->End < 0 || cur_event->Start < 0 || cur_event->Start >= cur_event->End)
+        if (cur_event->end < 0 || cur_event->start < 0 || cur_event->start >= cur_event->end)
         {
             continue;
         }
-        if ((uint64_t)cur_event->End < seg_start)
+        if ((uint64_t)cur_event->end < seg_start)
         {
             continue;
         }
 
         // apply clipping
-        if (cur_event->Start >= (int64_t)base_time)
+        if (cur_event->start >= (int64_t)base_time)
         {
-            cur_event->Start -= base_time;
-            if ((uint64_t)cur_event->Start > clip_to)
+            cur_event->start -= base_time;
+            if ((uint64_t)cur_event->start > clip_to)
             {
-                cur_event->Start = (long long)(clip_to);
+                cur_event->start = (long long)(clip_to);
             }
         }
         else
         {
-            cur_event->Start = 0;
+            cur_event->start = 0;
         }
 
-        cur_event->End -= base_time;
-        if ((uint64_t)cur_event->End > clip_to)
+        cur_event->end -= base_time;
+        if ((uint64_t)cur_event->end > clip_to)
         {
-            cur_event->End = (long long)(clip_to);
+            cur_event->end = (long long)(clip_to);
         }
 
         if (cur_frame != NULL)
         {
-            cur_frame->duration = cur_event->Start - last_start_time;
+            cur_frame->duration = cur_event->start - last_start_time;
             vtt_track->total_frames_duration += cur_frame->duration;
         }
         else
         {
             // if this is the very first event intersecting with segment, this is the first start in the segment
-            vtt_track->first_frame_time_offset = cur_event->Start;
+            vtt_track->first_frame_time_offset = cur_event->start;
             vtt_track->first_frame_index       = evntcounter;
         }
 
-        if ((uint64_t)cur_event->Start >= seg_end)
+        if ((uint64_t)cur_event->start >= seg_end)
         {
             // events are already ordered by start-time
             break;
@@ -658,17 +645,11 @@ ass_parse_frames(
             event_len[chunkcounter] = 0;
         }
 
-        bool_t  ibu_flags[NUM_OF_INLINE_TAGS_SUPPORTED] = {cur_style->Italic, cur_style->Bold, cur_style->Underline};
+        bool_t  ibu_flags[NUM_OF_INLINE_TAGS_SUPPORTED] = {cur_style->italic, cur_style->bold, cur_style->underline};
         uint32_t max_run = 0;
-        int  num_chunks_in_text = split_event_text_to_chunks(cur_event->Text, vod_strlen(cur_event->Text),
-                                  cur_style->b_right_to_left_language, event_textp, event_len,
+        int  num_chunks_in_text = split_event_text_to_chunks(cur_event->text, vod_strlen(cur_event->text),
+                                  cur_style->right_to_left_language, event_textp, event_len,
                                   ibu_flags, &max_run, request_context);
-
-#ifdef  TEMP_VERBOSITY
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "ass_parse_frames: event=%d num_chunks=%d len0=%d",
-            evntcounter, num_chunks_in_text, event_len[0]);
-#endif
 
         // allocate the output frame
         cur_frame = vod_array_push(&frames);
@@ -691,33 +672,27 @@ ass_parse_frames(
 
         if (evntcounter == (ass_track->n_events - 1))
         {
-            cur_frame->duration = cur_event->End - cur_event->Start;
+            cur_frame->duration = cur_event->end - cur_event->start;
             vtt_track->total_frames_duration += cur_frame->duration;
         }
 
-#ifdef  TEMP_VERBOSITY
-            vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-                "UPDATEDURATION: evntCounter=%d, Start=%D, End=%D,duration=%D, total_frames_duration=%D, firstFrmIdx=%d, firstFrmOffset=%D",
-                evntcounter, cur_event->Start, cur_event->End, cur_frame->duration, vtt_track->total_frames_duration,
-                vtt_track->first_frame_index, vtt_track->first_frame_time_offset);
-#endif
         // Cues are named "c<iteration_number_in_7_digits>" starting from c0000000
         vod_sprintf((u_char*)p, FIXED_WEBVTT_CUE_FORMAT_STR, evntcounter);      p+=FIXED_WEBVTT_CUE_NAME_WIDTH;
         len = 2; vod_memcpy(p, "\r\n", len);                                    p+=len;
         // timestamps will be inserted here, we now insert positioning and alignment changes
         {
             bool_t    bleft = FALSE, bright = FALSE;
-            if ((cur_style->Alignment & 1) == 0) {              //center Alignment  2/6/10
+            if ((cur_style->alignment & 1) == 0) {              //center alignment  2/6/10
                 // do nothing
-            } else if (((cur_style->Alignment - 1) & 3) == 0) { //left   Alignment  1/5/9
+            } else if (((cur_style->alignment - 1) & 3) == 0) { //left   alignment  1/5/9
                  bleft  = TRUE;
-            } else {                                            //right  Alignment  3/7/11
+            } else {                                            //right  alignment  3/7/11
                  bright = TRUE;
             }
 
-            margL = ((cur_event->MarginL > 0) ? cur_event->MarginL : cur_style->MarginL) * 100 / ass_track->PlayResX;
-            margR = (ass_track->PlayResX - ((cur_event->MarginR > 0) ? cur_event->MarginR : cur_style->MarginR)) * 100 / ass_track->PlayResX;
-            margV = ((cur_event->MarginV > 0) ? cur_event->MarginV : cur_style->MarginV) * 100 / ass_track->PlayResY; // top assumed
+            margL = ((cur_event->margin_l > 0) ? cur_event->margin_l : cur_style->margin_l) * 100 / ass_track->play_res_x;
+            margR = (ass_track->play_res_x - ((cur_event->margin_r > 0) ? cur_event->margin_r : cur_style->margin_r)) * 100 / ass_track->play_res_x;
+            margV = ((cur_event->margin_v > 0) ? cur_event->margin_v : cur_style->margin_v) * 100 / ass_track->play_res_y; // top assumed
             // All the margX variables are percentages in rounded integer values.
             // line is integer in range of [0 - 12] given 16 rows of lines in the frame.
             if (margL || margR || margV)
@@ -725,9 +700,9 @@ ass_parse_frames(
                 // center/middle means we are giving the coordinate of the center/middle point
                 int line, sizeH, pos;
 
-                if (cur_style->Alignment >= VALIGN_CENTER) {   //middle Alignment  for values 9,10,11
+                if (cur_style->alignment >= VALIGN_CENTER) {   //middle alignment  for values 9,10,11
                     line = 7;
-                } else if (cur_style->Alignment < VALIGN_TOP) { //bottom Alignment  for values 1, 2, 3
+                } else if (cur_style->alignment < VALIGN_TOP) { //bottom alignment  for values 1, 2, 3
                     margV = 100 - margV;
                     line = FFMINMAX((margV+4) >> 3, 0, 12);
                 } else {                                        //top alignment is the default assumption
@@ -737,11 +712,11 @@ ass_parse_frames(
                 // cap horizontal size to more than 2x to make sure we don't break lines with generic font
                 // cap horizontal size to no more than 3x to make sure we allow right and left aligned events on same line
                 sizeH = FFMINMAX(margR - margL, (int)(max_run*2), (int)(max_run*3));
-                if ((bleft == FALSE) && (bright == FALSE)) {        //center Alignment  2/6/10
+                if ((bleft == FALSE) && (bright == FALSE)) {        //center alignment  2/6/10
                     pos = FFMINMAX((margR + margL + 1)/2, sizeH/2, 100 - sizeH/2);
-                } else if (bleft == TRUE) {                         //left   Alignment  1/5/9
+                } else if (bleft == TRUE) {                         //left   alignment  1/5/9
                     pos = FFMINMAX(margL, 0, 100 - sizeH);
-                } else {                                            //right  Alignment  3/7/11
+                } else {                                            //right  alignment  3/7/11
                     pos = FFMINMAX(margR, sizeH, 100);
                 }
 
@@ -755,18 +730,18 @@ ass_parse_frames(
             // We should only insert this if an alignment override tag {\a...}is in the text, otherwise follow the style's alignment
             // but for now, insert it all the time till all players can read styles
             len =  7; vod_memcpy(p, " align:", len);                            p+=len;
-            if ((bleft == FALSE) && (bright == FALSE)) {            //center Alignment  2/6/10
+            if ((bleft == FALSE) && (bright == FALSE)) {            //center alignment  2/6/10
                 len =  6; vod_memcpy(p, "center", len);                         p+=len;
-            } else if (bleft == TRUE) {                             //left   Alignment  1/5/9
+            } else if (bleft == TRUE) {                             //left   alignment  1/5/9
                 len =  4; vod_memcpy(p, "left", len);                           p+=len;
-            } else {                                                //right  Alignment  3/7/11
+            } else {                                                //right  alignment  3/7/11
                 len =  5; vod_memcpy(p, "right", len);                          p+=len;
             }
             len = 2; vod_memcpy(p, "\r\n", len);                                p+=len;
         }
 #ifdef ASSUME_STYLE_SUPPORT
         vod_memcpy(p, FIXED_WEBVTT_VOICE_START_STR, FIXED_WEBVTT_VOICE_START_WIDTH);       p+=FIXED_WEBVTT_VOICE_START_WIDTH;
-        len = vod_strlen(cur_style->Name); vod_sprintf((u_char*)p, cur_style->Name, len);  p+=len;
+        len = vod_strlen(cur_style->name); vod_sprintf((u_char*)p, cur_style->name, len);  p+=len;
         vod_memcpy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);           p+=FIXED_WEBVTT_VOICE_END_WIDTH;
 #endif //ASSUME_STYLE_SUPPORT
 
@@ -789,12 +764,12 @@ ass_parse_frames(
         cur_frame->offset    = (uintptr_t)pfixed;
         cur_frame->size      = (uint32_t)(p - pfixed);
         cur_frame->key_frame = FIXED_WEBVTT_CUE_NAME_WIDTH + 2; // cue name + \r\n
-        cur_frame->pts_delay = cur_event->End - cur_event->Start;
+        cur_frame->pts_delay = cur_event->end - cur_event->start;
 
         vtt_track->total_frames_size += cur_frame->size;
-        cur_style->b_output_in_cur_segment = TRUE; // output this style as part of this segment
+        cur_style->output_in_cur_segment = TRUE; // output this style as part of this segment
 
-        last_start_time = cur_event->Start;
+        last_start_time = cur_event->start;
     }
 
     //allocate memory for the style's text string
@@ -807,7 +782,7 @@ ass_parse_frames(
         return VOD_ALLOC_FAILED;
     }
 
-    // We now insert header and all Style definitions
+    // We now insert header and all style definitions
     header->data              = (u_char*)pfixed;
     len = sizeof(WEBVTT_HEADER_NEWLINES) - 1; vod_memcpy(p, WEBVTT_HEADER_NEWLINES, len);  p+=len;
 #ifdef ASSUME_STYLE_SUPPORT
@@ -815,7 +790,7 @@ ass_parse_frames(
     for (stylecounter = (ass_track->default_style ? 1 : 0); (stylecounter < ass_track->n_styles); stylecounter++)
     {
         ass_style_t* cur_style = ass_track->styles + stylecounter;
-        if (cur_style->b_output_in_cur_segment == TRUE)
+        if (cur_style->output_in_cur_segment == TRUE)
             p = output_one_style(cur_style, p);
 
     }

--- a/vod/subtitle/ass_format.h
+++ b/vod/subtitle/ass_format.h
@@ -14,11 +14,11 @@
 
 typedef enum
 {
-    PST_UNKNOWN = 0,
-    PST_INFO,
-    PST_STYLES,
-    PST_EVENTS,
-    PST_FONTS
+	PST_UNKNOWN = 0,
+	PST_INFO,
+	PST_STYLES,
+	PST_EVENTS,
+	PST_FONTS
 } ParserState;
 
 // globals
@@ -27,31 +27,31 @@ extern media_format_t ass_format;
 /* ASS Style: line */
 typedef struct ass_style
 {
-    char       *name;
-    char       *font_name;
-    int         font_size;
-    uint32_t    primary_colour;
-    uint32_t    secondary_colour;
-    uint32_t    outline_colour;
-    uint32_t    back_colour;
-    bool_t      bold;
-    bool_t      italic;
-    bool_t      underline;
-    bool_t      strike_out;
-    bool_t      right_to_left_language;
-    bool_t      output_in_cur_segment;
-    double      scale_x;
-    double      scale_y;
-    double      spacing;
-    double      angle;
-    int         border_style;  // 1 means Outline + Shadow, 3 means Opaque box
-    int         outline;
-    int         shadow;
-    int         alignment;
-    int         margin_l;
-    int         margin_r;
-    int         margin_v;
-    int         encoding;
+	char		*name;
+	char		*font_name;
+	int			font_size;
+	uint32_t	primary_colour;
+	uint32_t	secondary_colour;
+	uint32_t	outline_colour;
+	uint32_t	back_colour;
+	bool_t		bold;
+	bool_t		italic;
+	bool_t		underline;
+	bool_t		strike_out;
+	bool_t		right_to_left_language;
+	bool_t		output_in_cur_segment;
+	double		scale_x;
+	double		scale_y;
+	double		spacing;
+	double		angle;
+	int			border_style;  // 1 means Outline + Shadow, 3 means Opaque box
+	int			outline;
+	int			shadow;
+	int			alignment;
+	int			margin_l;
+	int			margin_r;
+	int			margin_v;
+	int			encoding;
 } ass_style_t;
 
 /*
@@ -60,18 +60,18 @@ typedef struct ass_style
  */
 typedef struct ass_event
 {
-    long long   start;    // ms
-    long long   end;      // ms
+	long long	start;	// ms
+	long long	end;	  // ms
 
-    int         layer;
-    int         style;
-    char       *name;
-    int         margin_l;
-    int         margin_r;
-    int         margin_v;
-    char       *effect;
-    char       *text;
-    bool_t      right_to_left_language;
+	int			layer;
+	int			style;
+	char		*name;
+	int			margin_l;
+	int			margin_r;
+	int			margin_v;
+	char		*effect;
+	char		*text;
+	bool_t		right_to_left_language;
 } ass_event_t;
 
 /*
@@ -81,39 +81,38 @@ typedef struct ass_event
  */
 typedef struct ass_track
 {
-    int             n_styles;           // amount used
-    int             max_styles;         // amount allocated
-    int             n_events;
-    int             max_events;
-    ass_style_t    *styles;             // array of styles, max_styles length, n_styles used
-    ass_event_t    *events;             // the same as styles
+	int			n_styles;			// amount used
+	int			max_styles;			// amount allocated
+	int			n_events;
+	int			max_events;
+	ass_style_t	*styles;			// array of styles, max_styles length, n_styles used
+	ass_event_t	*events;			// the same as styles
 
-    char           *style_format;       // style format line (everything after "Format: ")
-    char           *event_format;       // event format line
+	char		*style_format;		// style format line (everything after "Format: ")
+	char		*event_format;		// event format line
 
-    enum {
-        TRACK_TYPE_UNKNOWN = 0,
-        TRACK_TYPE_ASS,
-        TRACK_TYPE_SSA
-    } track_type;
+	enum {
+		TRACK_TYPE_UNKNOWN = 0,
+		TRACK_TYPE_ASS,
+		TRACK_TYPE_SSA
+	} track_type;
 
-    // Script header fields
-    int             play_res_x;
-    int             play_res_y;
-    double          timer;
-    int             wrap_style;
-    int             scaled_border_and_shadow;
-    int             kerning;
-    char           *language;
-    char           *title;
-    bool_t          right_to_left_language;
+	// Script header fields
+	int			play_res_x;
+	int			play_res_y;
+	double		timer;
+	int			wrap_style;
+	int			scaled_border_and_shadow;
+	int			kerning;
+	char		*language;
+	char		*title;
+	bool_t		right_to_left_language;
 
-    int             default_style;    // index of default style, defaults to zero
-    char           *name;             // file name in case of external subs, 0 for streams
-    ParserState     state;
+	int			default_style;		// index of default style, defaults to zero
+	char		*name;				// file name in case of external subs, 0 for streams
+	ParserState	state;
 
-    long long       max_duration;      // ms, added for needs of the vod-module
-
+	long long	max_duration;		// ms, added for needs of the vod-module
 } ass_track_t;
 
 

--- a/vod/subtitle/ass_format.h
+++ b/vod/subtitle/ass_format.h
@@ -12,7 +12,8 @@
 #define FFMIN(a,b) ((a) > (b) ? (b) : (a))
 #define FFMINMAX(c,a,b) FFMIN(FFMAX(c, a), b)
 
-typedef enum {
+typedef enum
+{
     PST_UNKNOWN = 0,
     PST_INFO,
     PST_STYLES,
@@ -24,7 +25,8 @@ typedef enum {
 extern media_format_t ass_format;
 
 /* ASS Style: line */
-typedef struct ass_style {
+typedef struct ass_style
+{
     char       *name;
     char       *font_name;
     int         font_size;
@@ -56,7 +58,8 @@ typedef struct ass_style {
  * ass_event corresponds to a single Dialogue line;
  * text is stored as-is, style overrides will be parsed later.
  */
-typedef struct ass_event {
+typedef struct ass_event
+{
     long long   start;    // ms
     long long   end;      // ms
 
@@ -76,7 +79,8 @@ typedef struct ass_event {
  * (no real difference between them); it can be used in rendering after the
  * headers are parsed (i.e. events format line read).
  */
-typedef struct ass_track {
+typedef struct ass_track
+{
     int             n_styles;           // amount used
     int             max_styles;         // amount allocated
     int             n_events;

--- a/vod/subtitle/ass_format.h
+++ b/vod/subtitle/ass_format.h
@@ -61,7 +61,7 @@ typedef struct ass_style
 typedef struct ass_event
 {
 	long long	start;	// ms
-	long long	end;	  // ms
+	long long	end;	// ms
 
 	int			layer;
 	int			style;

--- a/vod/subtitle/ass_format.h
+++ b/vod/subtitle/ass_format.h
@@ -25,31 +25,31 @@ extern media_format_t ass_format;
 
 /* ASS Style: line */
 typedef struct ass_style {
-    char       *Name;
-    char       *FontName;
-    int         FontSize;
-    uint32_t    PrimaryColour;
-    uint32_t    SecondaryColour;
-    uint32_t    OutlineColour;
-    uint32_t    BackColour;
-    bool_t      Bold;
-    bool_t      Italic;
-    bool_t      Underline;
-    bool_t      StrikeOut;
-    bool_t      b_right_to_left_language;
-    bool_t      b_output_in_cur_segment;
-    double      ScaleX;
-    double      ScaleY;
-    double      Spacing;
-    double      Angle;
-    int         BorderStyle;  // 1 means Outline + Shadow, 3 means Opaque box
-    int         Outline;
-    int         Shadow;
-    int         Alignment;
-    int         MarginL;
-    int         MarginR;
-    int         MarginV;
-    int         Encoding;
+    char       *name;
+    char       *font_name;
+    int         font_size;
+    uint32_t    primary_colour;
+    uint32_t    secondary_colour;
+    uint32_t    outline_colour;
+    uint32_t    back_colour;
+    bool_t      bold;
+    bool_t      italic;
+    bool_t      underline;
+    bool_t      strike_out;
+    bool_t      right_to_left_language;
+    bool_t      output_in_cur_segment;
+    double      scale_x;
+    double      scale_y;
+    double      spacing;
+    double      angle;
+    int         border_style;  // 1 means Outline + Shadow, 3 means Opaque box
+    int         outline;
+    int         shadow;
+    int         alignment;
+    int         margin_l;
+    int         margin_r;
+    int         margin_v;
+    int         encoding;
 } ass_style_t;
 
 /*
@@ -57,19 +57,18 @@ typedef struct ass_style {
  * text is stored as-is, style overrides will be parsed later.
  */
 typedef struct ass_event {
-    long long   Start;    // ms
-    long long   End;      // ms
+    long long   start;    // ms
+    long long   end;      // ms
 
-    //int         ReadOrder;
-    int         Layer;
-    int         Style;
-    char       *Name;
-    int         MarginL;
-    int         MarginR;
-    int         MarginV;
-    char       *Effect;
-    char       *Text;
-    bool_t      b_right_to_left_language;
+    int         layer;
+    int         style;
+    char       *name;
+    int         margin_l;
+    int         margin_r;
+    int         margin_v;
+    char       *effect;
+    char       *text;
+    bool_t      right_to_left_language;
 } ass_event_t;
 
 /*
@@ -95,21 +94,21 @@ typedef struct ass_track {
     } track_type;
 
     // Script header fields
-    int             PlayResX;
-    int             PlayResY;
-    double          Timer;
-    int             WrapStyle;
-    int             ScaledBorderAndShadow;
-    int             Kerning;
-    char           *Language;
-    char           *Title;
-    bool_t          b_right_to_left_language;
+    int             play_res_x;
+    int             play_res_y;
+    double          timer;
+    int             wrap_style;
+    int             scaled_border_and_shadow;
+    int             kerning;
+    char           *language;
+    char           *title;
+    bool_t          right_to_left_language;
 
     int             default_style;    // index of default style, defaults to zero
     char           *name;             // file name in case of external subs, 0 for streams
     ParserState     state;
 
-    long long       maxDuration;      // ms, added for needs of the vod-module
+    long long       max_duration;      // ms, added for needs of the vod-module
 
 } ass_track_t;
 

--- a/vod/subtitle/ass_parse.c
+++ b/vod/subtitle/ass_parse.c
@@ -24,7 +24,8 @@
 #define ASS_SIZE_MAX ((size_t)-1)
 #define ass_atof(STR) (ass_strtod((STR),NULL))
 
-static const unsigned char lowertab[] = {
+static const unsigned char lowertab[] =
+{
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
     0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
     0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
@@ -55,7 +56,8 @@ static int ass_strcasecmp(const char *s1, const char *s2)
 {
     unsigned char a, b;
 
-    do {
+    do
+    {
         a = lowertab[(unsigned char)*s1++];
         b = lowertab[(unsigned char)*s2++];
     } while (a && a == b);
@@ -69,7 +71,8 @@ static int ass_strncasecmp(const char *s1, const char *s2, size_t n)
     unsigned char a, b;
     const char *last = s1 + n;
 
-    do {
+    do
+    {
         a = lowertab[(unsigned char)*s1++];
         b = lowertab[(unsigned char)*s2++];
     } while (s1 < last && a && a == b);
@@ -123,9 +126,10 @@ const size_t maxExponent = 511; /* Largest possible base 10 exponent.  Any
                                  */
 
 static
-const double powersOf10[] = {   /* Table giving binary powers of 10.  Entry */
-    10.,                        /* is 10^2^i.  Used to convert decimal */
-    100.,                       /* exponents into floating-point numbers. */
+const double powersOf10[] =     /* Table giving binary powers of 10.  Entry */
+{                               /* is 10^2^i.  Used to convert decimal */
+    10.,                        /* exponents into floating-point numbers. */
+    100.,
     1.0e4,
     1.0e8,
     1.0e16,
@@ -136,10 +140,11 @@ const double powersOf10[] = {   /* Table giving binary powers of 10.  Entry */
 };
 
 static
-const double negPowOf10[] = {   /* Table giving negative binary powers */
-    0.1,                        /* of 10.  Entry is 10^-2^i. */
-    0.01,                       /* Used to convert decimal exponents */
-    1.0e-4,                     /* into floating-point numbers. */
+const double negPowOf10[] =     /* Table giving negative binary powers */
+{                               /* of 10.  Entry is 10^-2^i. */
+    0.1,                        /* Used to convert decimal exponents */
+    0.01,                       /* into floating-point numbers. */
+    1.0e-4,
     1.0e-8,
     1.0e-16,
     1.0e-32,
@@ -158,8 +163,8 @@ const double negPowOf10[] = {   /* Table giving negative binary powers */
  *
  * Results:
  * The return value is the double-precision floating-point
- * representation of the characters in string.  If endPtr isn't
- * NULL, then *endPtr is filled in with the address of the
+ * representation of the characters in string.  If end_ptr isn't
+ * NULL, then *end_ptr is filled in with the address of the
  * next character after the last one that was part of the
  * floating-point number.
  *
@@ -183,7 +188,7 @@ ass_strtod(
                              * The "E" may actually be an "e".  E and X
                              * may both be omitted (but not just one).
                              */
-    char **endPtr           /* If non-NULL, store terminating character's
+    char **end_ptr           /* If non-NULL, store terminating character's
                              * address here. */
     )
 {
@@ -214,14 +219,19 @@ ass_strtod(
      */
 
     p = string;
-    while (ass_isspace(*p)) {
+    while (ass_isspace(*p))
+    {
         p += 1;
     }
-    if (*p == '-') {
+    if (*p == '-')
+    {
         sign = 1;
         p += 1;
-    } else {
-        if (*p == '+') {
+    }
+    else
+    {
+        if (*p == '+')
+        {
             p += 1;
         }
         sign = 0;
@@ -238,11 +248,13 @@ ass_strtod(
     {
         c = *p;
         if (!ass_isdigit(c)) {
-            if ((c != '.') || (decPt != (size_t) -1)) {
+            if ((c != '.') || (decPt != (size_t) -1))
+            {
                 break;
             }
             decPt = mantSize;
-        } else if ((c != '0') && (leadZeros == (size_t) -1)) {
+        } else if ((c != '0') && (leadZeros == (size_t) -1))
+        {
             leadZeros = mantSize;
         }
         p += 1;
@@ -255,34 +267,44 @@ ass_strtod(
      * they can't affect the value anyway.
      */
 
-    if (leadZeros == (size_t) -1) {
+    if (leadZeros == (size_t) -1)
+    {
         leadZeros = mantSize;
     }
     pExp  = p;
     p -= mantSize - leadZeros;
-    if (decPt == (size_t) -1) {
+    if (decPt == (size_t) -1)
+    {
         decPt = mantSize;
     } else {
         mantSize -= 1;      /* One of the digits was the point. */
-        if (decPt < leadZeros) {
+        if (decPt < leadZeros)
+        {
             leadZeros -= 1;
         }
     }
-    if (mantSize - leadZeros > 18) {
+    if (mantSize - leadZeros > 18)
+    {
         mantSize = leadZeros + 18;
     }
-    if (decPt < mantSize) {
+    if (decPt < mantSize)
+    {
         fracExpSign = 1;
         fracExp = mantSize - decPt;
-    } else {
+    }
+    else
+    {
         fracExpSign = 0;
         fracExp = decPt - mantSize;
     }
-    if (mantSize == 0) {
+    if (mantSize == 0)
+    {
         fraction = 0.0;
         p = string;
         goto done;
-    } else {
+    }
+    else
+    {
         int frac1, frac2, m;
         mantSize -= leadZeros;
         m = mantSize;
@@ -316,7 +338,8 @@ ass_strtod(
      */
 
     p = pExp;
-    if ((*p == 'E') || (*p == 'e')) {
+    if ((*p == 'E') || (*p == 'e'))
+    {
         size_t expLimit;    /* If exp > expLimit, appending another digit
                              * to exp is guaranteed to make it too large.
                              * If exp == expLimit, this may depend on
@@ -326,45 +349,64 @@ ass_strtod(
                              * exceed maxExponent. */
         int expWraparound = 0;
         p += 1;
-        if (*p == '-') {
+        if (*p == '-')
+        {
             expSign = 1;
             p += 1;
         } else {
-            if (*p == '+') {
+            if (*p == '+')
+            {
                 p += 1;
             }
             expSign = 0;
         }
-        if (expSign == fracExpSign) {
-            if (maxExponent < fracExp) {
+        if (expSign == fracExpSign)
+        {
+            if (maxExponent < fracExp)
+            {
                 expLimit = 0;
-            } else {
+            }
+            else
+            {
                 expLimit = (maxExponent - fracExp) / 10;
             }
-        } else {
+        }
+        else
+        {
             expLimit = fracExp / 10 + (fracExp % 10 + maxExponent) / 10;
         }
-        while (ass_isdigit(*p)) {
-            if ((exp > expLimit) || expWraparound) {
-                do {
+        while (ass_isdigit(*p))
+        {
+            if ((exp > expLimit) || expWraparound)
+            {
+                do
+                {
                     p += 1;
                 } while (ass_isdigit(*p));
                 goto expOverflow;
-            } else if (exp > ((size_t) -1 - (*p - '0')) / 10) {
+            } else if (exp > ((size_t) -1 - (*p - '0')) / 10)
+            {
                 expWraparound = 1;
             }
             exp = exp * 10 + (*p - '0');
             p += 1;
         }
-        if (expSign == fracExpSign) {
+        if (expSign == fracExpSign)
+        {
             exp = fracExp + exp;
-        } else if ((fracExp <= exp) || expWraparound) {
+        }
+        else if ((fracExp <= exp) || expWraparound)
+        {
             exp = exp - fracExp;
-        } else {
+        }
+        else
+        {
             exp = fracExp - exp;
             expSign = fracExpSign;
         }
-    } else {
+    }
+    else
+    {
         exp = fracExp;
         expSign = fracExpSign;
     }
@@ -376,21 +418,27 @@ ass_strtod(
      * fraction.
      */
 
-    if (exp > maxExponent) {
+    if (exp > maxExponent)
+    {
 expOverflow:
         exp = maxExponent;
-        if (fraction != 0.0) {
+        if (fraction != 0.0)
+        {
             errno = ERANGE;
         }
     }
     /* Prefer positive powers of 10 for increased precision, especially
      * for small powers that are represented exactly in floating-point. */
-    if ((exp <= DBL_MAX_10_EXP) || !expSign) {
+    if ((exp <= DBL_MAX_10_EXP) || !expSign)
+    {
         d = powersOf10;
-    } else {
+    }
+    else
+    {
         /* The floating-point format supports more negative exponents
          * than positive, or perhaps the result is a subnormal number. */
-        if (exp > -DBL_MIN_10_EXP) {
+        if (exp > -DBL_MIN_10_EXP)
+        {
             /* The result might be a valid subnormal number, but the
              * exponent underflows.  Tweak fraction so that it is below
              * 1.0 first, so that if the exponent still underflows after
@@ -409,22 +457,28 @@ expOverflow:
     }
     dblExp = 1.0;
     for (; exp != 0; exp >>= 1, d += 1) {
-        if (exp & 01) {
+        if (exp & 01)
+        {
             dblExp *= *d;
         }
     }
-    if (expSign) {
+    if (expSign)
+    {
         fraction /= dblExp;
-    } else {
+    }
+    else
+    {
         fraction *= dblExp;
     }
 
 done:
-    if (endPtr != NULL) {
-        *endPtr = (char *) p;
+    if (end_ptr != NULL)
+    {
+        *end_ptr = (char *) p;
     }
 
-    if (sign) {
+    if (sign)
+    {
         return -fraction;
     }
     return fraction;
@@ -516,7 +570,9 @@ static int mystrtou32_modulo(char **p, int base, uint32_t *res)
     if (read_digits(p, base, res)) {
         *res *= sign;
         return 1;
-    } else {
+    }
+    else
+    {
         *p = start;
         return 0;
     }
@@ -548,10 +604,12 @@ uint32_t parse_color_header(char *str)
     uint32_t color = 0;
     int base;
 
-    if (!ass_strncasecmp(str, "&h", 2) || !ass_strncasecmp(str, "0x", 2)) {
+    if (!ass_strncasecmp(str, "&h", 2) || !ass_strncasecmp(str, "0x", 2))
+    {
         str += 2;
         base = 16;
-    } else
+    }
+    else
         base = 10;
 
     mystrtou32_modulo(&str, base, &color);
@@ -626,12 +684,14 @@ void ass_free_track(vod_pool_t* pool, ass_track_t *track)
     free(track->event_format);
     free(track->language);
     free(track->title);
-    if (track->styles) {
+    if (track->styles)
+    {
         for (i = 0; i < track->n_styles; ++i)
             ass_free_style(track, i);
     }
     free(track->styles);
-    if (track->events) {
+    if (track->events)
+    {
         for (i = 0; i < track->n_events; ++i)
             ass_free_event(track, i);
     }
@@ -650,10 +710,10 @@ void ass_free_track(vod_pool_t* pool, ass_track_t *track)
  */
 static void set_default_style(ass_style_t *style, bool_t alloc_names)
 {
-    if (alloc_names == TRUE)
+    if (alloc_names)
     {
-        style->name                 = strdup("Default");
-        style->font_name             = strdup("Arial");
+        style->name             = strdup("Default");
+        style->font_name        = strdup("Arial");
     }
     style->font_size            = 18;
     style->primary_colour       = 0xffffff00;
@@ -683,7 +743,8 @@ static long long string2timecode(char *p)
     int h, m, s, ms;
     long long tm;
     int res = sscanf(p, "%d:%d:%d.%d", &h, &m, &s, &ms);
-    if (res < 4) {
+    if (res < 4)
+    {
         // error msg "Bad timestamp";
         return 0;
     }
@@ -695,7 +756,7 @@ static long long string2timecode(char *p)
  * \param track track
  * \param name style name
  * \return index in track->styles
- * Returns 0 if no styles found => expects at least 1 style.
+ * Returns 0 if no styles found -> expects at least 1 style.
  * Parsing code always adds "Default" style in the beginning.
  */
 int lookup_style(ass_track_t *track, char *name)
@@ -709,7 +770,8 @@ int lookup_style(ass_track_t *track, char *name)
     // (only in contexts where this function is called)
     if (ass_strcasecmp(name, "Default") == 0)
         name = "Default";
-    for (i = track->n_styles - 1; i >= 0; --i) {
+    for (i = track->n_styles - 1; i >= 0; --i)
+    {
         if (strcmp(track->styles[i].name, name) == 0)
             return i;
     }
@@ -778,7 +840,9 @@ static char *next_token(char **str)
     }
     if (*p == '\0') {
         *str = p;               // eos found, str will point to '\0' at exit
-    } else {
+    }
+    else
+    {
         *p = '\0';
         *str = p + 1;           // ',' found, str will point to the next char (beginning of the next token)
     }
@@ -803,7 +867,8 @@ static int process_event_tail(ass_track_t *track, ass_event_t *event, char *str)
     char *format = strdup(track->event_format);
     char *q = format;           // format scanning pointer
 
-    if (track->n_styles == 0) {
+    if (track->n_styles == 0)
+    {
         // add "Default" style to the end
         // will be used if track does not contain a default style (or even does not contain styles at all)
         int sid = ass_alloc_style(track);
@@ -811,9 +876,11 @@ static int process_event_tail(ass_track_t *track, ass_event_t *event, char *str)
         track->default_style = sid;
     }
 
-    while (1) {
+    while (1)
+    {
         NEXT(q, tname);
-        if (ass_strcasecmp(tname, "Text") == 0) {
+        if (ass_strcasecmp(tname, "Text") == 0)
+        {
             char *last;
             event->text = strdup(p);
             if (*event->text != 0) {
@@ -822,7 +889,8 @@ static int process_event_tail(ass_track_t *track, ass_event_t *event, char *str)
                     *last = 0;
             }
             // need to track the largest end time in all events, since they are not in chronological order
-            if (track->max_duration < event->end) {
+            if (track->max_duration < event->end)
+            {
                 track->max_duration = event->end;
             }
             free(format);
@@ -885,7 +953,8 @@ static int process_style(ass_track_t *track, char *str, request_context_t* reque
     ass_style_t *style;
     ass_style_t *target;
 
-    if (!track->style_format) {
+    if (!track->style_format)
+    {
         // no style format header
         // probably an ancient script version
         if (track->track_type == TRACK_TYPE_SSA)
@@ -906,7 +975,8 @@ static int process_style(ass_track_t *track, char *str, request_context_t* reque
     q = format = strdup(track->style_format);
 
     // Add default style first
-    if (track->n_styles == 0) {
+    if (track->n_styles == 0)
+    {
         // will be used if track does not contain a default style (or even does not contain styles at all)
         int sid = ass_alloc_style(track);
         set_default_style(&track->styles[sid], TRUE);
@@ -920,7 +990,8 @@ static int process_style(ass_track_t *track, char *str, request_context_t* reque
 
     set_default_style(target, FALSE);
 
-    while (1) {
+    while (1)
+    {
         NEXT(q, tname);
         NEXT(p, token);
 
@@ -981,9 +1052,12 @@ static int process_style(ass_track_t *track, char *str, request_context_t* reque
         style->font_name = strdup("Arial");
 
     // For now, right_to_left_language is TRUE only for Arabic language. In future, it will be enabled for many others.
-    if ( !ass_strncasecmp(style->font_name, "Adobe Arabic", 12) ) {
+    if ( !ass_strncasecmp(style->font_name, "Adobe Arabic", 12) )
+    {
         style->right_to_left_language = TRUE;
-    } else {
+    }
+    else
+    {
         style->right_to_left_language = track->right_to_left_language;
     }
     free(format);
@@ -993,12 +1067,14 @@ static int process_style(ass_track_t *track, char *str, request_context_t* reque
 
 static int process_styles_line(ass_track_t *track, char *str, request_context_t* request_context)
 {
-    if (!strncmp(str, "Format:", 7)) {
+    if (!strncmp(str, "Format:", 7))
+    {
         char *p = str + 7;
         skip_spaces(&p);
         free(track->style_format);
         track->style_format = strdup(p);
-    } else if (!strncmp(str, "Style:", 6)) {
+    } else if (!strncmp(str, "Style:", 6))
+    {
         char *p = str + 6;
         skip_spaces(&p);
         process_style(track, p, request_context);
@@ -1008,26 +1084,42 @@ static int process_styles_line(ass_track_t *track, char *str, request_context_t*
 
 static int process_info_line(ass_track_t *track, char *str, request_context_t* request_context)
 {
-    if (!strncmp(str, "PlayResX:", 9)) {
+    if (!strncmp(str, "PlayResX:", 9))
+    {
         track->play_res_x = atoi(str + 9);
-    } else if (!strncmp(str, "PlayResY:", 9)) {
+    }
+    else if (!strncmp(str, "PlayResY:", 9))
+    {
         track->play_res_y = atoi(str + 9);
-    } else if (!strncmp(str, "Timer:", 6)) {
+    }
+    else if (!strncmp(str, "Timer:", 6))
+    {
         track->timer = ass_atof(str + 6);
-    } else if (!strncmp(str, "WrapStyle:", 10)) {
+    }
+    else if (!strncmp(str, "WrapStyle:", 10))
+    {
         track->wrap_style = atoi(str + 10);
-    } else if (!strncmp(str, "ScaledBorderAndShadow:", 22)) {
+    }
+    else if (!strncmp(str, "ScaledBorderAndShadow:", 22))
+    {
         track->scaled_border_and_shadow = parse_bool(str + 22);
-    } else if (!strncmp(str, "Kerning:", 8)) {
+    }
+    else if (!strncmp(str, "Kerning:", 8))
+    {
         track->kerning = parse_bool(str + 8);
-    } else if (!strncmp(str, "YCbCr Matrix:", 13)) {
+    }
+    else if (!strncmp(str, "YCbCr Matrix:", 13))
+    {
         // ignore for now
-    } else if (!strncmp(str, "Language:", 9)) { // This field is not part of the ASS/SSA specs
+    }
+    else if (!strncmp(str, "Language:", 9))
+    { // This field is not part of the ASS/SSA specs
         char *p = str + 9;
         while (*p && ass_isspace(*p)) p++;
         free(track->language);
         track->language = strndup(p, 2);
-    } else if (!strncmp(str, "Title:", 6)) {
+    } else if (!strncmp(str, "Title:", 6))
+    {
         char *p = str + 6;
         char *strt, *end;
         while (*p && ass_isspace(*p))
@@ -1057,13 +1149,16 @@ static void event_format_fallback(ass_track_t *track)
 
 static int process_events_line(ass_track_t *track, char *str, request_context_t* request_context)
 {
-    if (!strncmp(str, "Format:", 7)) {
+    if (!strncmp(str, "Format:", 7))
+    {
         char *p = str + 7;
         skip_spaces(&p);
         free(track->event_format);
         track->event_format = strdup(p);
 
-    } else if (!strncmp(str, "Dialogue:", 9)) {
+    }
+    else if (!strncmp(str, "Dialogue:", 9))
+    {
         // This should never be reached for embedded subtitles.
         // They have slightly different format and are parsed in ass_process_chunk,
         // called directly from demuxer
@@ -1081,9 +1176,13 @@ static int process_events_line(ass_track_t *track, char *str, request_context_t*
             event_format_fallback(track);
 
         process_event_tail(track, event, str);
-    } else if (!strncmp(str, "Comment:", 8)) {
+    }
+    else if (!strncmp(str, "Comment:", 8))
+    {
         // Ignore and do nothing, this is just a comment line
-    } else {
+    }
+    else
+    {
         vod_log_error(VOD_LOG_ERR, request_context->log, 0,
             "Event line not understood: %s", str);
     }
@@ -1098,20 +1197,32 @@ static int process_events_line(ass_track_t *track, char *str, request_context_t*
 static int process_line(ass_track_t *track, char *str, request_context_t* request_context)
 {
     int retval = 0;
-    if (!ass_strncasecmp(str, "[Script Info]", 13)) {
+    if (!ass_strncasecmp(str, "[Script Info]", 13))
+    {
         track->state = PST_INFO;
-    } else if (!ass_strncasecmp(str, "[V4 Styles]", 11)) {
+    }
+    else if (!ass_strncasecmp(str, "[V4 Styles]", 11))
+    {
         track->state = PST_STYLES;
         track->track_type = TRACK_TYPE_SSA;
-    } else if (!ass_strncasecmp(str, "[V4+ Styles]", 12)) {
+    }
+    else if (!ass_strncasecmp(str, "[V4+ Styles]", 12))
+    {
         track->state = PST_STYLES;
         track->track_type = TRACK_TYPE_ASS;
-    } else if (!ass_strncasecmp(str, "[Events]", 8)) {
+    }
+    else if (!ass_strncasecmp(str, "[Events]", 8))
+    {
         track->state = PST_EVENTS;
-    } else if (!ass_strncasecmp(str, "[Fonts]", 7)) {
+    }
+    else if (!ass_strncasecmp(str, "[Fonts]", 7))
+    {
         track->state = PST_FONTS;
-    } else {
-        switch (track->state) {
+    }
+    else
+    {
+        switch (track->state)
+        {
         case PST_INFO:
             retval |= process_info_line(track, str, request_context);
             break;
@@ -1141,9 +1252,11 @@ static int process_text(ass_track_t *track, char *str, request_context_t* reques
     int retval = 0;
     char *p = str;
 
-    while (1) {
+    while (1)
+    {
         char *q;
-        while (1) {
+        while (1)
+        {
             if ((*p == '\r') || (*p == '\n'))
                 ++p;
             else if (p[0] == '\xef' && p[1] == '\xbb' && p[2] == '\xbf')
@@ -1151,7 +1264,8 @@ static int process_text(ass_track_t *track, char *str, request_context_t* reques
             else
                 break;
         }
-        for (q = p; ((*q != '\0') && (*q != '\r') && (*q != '\n')); ++q) {
+        for (q = p; ((*q != '\0') && (*q != '\r') && (*q != '\n')); ++q)
+        {
         };
         if (q == p)
             break;

--- a/vod/subtitle/ass_parse.c
+++ b/vod/subtitle/ass_parse.c
@@ -623,13 +623,24 @@ char parse_bool(char *str)
 	return !ass_strncasecmp(str, "yes", 3) || strtol(str, NULL, 10) > 0;
 }
 
+ass_track_t * ass_alloc_track(request_context_t *request_context)
+{
+	ass_track_t *track = vod_calloc(request_context->pool, sizeof(ass_track_t));
+	if (!track)
+		return NULL;
+
+	track->play_res_x = 1920;
+	track->play_res_y = 1080;
+
+	return track;
+}
+
 int ass_alloc_style(ass_track_t *track)
 {
 	int sid;
 
-	//assert(track->n_styles <= track->max_styles);
-
-	if (track->n_styles == track->max_styles) {
+	if (track->n_styles == track->max_styles)
+	{
 		track->max_styles += ASS_STYLES_ALLOC;
 		track->styles =
 			(ass_style_t *) realloc(track->styles,
@@ -638,7 +649,7 @@ int ass_alloc_style(ass_track_t *track)
 	}
 
 	sid = track->n_styles++;
-	vod_memset(track->styles + sid, 0, sizeof(ass_style_t));
+	vod_memzero(track->styles + sid, sizeof(ass_style_t));
 	return sid;
 }
 
@@ -646,9 +657,8 @@ int ass_alloc_event(ass_track_t *track)
 {
 	int eid;
 
-	//assert(track->n_events <= track->max_events);
-
-	if (track->n_events == track->max_events) {
+	if (track->n_events == track->max_events)
+	{
 		track->max_events = track->max_events * 2 + 1;
 		track->events =
 			(ass_event_t *) realloc(track->events,
@@ -1113,7 +1123,8 @@ static int process_info_line(ass_track_t *track, char *str, request_context_t* r
 		// ignore for now
 	}
 	else if (!strncmp(str, "Language:", 9))
-	{ // This field is not part of the ASS/SSA specs
+	{
+		// This field is not part of the ASS/SSA specs
 		char *p = str + 9;
 		while (*p && ass_isspace(*p)) p++;
 		free(track->language);
@@ -1296,8 +1307,7 @@ ass_track_t *parse_memory(char *buf, int len, request_context_t* request_context
 	}
 	vod_memcpy(pcopy, buf, len+1);
 
-	// initializes all fields to zero. If that doesn't suit your need, use another track_init function.
-	track = vod_calloc(request_context->pool, sizeof(ass_track_t));
+	track = ass_alloc_track(request_context);
 	if (!track)
 	{
 		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,

--- a/vod/subtitle/ass_parse.c
+++ b/vod/subtitle/ass_parse.c
@@ -26,131 +26,131 @@
 
 static const unsigned char lowertab[] =
 {
-    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
-    0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
-    0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
-    0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b,
-    0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,
-    0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40, 0x61,
-    0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c,
-    0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77,
-    0x78, 0x79, 0x7a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60, 0x61, 0x62,
-    0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d,
-    0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
-    0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f, 0x80, 0x81, 0x82, 0x83,
-    0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e,
-    0x8f, 0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99,
-    0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4,
-    0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
-    0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba,
-    0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5,
-    0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf, 0xd0,
-    0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb,
-    0xdc, 0xdd, 0xde, 0xdf, 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6,
-    0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef, 0xf0, 0xf1,
-    0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc,
-    0xfd, 0xfe, 0xff
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+	0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+	0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+	0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b,
+	0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,
+	0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40, 0x61,
+	0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c,
+	0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77,
+	0x78, 0x79, 0x7a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60, 0x61, 0x62,
+	0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d,
+	0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+	0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f, 0x80, 0x81, 0x82, 0x83,
+	0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e,
+	0x8f, 0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99,
+	0x9a, 0x9b, 0x9c, 0x9d, 0x9e, 0x9f, 0xa0, 0xa1, 0xa2, 0xa3, 0xa4,
+	0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+	0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba,
+	0xbb, 0xbc, 0xbd, 0xbe, 0xbf, 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5,
+	0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf, 0xd0,
+	0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb,
+	0xdc, 0xdd, 0xde, 0xdf, 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6,
+	0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef, 0xf0, 0xf1,
+	0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc,
+	0xfd, 0xfe, 0xff
 };
 
 static int ass_strcasecmp(const char *s1, const char *s2)
 {
-    unsigned char a, b;
+	unsigned char a, b;
 
-    do
-    {
-        a = lowertab[(unsigned char)*s1++];
-        b = lowertab[(unsigned char)*s2++];
-    } while (a && a == b);
+	do
+	{
+		a = lowertab[(unsigned char)*s1++];
+		b = lowertab[(unsigned char)*s2++];
+	} while (a && a == b);
 
-    return a - b;
+	return a - b;
 }
 
 
 static int ass_strncasecmp(const char *s1, const char *s2, size_t n)
 {
-    unsigned char a, b;
-    const char *last = s1 + n;
+	unsigned char a, b;
+	const char *last = s1 + n;
 
-    do
-    {
-        a = lowertab[(unsigned char)*s1++];
-        b = lowertab[(unsigned char)*s2++];
-    } while (s1 < last && a && a == b);
+	do
+	{
+		a = lowertab[(unsigned char)*s1++];
+		b = lowertab[(unsigned char)*s2++];
+	} while (s1 < last && a && a == b);
 
-    return a - b;
+	return a - b;
 }
 
 void skip_spaces(char **str)
 {
-    char *p = *str;
-    while ((*p == ' ') || (*p == '\t'))
-        ++p;
-    *str = p;
+	char *p = *str;
+	while ((*p == ' ') || (*p == '\t'))
+		++p;
+	*str = p;
 }
 
 void rskip_spaces(char **str, char *limit)
 {
-    char *p = *str;
-    while ((p > limit) && ((p[-1] == ' ') || (p[-1] == '\t')))
-        --p;
-    *str = p;
+	char *p = *str;
+	while ((p > limit) && ((p[-1] == ' ') || (p[-1] == '\t')))
+		--p;
+	*str = p;
 }
 
 static inline uint32_t ass_bswap32(uint32_t x)
 {
 #ifdef _MSC_VER
-    return _byteswap_ulong(x);
+	return _byteswap_ulong(x);
 #else
-    return (x & 0x000000FF) << 24 | (x & 0x0000FF00) <<  8 |
-           (x & 0x00FF0000) >>  8 | (x & 0xFF000000) >> 24;
+	return	(x & 0x000000FF) << 24 | (x & 0x0000FF00) <<  8 |
+			(x & 0x00FF0000) >>  8 | (x & 0xFF000000) >> 24;
 #endif
 }
 
 static inline int ass_isspace(int c)
 {
-    return c == ' ' || c == '\t' || c == '\n' || c == '\v' ||
-           c == '\f' || c == '\r';
+	return	c == ' ' || c == '\t' || c == '\n' || c == '\v' ||
+			c == '\f' || c == '\r';
 }
 
 static inline int ass_isdigit(int c)
 {
-    return c >= '0' && c <= '9';
+	return c >= '0' && c <= '9';
 }
 
 
 static
-const size_t maxExponent = 511; /* Largest possible base 10 exponent.  Any
-                                 * exponent larger than this will already
-                                 * produce underflow or overflow, so there's
-                                 * no need to worry about additional digits.
-                                 */
+const size_t max_exponent = 511;/* Largest possible base 10 exponent.  Any
+								 * exponent larger than this will already
+								 * produce underflow or overflow, so there's
+								 * no need to worry about additional digits.
+								 */
 
 static
-const double powersOf10[] =     /* Table giving binary powers of 10.  Entry */
-{                               /* is 10^2^i.  Used to convert decimal */
-    10.,                        /* exponents into floating-point numbers. */
-    100.,
-    1.0e4,
-    1.0e8,
-    1.0e16,
-    1.0e32,
-    1.0e64,
-    1.0e128,
-    1.0e256
+const double powersOf10[] =		/* Table giving binary powers of 10.  Entry */
+{								/* is 10^2^i.  Used to convert decimal */
+	10.,						/* exponents into floating-point numbers. */
+	100.,
+	1.0e4,
+	1.0e8,
+	1.0e16,
+	1.0e32,
+	1.0e64,
+	1.0e128,
+	1.0e256
 };
 
 static
-const double negPowOf10[] =     /* Table giving negative binary powers */
-{                               /* of 10.  Entry is 10^-2^i. */
-    0.1,                        /* Used to convert decimal exponents */
-    0.01,                       /* into floating-point numbers. */
-    1.0e-4,
-    1.0e-8,
-    1.0e-16,
-    1.0e-32,
-    1.0e-64,
-    1.0e-128,
-    1.0e-256
+const double negPowOf10[] =		/* Table giving negative binary powers */
+{								/* of 10.  Entry is 10^-2^i. */
+	0.1,						/* Used to convert decimal exponents */
+	0.01,						/* into floating-point numbers. */
+	1.0e-4,
+	1.0e-8,
+	1.0e-16,
+	1.0e-32,
+	1.0e-64,
+	1.0e-128,
+	1.0e-256
 };
 
 /*
@@ -176,368 +176,368 @@ const double negPowOf10[] =     /* Table giving negative binary powers */
 
 double
 ass_strtod(
-    const char *string,     /* A decimal ASCII floating-point number,
-                             * optionally preceded by white space.
-                             * Must have form "-I.FE-X", where I is the
-                             * integer part of the mantissa, F is the
-                             * fractional part of the mantissa, and X
-                             * is the exponent.  Either of the signs
-                             * may be "+", "-", or omitted.  Either I
-                             * or F may be omitted, or both.  The decimal
-                             * point isn't necessary unless F is present.
-                             * The "E" may actually be an "e".  E and X
-                             * may both be omitted (but not just one).
-                             */
-    char **end_ptr           /* If non-NULL, store terminating character's
-                             * address here. */
-    )
+	const char *string, /* A decimal ASCII floating-point number,
+						 * optionally preceded by white space.
+						 * Must have form "-I.FE-X", where I is the
+						 * integer part of the mantissa, F is the
+						 * fractional part of the mantissa, and X
+						 * is the exponent.  Either of the signs
+						 * may be "+", "-", or omitted.  Either I
+						 * or F may be omitted, or both.  The decimal
+						 * point isn't necessary unless F is present.
+						 * The "E" may actually be an "e".  E and X
+						 * may both be omitted (but not just one).
+						 */
+	char **end_ptr		/* If non-NULL, store terminating character's
+						 * address here. */
+	)
 {
-    int sign, fracExpSign, expSign;
-    double fraction, dblExp;
-    const double *d;
-    register const char *p;
-    register int c;
-    size_t exp = 0;         /* Exponent read from "EX" field. */
-    size_t fracExp;         /* Exponent that derives from the fractional
-                             * part.  Under normal circumstatnces, it is
-                             * the negative of the number of digits in F.
-                             * However, if I is very long, the last digits
-                             * of I get dropped (otherwise a long I with a
-                             * large negative exponent could cause an
-                             * unnecessary overflow on I alone).  In this
-                             * case, fracExp is incremented one for each
-                             * dropped digit. */
-    size_t mantSize;    /* Number of digits in mantissa. */
-    size_t decPt;       /* Number of mantissa digits BEFORE decimal
-                         * point. */
-    size_t leadZeros;   /* Number of leading zeros in mantissa. */
-    const char *pExp;       /* Temporarily holds location of exponent
-                             * in string. */
+	int sign, frac_exp_sign, exp_sign;
+	double fraction, dbl_exp;
+	const double *d;
+	register const char *p;
+	register int c;
+	size_t exp = 0;		/* Exponent read from "EX" field. */
+	size_t frac_exp;	/* Exponent that derives from the fractional
+						 * part.  Under normal circumstatnces, it is
+						 * the negative of the number of digits in F.
+						 * However, if I is very long, the last digits
+						 * of I get dropped (otherwise a long I with a
+						 * large negative exponent could cause an
+						 * unnecessary overflow on I alone).  In this
+						 * case, frac_exp is incremented one for each
+						 * dropped digit. */
+	size_t mant_size;	/* Number of digits in mantissa. */
+	size_t dec_pt;		/* Number of mantissa digits BEFORE decimal
+						 * point. */
+	size_t lead_zeros;	/* Number of leading zeros in mantissa. */
+	const char *p_exp;	/* Temporarily holds location of exponent
+						 * in string. */
 
-    /*
-     * Strip off leading blanks and check for a sign.
-     */
+	/*
+	 * Strip off leading blanks and check for a sign.
+	 */
 
-    p = string;
-    while (ass_isspace(*p))
-    {
-        p += 1;
-    }
-    if (*p == '-')
-    {
-        sign = 1;
-        p += 1;
-    }
-    else
-    {
-        if (*p == '+')
-        {
-            p += 1;
-        }
-        sign = 0;
-    }
+	p = string;
+	while (ass_isspace(*p))
+	{
+		p += 1;
+	}
+	if (*p == '-')
+	{
+		sign = 1;
+		p += 1;
+	}
+	else
+	{
+		if (*p == '+')
+		{
+			p += 1;
+		}
+		sign = 0;
+	}
 
-    /*
-     * Count the number of digits in the mantissa (including the decimal
-     * point), and also locate the decimal point.
-     */
+	/*
+	 * Count the number of digits in the mantissa (including the decimal
+	 * point), and also locate the decimal point.
+	 */
 
-    decPt = -1;
-    leadZeros = -1;
-    for (mantSize = 0; ; mantSize += 1)
-    {
-        c = *p;
-        if (!ass_isdigit(c)) {
-            if ((c != '.') || (decPt != (size_t) -1))
-            {
-                break;
-            }
-            decPt = mantSize;
-        } else if ((c != '0') && (leadZeros == (size_t) -1))
-        {
-            leadZeros = mantSize;
-        }
-        p += 1;
-    }
+	dec_pt = -1;
+	lead_zeros = -1;
+	for (mant_size = 0; ; mant_size += 1)
+	{
+		c = *p;
+		if (!ass_isdigit(c)) {
+			if ((c != '.') || (dec_pt != (size_t) -1))
+			{
+				break;
+			}
+			dec_pt = mant_size;
+		} else if ((c != '0') && (lead_zeros == (size_t) -1))
+		{
+			lead_zeros = mant_size;
+		}
+		p += 1;
+	}
 
-    /*
-     * Now suck up the digits in the mantissa.  Use two integers to
-     * collect 9 digits each (this is faster than using floating-point).
-     * If the mantissa has more than 18 digits, ignore the extras, since
-     * they can't affect the value anyway.
-     */
+	/*
+	 * Now suck up the digits in the mantissa.  Use two integers to
+	 * collect 9 digits each (this is faster than using floating-point).
+	 * If the mantissa has more than 18 digits, ignore the extras, since
+	 * they can't affect the value anyway.
+	 */
 
-    if (leadZeros == (size_t) -1)
-    {
-        leadZeros = mantSize;
-    }
-    pExp  = p;
-    p -= mantSize - leadZeros;
-    if (decPt == (size_t) -1)
-    {
-        decPt = mantSize;
-    } else {
-        mantSize -= 1;      /* One of the digits was the point. */
-        if (decPt < leadZeros)
-        {
-            leadZeros -= 1;
-        }
-    }
-    if (mantSize - leadZeros > 18)
-    {
-        mantSize = leadZeros + 18;
-    }
-    if (decPt < mantSize)
-    {
-        fracExpSign = 1;
-        fracExp = mantSize - decPt;
-    }
-    else
-    {
-        fracExpSign = 0;
-        fracExp = decPt - mantSize;
-    }
-    if (mantSize == 0)
-    {
-        fraction = 0.0;
-        p = string;
-        goto done;
-    }
-    else
-    {
-        int frac1, frac2, m;
-        mantSize -= leadZeros;
-        m = mantSize;
-        frac1 = 0;
-        for ( ; m > 9; m -= 1)
-        {
-            c = *p;
-            p += 1;
-            if (c == '.') {
-                c = *p;
-                p += 1;
-            }
-            frac1 = 10*frac1 + (c - '0');
-        }
-        frac2 = 0;
-        for (; m > 0; m -= 1)
-        {
-            c = *p;
-            p += 1;
-            if (c == '.') {
-                c = *p;
-                p += 1;
-            }
-            frac2 = 10*frac2 + (c - '0');
-        }
-        fraction = (1.0e9 * frac1) + frac2;
-    }
+	if (lead_zeros == (size_t) -1)
+	{
+		lead_zeros = mant_size;
+	}
+	p_exp  = p;
+	p -= mant_size - lead_zeros;
+	if (dec_pt == (size_t) -1)
+	{
+		dec_pt = mant_size;
+	} else {
+		mant_size -= 1;	  /* One of the digits was the point. */
+		if (dec_pt < lead_zeros)
+		{
+			lead_zeros -= 1;
+		}
+	}
+	if (mant_size - lead_zeros > 18)
+	{
+		mant_size = lead_zeros + 18;
+	}
+	if (dec_pt < mant_size)
+	{
+		frac_exp_sign = 1;
+		frac_exp = mant_size - dec_pt;
+	}
+	else
+	{
+		frac_exp_sign = 0;
+		frac_exp = dec_pt - mant_size;
+	}
+	if (mant_size == 0)
+	{
+		fraction = 0.0;
+		p = string;
+		goto done;
+	}
+	else
+	{
+		int frac1, frac2, m;
+		mant_size -= lead_zeros;
+		m = mant_size;
+		frac1 = 0;
+		for ( ; m > 9; m -= 1)
+		{
+			c = *p;
+			p += 1;
+			if (c == '.') {
+				c = *p;
+				p += 1;
+			}
+			frac1 = 10*frac1 + (c - '0');
+		}
+		frac2 = 0;
+		for (; m > 0; m -= 1)
+		{
+			c = *p;
+			p += 1;
+			if (c == '.') {
+				c = *p;
+				p += 1;
+			}
+			frac2 = 10*frac2 + (c - '0');
+		}
+		fraction = (1.0e9 * frac1) + frac2;
+	}
 
-    /*
-     * Skim off the exponent.
-     */
+	/*
+	 * Skim off the exponent.
+	 */
 
-    p = pExp;
-    if ((*p == 'E') || (*p == 'e'))
-    {
-        size_t expLimit;    /* If exp > expLimit, appending another digit
-                             * to exp is guaranteed to make it too large.
-                             * If exp == expLimit, this may depend on
-                             * the exact digit, but in any case exp with
-                             * the digit appended and fracExp added will
-                             * still fit in size_t, even if it does
-                             * exceed maxExponent. */
-        int expWraparound = 0;
-        p += 1;
-        if (*p == '-')
-        {
-            expSign = 1;
-            p += 1;
-        } else {
-            if (*p == '+')
-            {
-                p += 1;
-            }
-            expSign = 0;
-        }
-        if (expSign == fracExpSign)
-        {
-            if (maxExponent < fracExp)
-            {
-                expLimit = 0;
-            }
-            else
-            {
-                expLimit = (maxExponent - fracExp) / 10;
-            }
-        }
-        else
-        {
-            expLimit = fracExp / 10 + (fracExp % 10 + maxExponent) / 10;
-        }
-        while (ass_isdigit(*p))
-        {
-            if ((exp > expLimit) || expWraparound)
-            {
-                do
-                {
-                    p += 1;
-                } while (ass_isdigit(*p));
-                goto expOverflow;
-            } else if (exp > ((size_t) -1 - (*p - '0')) / 10)
-            {
-                expWraparound = 1;
-            }
-            exp = exp * 10 + (*p - '0');
-            p += 1;
-        }
-        if (expSign == fracExpSign)
-        {
-            exp = fracExp + exp;
-        }
-        else if ((fracExp <= exp) || expWraparound)
-        {
-            exp = exp - fracExp;
-        }
-        else
-        {
-            exp = fracExp - exp;
-            expSign = fracExpSign;
-        }
-    }
-    else
-    {
-        exp = fracExp;
-        expSign = fracExpSign;
-    }
+	p = p_exp;
+	if ((*p == 'E') || (*p == 'e'))
+	{
+		size_t expLimit;	/* If exp > expLimit, appending another digit
+						 	 * to exp is guaranteed to make it too large.
+						 	 * If exp == expLimit, this may depend on
+						 	 * the exact digit, but in any case exp with
+						 	 * the digit appended and frac_exp added will
+						 	 * still fit in size_t, even if it does
+						 	 * exceed max_exponent. */
+		int expWraparound = 0;
+		p += 1;
+		if (*p == '-')
+		{
+			exp_sign = 1;
+			p += 1;
+		} else {
+			if (*p == '+')
+			{
+				p += 1;
+			}
+			exp_sign = 0;
+		}
+		if (exp_sign == frac_exp_sign)
+		{
+			if (max_exponent < frac_exp)
+			{
+				expLimit = 0;
+			}
+			else
+			{
+				expLimit = (max_exponent - frac_exp) / 10;
+			}
+		}
+		else
+		{
+			expLimit = frac_exp / 10 + (frac_exp % 10 + max_exponent) / 10;
+		}
+		while (ass_isdigit(*p))
+		{
+			if ((exp > expLimit) || expWraparound)
+			{
+				do
+				{
+					p += 1;
+				} while (ass_isdigit(*p));
+				goto exp_overflow;
+			} else if (exp > ((size_t) -1 - (*p - '0')) / 10)
+			{
+				expWraparound = 1;
+			}
+			exp = exp * 10 + (*p - '0');
+			p += 1;
+		}
+		if (exp_sign == frac_exp_sign)
+		{
+			exp = frac_exp + exp;
+		}
+		else if ((frac_exp <= exp) || expWraparound)
+		{
+			exp = exp - frac_exp;
+		}
+		else
+		{
+			exp = frac_exp - exp;
+			exp_sign = frac_exp_sign;
+		}
+	}
+	else
+	{
+		exp = frac_exp;
+		exp_sign = frac_exp_sign;
+	}
 
-    /*
-     * Generate a floating-point number that represents the exponent.
-     * Do this by processing the exponent one bit at a time to combine
-     * many powers of 2 of 10. Then combine the exponent with the
-     * fraction.
-     */
+	/*
+	 * Generate a floating-point number that represents the exponent.
+	 * Do this by processing the exponent one bit at a time to combine
+	 * many powers of 2 of 10. Then combine the exponent with the
+	 * fraction.
+	 */
 
-    if (exp > maxExponent)
-    {
-expOverflow:
-        exp = maxExponent;
-        if (fraction != 0.0)
-        {
-            errno = ERANGE;
-        }
-    }
-    /* Prefer positive powers of 10 for increased precision, especially
-     * for small powers that are represented exactly in floating-point. */
-    if ((exp <= DBL_MAX_10_EXP) || !expSign)
-    {
-        d = powersOf10;
-    }
-    else
-    {
-        /* The floating-point format supports more negative exponents
-         * than positive, or perhaps the result is a subnormal number. */
-        if (exp > -DBL_MIN_10_EXP)
-        {
-            /* The result might be a valid subnormal number, but the
-             * exponent underflows.  Tweak fraction so that it is below
-             * 1.0 first, so that if the exponent still underflows after
-             * that, the result is sure to underflow as well. */
-            exp -= mantSize;
-            dblExp = 1.0;
-            for (d = powersOf10; mantSize != 0; mantSize >>= 1, d += 1) {
-                if (mantSize & 01) {
-                    dblExp *= *d;
-                }
-            }
-            fraction /= dblExp;
-        }
-        d = negPowOf10;
-        expSign = 0;
-    }
-    dblExp = 1.0;
-    for (; exp != 0; exp >>= 1, d += 1) {
-        if (exp & 01)
-        {
-            dblExp *= *d;
-        }
-    }
-    if (expSign)
-    {
-        fraction /= dblExp;
-    }
-    else
-    {
-        fraction *= dblExp;
-    }
+	if (exp > max_exponent)
+	{
+exp_overflow:
+		exp = max_exponent;
+		if (fraction != 0.0)
+		{
+			errno = ERANGE;
+		}
+	}
+	/* Prefer positive powers of 10 for increased precision, especially
+	 * for small powers that are represented exactly in floating-point. */
+	if ((exp <= DBL_MAX_10_EXP) || !exp_sign)
+	{
+		d = powersOf10;
+	}
+	else
+	{
+		/* The floating-point format supports more negative exponents
+		 * than positive, or perhaps the result is a subnormal number. */
+		if (exp > -DBL_MIN_10_EXP)
+		{
+			/* The result might be a valid subnormal number, but the
+			 * exponent underflows.  Tweak fraction so that it is below
+			 * 1.0 first, so that if the exponent still underflows after
+			 * that, the result is sure to underflow as well. */
+			exp -= mant_size;
+			dbl_exp = 1.0;
+			for (d = powersOf10; mant_size != 0; mant_size >>= 1, d += 1) {
+				if (mant_size & 01) {
+					dbl_exp *= *d;
+				}
+			}
+			fraction /= dbl_exp;
+		}
+		d = negPowOf10;
+		exp_sign = 0;
+	}
+	dbl_exp = 1.0;
+	for (; exp != 0; exp >>= 1, d += 1) {
+		if (exp & 01)
+		{
+			dbl_exp *= *d;
+		}
+	}
+	if (exp_sign)
+	{
+		fraction /= dbl_exp;
+	}
+	else
+	{
+		fraction *= dbl_exp;
+	}
 
 done:
-    if (end_ptr != NULL)
-    {
-        *end_ptr = (char *) p;
-    }
+	if (end_ptr != NULL)
+	{
+		*end_ptr = (char *) p;
+	}
 
-    if (sign)
-    {
-        return -fraction;
-    }
-    return fraction;
+	if (sign)
+	{
+		return -fraction;
+	}
+	return fraction;
 }
 
 int mystrtoi(char **p, int *res)
 {
-    char *start = *p;
-    double temp_res = ass_strtod(*p, p);
-    *res = (int) (temp_res + (temp_res > 0 ? 0.5 : -0.5));
-    return *p != start;
+	char *start = *p;
+	double temp_res = ass_strtod(*p, p);
+	*res = (int) (temp_res + (temp_res > 0 ? 0.5 : -0.5));
+	return *p != start;
 }
 
 int mystrtoll(char **p, long long *res)
 {
-    char *start = *p;
-    double temp_res = ass_strtod(*p, p);
-    *res = (long long) (temp_res + (temp_res > 0 ? 0.5 : -0.5));
-    return *p != start;
+	char *start = *p;
+	double temp_res = ass_strtod(*p, p);
+	*res = (long long) (temp_res + (temp_res > 0 ? 0.5 : -0.5));
+	return *p != start;
 }
 
 int mystrtod(char **p, double *res)
 {
-    char *start = *p;
-    *res = ass_strtod(*p, p);
-    return *p != start;
+	char *start = *p;
+	*res = ass_strtod(*p, p);
+	return *p != start;
 }
 
 int mystrtoi32(char **p, int base, int32_t *res)
 {
-    char *start = *p;
-    long long temp_res = strtoll(*p, p, base);
-    *res = FFMINMAX(temp_res, INT32_MIN, INT32_MAX);
-    return *p != start;
+	char *start = *p;
+	long long temp_res = strtoll(*p, p, base);
+	*res = FFMINMAX(temp_res, INT32_MIN, INT32_MAX);
+	return *p != start;
 }
 
 static int read_digits(char **str, int base, uint32_t *res)
 {
-    char *p = *str;
-    char *start = p;
-    uint32_t val = 0;
+	char *p = *str;
+	char *start = p;
+	uint32_t val = 0;
 
-    while (1) {
-        int digit;
-        if (*p >= '0' && *p < FFMIN(base, 10) + '0')
-            digit = *p - '0';
-        else if (*p >= 'a' && *p < base - 10 + 'a')
-            digit = *p - 'a' + 10;
-        else if (*p >= 'A' && *p < base - 10 + 'A')
-            digit = *p - 'A' + 10;
-        else
-            break;
-        val = val * base + digit;
-        ++p;
-    }
+	while (1) {
+		int digit;
+		if (*p >= '0' && *p < FFMIN(base, 10) + '0')
+			digit = *p - '0';
+		else if (*p >= 'a' && *p < base - 10 + 'a')
+			digit = *p - 'a' + 10;
+		else if (*p >= 'A' && *p < base - 10 + 'A')
+			digit = *p - 'A' + 10;
+		else
+			break;
+		val = val * base + digit;
+		++p;
+	}
 
-    *res = val;
-    *str = p;
-    return p != start;
+	*res = val;
+	*str = p;
+	return p != start;
 }
 
 /*
@@ -547,157 +547,157 @@ static int read_digits(char **str, int base, uint32_t *res)
  */
 static int mystrtou32_modulo(char **p, int base, uint32_t *res)
 {
-    // This emulates scanf with %d or %x format as it works on
-    // Windows, because that's what is used by VSFilter. In practice,
-    // scanf works the same way on other platforms too, but
-    // the standard leaves its behavior on overflow undefined.
+	// This emulates scanf with %d or %x format as it works on
+	// Windows, because that's what is used by VSFilter. In practice,
+	// scanf works the same way on other platforms too, but
+	// the standard leaves its behavior on overflow undefined.
 
-    // Unlike scanf and like strtoul, produce 0 for invalid inputs.
+	// Unlike scanf and like strtoul, produce 0 for invalid inputs.
 
-    char *start = *p;
-    int sign = 1;
+	char *start = *p;
+	int sign = 1;
 
-    skip_spaces(p);
+	skip_spaces(p);
 
-    if (**p == '+')
-        ++*p;
-    else if (**p == '-')
-        sign = -1, ++*p;
+	if (**p == '+')
+		++*p;
+	else if (**p == '-')
+		sign = -1, ++*p;
 
-    if (base == 16 && !ass_strncasecmp(*p, "0x", 2))
-        *p += 2;
+	if (base == 16 && !ass_strncasecmp(*p, "0x", 2))
+		*p += 2;
 
-    if (read_digits(p, base, res)) {
-        *res *= sign;
-        return 1;
-    }
-    else
-    {
-        *p = start;
-        return 0;
-    }
+	if (read_digits(p, base, res)) {
+		*res *= sign;
+		return 1;
+	}
+	else
+	{
+		*p = start;
+		return 0;
+	}
 }
 int32_t parse_alpha_tag(char *str)
 {
-    int32_t alpha = 0;
+	int32_t alpha = 0;
 
-    while (*str == '&' || *str == 'H')
-        ++str;
+	while (*str == '&' || *str == 'H')
+		++str;
 
-    mystrtoi32(&str, 16, &alpha);
-    return alpha;
+	mystrtoi32(&str, 16, &alpha);
+	return alpha;
 }
 
 uint32_t parse_color_tag(char *str)
 {
-    int32_t color = 0;
+	int32_t color = 0;
 
-    while (*str == '&' || *str == 'H')
-        ++str;
+	while (*str == '&' || *str == 'H')
+		++str;
 
-    mystrtoi32(&str, 16, &color);
-    return ass_bswap32((uint32_t) color);
+	mystrtoi32(&str, 16, &color);
+	return ass_bswap32((uint32_t) color);
 }
 
 uint32_t parse_color_header(char *str)
 {
-    uint32_t color = 0;
-    int base;
+	uint32_t color = 0;
+	int base;
 
-    if (!ass_strncasecmp(str, "&h", 2) || !ass_strncasecmp(str, "0x", 2))
-    {
-        str += 2;
-        base = 16;
-    }
-    else
-        base = 10;
+	if (!ass_strncasecmp(str, "&h", 2) || !ass_strncasecmp(str, "0x", 2))
+	{
+		str += 2;
+		base = 16;
+	}
+	else
+		base = 10;
 
-    mystrtou32_modulo(&str, base, &color);
-    return ass_bswap32(color);
+	mystrtou32_modulo(&str, base, &color);
+	return ass_bswap32(color);
 }
 
 // Return a boolean value for a string
 char parse_bool(char *str)
 {
-    skip_spaces(&str);
-    return !ass_strncasecmp(str, "yes", 3) || strtol(str, NULL, 10) > 0;
+	skip_spaces(&str);
+	return !ass_strncasecmp(str, "yes", 3) || strtol(str, NULL, 10) > 0;
 }
 
 int ass_alloc_style(ass_track_t *track)
 {
-    int sid;
+	int sid;
 
-    //assert(track->n_styles <= track->max_styles);
+	//assert(track->n_styles <= track->max_styles);
 
-    if (track->n_styles == track->max_styles) {
-        track->max_styles += ASS_STYLES_ALLOC;
-        track->styles =
-            (ass_style_t *) realloc(track->styles,
-                                    sizeof(ass_style_t) *
-                                    track->max_styles);
-    }
+	if (track->n_styles == track->max_styles) {
+		track->max_styles += ASS_STYLES_ALLOC;
+		track->styles =
+			(ass_style_t *) realloc(track->styles,
+									sizeof(ass_style_t) *
+									track->max_styles);
+	}
 
-    sid = track->n_styles++;
-    vod_memset(track->styles + sid, 0, sizeof(ass_style_t));
-    return sid;
+	sid = track->n_styles++;
+	vod_memset(track->styles + sid, 0, sizeof(ass_style_t));
+	return sid;
 }
 
 int ass_alloc_event(ass_track_t *track)
 {
-    int eid;
+	int eid;
 
-    //assert(track->n_events <= track->max_events);
+	//assert(track->n_events <= track->max_events);
 
-    if (track->n_events == track->max_events) {
-        track->max_events = track->max_events * 2 + 1;
-        track->events =
-            (ass_event_t *) realloc(track->events,
-                                    sizeof(ass_event_t) *
-                                    track->max_events);
-    }
+	if (track->n_events == track->max_events) {
+		track->max_events = track->max_events * 2 + 1;
+		track->events =
+			(ass_event_t *) realloc(track->events,
+									sizeof(ass_event_t) *
+									track->max_events);
+	}
 
-    eid = track->n_events++;
-    vod_memzero(track->events + eid, sizeof(ass_event_t));
-    return eid;
+	eid = track->n_events++;
+	vod_memzero(track->events + eid, sizeof(ass_event_t));
+	return eid;
 }
 void ass_free_event(ass_track_t *track, int eid)
 {
-    ass_event_t *event = track->events + eid;
+	ass_event_t *event = track->events + eid;
 
-    free(event->name);
-    free(event->effect);
-    free(event->text);
+	free(event->name);
+	free(event->effect);
+	free(event->text);
 }
 void ass_free_style(ass_track_t *track, int sid)
 {
-    ass_style_t *style = track->styles + sid;
+	ass_style_t *style = track->styles + sid;
 
-    free(style->name);
-    free(style->font_name);
+	free(style->name);
+	free(style->font_name);
 }
 
 void ass_free_track(vod_pool_t* pool, ass_track_t *track)
 {
-    int i;
+	int i;
 
-    free(track->style_format);
-    free(track->event_format);
-    free(track->language);
-    free(track->title);
-    if (track->styles)
-    {
-        for (i = 0; i < track->n_styles; ++i)
-            ass_free_style(track, i);
-    }
-    free(track->styles);
-    if (track->events)
-    {
-        for (i = 0; i < track->n_events; ++i)
-            ass_free_event(track, i);
-    }
-    free(track->events);
-    free(track->name);
-    vod_free(pool, track);
+	free(track->style_format);
+	free(track->event_format);
+	free(track->language);
+	free(track->title);
+	if (track->styles)
+	{
+		for (i = 0; i < track->n_styles; ++i)
+			ass_free_style(track, i);
+	}
+	free(track->styles);
+	if (track->events)
+	{
+		for (i = 0; i < track->n_events; ++i)
+			ass_free_event(track, i);
+	}
+	free(track->events);
+	free(track->name);
+	vod_free(pool, track);
 }
 
 
@@ -710,46 +710,46 @@ void ass_free_track(vod_pool_t* pool, ass_track_t *track)
  */
 static void set_default_style(ass_style_t *style, bool_t alloc_names)
 {
-    if (alloc_names)
-    {
-        style->name             = strdup("Default");
-        style->font_name        = strdup("Arial");
-    }
-    style->font_size            = 18;
-    style->primary_colour       = 0xffffff00;
-    style->secondary_colour     = 0x00ffff00;
-    style->outline_colour       = 0x00000000;
-    style->back_colour          = 0x00000080;
-    style->bold                 = FALSE;
-    style->italic               = FALSE;
-    style->underline            = FALSE;
-    style->strike_out           = FALSE;
-    style->right_to_left_language = FALSE;
-    style->output_in_cur_segment  = FALSE;
-    style->scale_x              = 100.0;
-    style->scale_y              = 100.0;
-    style->spacing              = 0.0;
-    style->angle                = 0.0;
-    style->border_style         = 1;
-    style->outline              = 2;
-    style->shadow               = 0;
-    style->alignment            = 2;
-    style->margin_l = style->margin_r = style->margin_v = 20;
-    style->encoding             = 0;
+	if (alloc_names)
+	{
+		style->name				= strdup("Default");
+		style->font_name		= strdup("Arial");
+	}
+	style->font_size			= 18;
+	style->primary_colour		= 0xffffff00;
+	style->secondary_colour		= 0x00ffff00;
+	style->outline_colour		= 0x00000000;
+	style->back_colour			= 0x00000080;
+	style->bold					= FALSE;
+	style->italic				= FALSE;
+	style->underline			= FALSE;
+	style->strike_out			= FALSE;
+	style->right_to_left_language = FALSE;
+	style->output_in_cur_segment  = FALSE;
+	style->scale_x				= 100.0;
+	style->scale_y				= 100.0;
+	style->spacing				= 0.0;
+	style->angle				= 0.0;
+	style->border_style			= 1;
+	style->outline				= 2;
+	style->shadow				= 0;
+	style->alignment			= 2;
+	style->margin_l = style->margin_r = style->margin_v = 20;
+	style->encoding				= 0;
 }
 
 static long long string2timecode(char *p)
 {
-    int h, m, s, ms;
-    long long tm;
-    int res = sscanf(p, "%d:%d:%d.%d", &h, &m, &s, &ms);
-    if (res < 4)
-    {
-        // error msg "Bad timestamp";
-        return 0;
-    }
-    tm = ((h * 60LL + m) * 60 + s) * 1000 + ms * 10LL;
-    return tm;
+	int h, m, s, ms;
+	long long tm;
+	int res = sscanf(p, "%d:%d:%d.%d", &h, &m, &s, &ms);
+	if (res < 4)
+	{
+		// error msg "Bad timestamp";
+		return 0;
+	}
+	tm = ((h * 60LL + m) * 60 + s) * 1000 + ms * 10LL;
+	return tm;
 }
 /**
  * \brief find style by name
@@ -761,31 +761,31 @@ static long long string2timecode(char *p)
  */
 int lookup_style(ass_track_t *track, char *name)
 {
-    int i;
-    // '*' seem to mean literally nothing;
-    // VSFilter removes them as soon as it can
-    while (*name == '*')
-        ++name;
-    // VSFilter then normalizes the case of "Default"
-    // (only in contexts where this function is called)
-    if (ass_strcasecmp(name, "Default") == 0)
-        name = "Default";
-    for (i = track->n_styles - 1; i >= 0; --i)
-    {
-        if (strcmp(track->styles[i].name, name) == 0)
-            return i;
-    }
-    i = track->default_style;
-    return i;
+	int i;
+	// '*' seem to mean literally nothing;
+	// VSFilter removes them as soon as it can
+	while (*name == '*')
+		++name;
+	// VSFilter then normalizes the case of "Default"
+	// (only in contexts where this function is called)
+	if (ass_strcasecmp(name, "Default") == 0)
+		name = "Default";
+	for (i = track->n_styles - 1; i >= 0; --i)
+	{
+		if (strcmp(track->styles[i].name, name) == 0)
+			return i;
+	}
+	i = track->default_style;
+	return i;
 }
 
 #define NEXT(str,token) \
-    token = next_token(&str); \
-    if (!token) break;
+	token = next_token(&str); \
+	if (!token) break;
 
 
 #define ALIAS(alias,name) \
-        if (ass_strcasecmp(tname, #alias) == 0) {tname = #name;}
+		if (ass_strcasecmp(tname, #alias) == 0) {tname = #name;}
 
 /* One section started with PARSE_START and PARSE_END parses a single token
  * (contained in the variable named token) for the header indicated by the
@@ -797,58 +797,58 @@ int lookup_style(ass_track_t *track, char *name)
  * a header could be parsed. The parsed results are stored in the variable
  * target, which has the type ass_style_t* or ass_event_t*.
  */
-#define PARSE_START if (0) {
-#define PARSE_END   }
+#define PARSE_START	if (0) {
+#define PARSE_END	}
 
 #define ANYVAL(name,func) \
-    } else if (ass_strcasecmp(tname, #name) == 0) { \
-        target->name = func(token);
+	} else if (ass_strcasecmp(tname, #name) == 0) { \
+		target->name = func(token);
 
 #define STRVAL(name) \
-    } else if (ass_strcasecmp(tname, #name) == 0) { \
-        if (target->name != NULL) free(target->name); \
-        target->name = strdup(token);
+	} else if (ass_strcasecmp(tname, #name) == 0) { \
+		if (target->name != NULL) free(target->name); \
+		target->name = strdup(token);
 
 #define STARREDSTRVAL(name) \
-    } else if (ass_strcasecmp(tname, #name) == 0) { \
-        if (target->name != NULL) free(target->name); \
-        while (*token == '*') ++token; \
-        target->name = strdup(token);
+	} else if (ass_strcasecmp(tname, #name) == 0) { \
+		if (target->name != NULL) free(target->name); \
+		while (*token == '*') ++token; \
+		target->name = strdup(token);
 
 #define COLORVAL(name) ANYVAL(name,parse_color_header)
 #define INTVAL(name) ANYVAL(name,atoi)
 #define FPVAL(name) ANYVAL(name,ass_atof)
 #define TIMEVAL(name) \
-    } else if (ass_strcasecmp(tname, #name) == 0) { \
-        target->name = string2timecode(token);
+	} else if (ass_strcasecmp(tname, #name) == 0) { \
+		target->name = string2timecode(token);
 
 #define STYLEVAL(name) \
-    } else if (ass_strcasecmp(tname, #name) == 0) { \
-        target->name = lookup_style(track, token);
+	} else if (ass_strcasecmp(tname, #name) == 0) { \
+		target->name = lookup_style(track, token);
 
 static char *next_token(char **str)
 {
-    char *p = *str;
-    char *start;
-    skip_spaces(&p);
-    if (*p == '\0') {
-        *str = p;
-        return 0;
-    }
-    start = p;                  // start of the token
-    for (; (*p != '\0') && (*p != ','); ++p) {
-    }
-    if (*p == '\0') {
-        *str = p;               // eos found, str will point to '\0' at exit
-    }
-    else
-    {
-        *p = '\0';
-        *str = p + 1;           // ',' found, str will point to the next char (beginning of the next token)
-    }
-    rskip_spaces(&p, start);    // end of current token: the first space character, or '\0'
-    *p = '\0';
-    return start;
+	char *p = *str;
+	char *start;
+	skip_spaces(&p);
+	if (*p == '\0') {
+		*str = p;
+		return 0;
+	}
+	start = p;					// start of the token
+	for (; (*p != '\0') && (*p != ','); ++p) {
+	}
+	if (*p == '\0') {
+		*str = p;				// eos found, str will point to '\0' at exit
+	}
+	else
+	{
+		*p = '\0';
+		*str = p + 1;			// ',' found, str will point to the next char (beginning of the next token)
+	}
+	rskip_spaces(&p, start);	// end of current token: the first space character, or '\0'
+	*p = '\0';
+	return start;
 }
 
 /**
@@ -859,59 +859,59 @@ static char *next_token(char **str)
 */
 static int process_event_tail(ass_track_t *track, ass_event_t *event, char *str)
 {
-    char *token;
-    char *tname;
-    char *p = str;
-    ass_event_t *target = event;
+	char *token;
+	char *tname;
+	char *p = str;
+	ass_event_t *target = event;
 
-    char *format = strdup(track->event_format);
-    char *q = format;           // format scanning pointer
+	char *format = strdup(track->event_format);
+	char *q = format;			// format scanning pointer
 
-    if (track->n_styles == 0)
-    {
-        // add "Default" style to the end
-        // will be used if track does not contain a default style (or even does not contain styles at all)
-        int sid = ass_alloc_style(track);
-        set_default_style(&track->styles[sid], TRUE);
-        track->default_style = sid;
-    }
+	if (track->n_styles == 0)
+	{
+		// add "Default" style to the end
+		// will be used if track does not contain a default style (or even does not contain styles at all)
+		int sid = ass_alloc_style(track);
+		set_default_style(&track->styles[sid], TRUE);
+		track->default_style = sid;
+	}
 
-    while (1)
-    {
-        NEXT(q, tname);
-        if (ass_strcasecmp(tname, "Text") == 0)
-        {
-            char *last;
-            event->text = strdup(p);
-            if (*event->text != 0) {
-                last = event->text + strlen(event->text) - 1;
-                if (last >= event->text && *last == '\r')
-                    *last = 0;
-            }
-            // need to track the largest end time in all events, since they are not in chronological order
-            if (track->max_duration < event->end)
-            {
-                track->max_duration = event->end;
-            }
-            free(format);
-            return 0;           // "Text" is always the last
-        }
-        NEXT(p, token);
+	while (1)
+	{
+		NEXT(q, tname);
+		if (ass_strcasecmp(tname, "Text") == 0)
+		{
+			char *last;
+			event->text = strdup(p);
+			if (*event->text != 0) {
+				last = event->text + strlen(event->text) - 1;
+				if (last >= event->text && *last == '\r')
+					*last = 0;
+			}
+			// need to track the largest end time in all events, since they are not in chronological order
+			if (track->max_duration < event->end)
+			{
+				track->max_duration = event->end;
+			}
+			free(format);
+			return 0;			// "Text" is always the last
+		}
+		NEXT(p, token);
 
-        PARSE_START
-            INTVAL(layer)
-            STYLEVAL(style)
-            STRVAL(name)
-            STRVAL(effect)
-            INTVAL(margin_l)
-            INTVAL(margin_r)
-            INTVAL(margin_v)
-            TIMEVAL(start)
-            TIMEVAL(end)
-        PARSE_END
-    }
-    free(format);
-    return 1;
+		PARSE_START
+			INTVAL(layer)
+			STYLEVAL(style)
+			STRVAL(name)
+			STRVAL(effect)
+			INTVAL(margin_l)
+			INTVAL(margin_r)
+			INTVAL(margin_v)
+			TIMEVAL(start)
+			TIMEVAL(end)
+		PARSE_END
+	}
+	free(format);
+	return 1;
 }
 
 /**
@@ -919,20 +919,20 @@ static int process_event_tail(ass_track_t *track, ass_event_t *event, char *str)
  */
 int numpad2align(int val)
 {
-    if (val < -INT_MAX)
-        // Pick an alignment somewhat arbitrarily. VSFilter handles
-        // INT32_MIN as a mix of 1, 2 and 3, so prefer one of those values.
-        val = 2;
-    else if (val < 0)
-        val = -val;
-    int res = ((val - 1) % 3) + 1;  // horizontal alignment
-    if (val <= 3)
-        res |= VALIGN_SUB;
-    else if (val <= 6)
-        res |= VALIGN_CENTER;
-    else
-        res |= VALIGN_TOP;
-    return res;
+	if (val < -INT_MAX)
+		// Pick an alignment somewhat arbitrarily. VSFilter handles
+		// INT32_MIN as a mix of 1, 2 and 3, so prefer one of those values.
+		val = 2;
+	else if (val < 0)
+		val = -val;
+	int res = ((val - 1) % 3) + 1;  // horizontal alignment
+	if (val <= 3)
+		res |= VALIGN_SUB;
+	else if (val <= 6)
+		res |= VALIGN_CENTER;
+	else
+		res |= VALIGN_TOP;
+	return res;
 }
 
 /**
@@ -944,249 +944,249 @@ int numpad2align(int val)
 static int process_style(ass_track_t *track, char *str, request_context_t* request_context)
 {
 
-    char *token;
-    char *tname;
-    char *p = str;
-    char *format;
-    char *q;                    // format scanning pointer
-    int sid;
-    ass_style_t *style;
-    ass_style_t *target;
+	char *token;
+	char *tname;
+	char *p = str;
+	char *format;
+	char *q;						// format scanning pointer
+	int sid;
+	ass_style_t *style;
+	ass_style_t *target;
 
-    if (!track->style_format)
-    {
-        // no style format header
-        // probably an ancient script version
-        if (track->track_type == TRACK_TYPE_SSA)
-            track->style_format =
-                strdup
-                ("Name, Fontname, Fontsize, PrimaryColour, SecondaryColour,"
-                 "TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline,"
-                 "Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding");
-        else
-            track->style_format =
-                strdup
-                ("Name, Fontname, Fontsize, PrimaryColour, SecondaryColour,"
-                 "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut,"
-                 "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow,"
-                 "Alignment, MarginL, MarginR, MarginV, Encoding");
-    }
+	if (!track->style_format)
+	{
+		// no style format header
+		// probably an ancient script version
+		if (track->track_type == TRACK_TYPE_SSA)
+			track->style_format =
+				strdup
+				("Name, Fontname, Fontsize, PrimaryColour, SecondaryColour,"
+				 "TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline,"
+				 "Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding");
+		else
+			track->style_format =
+				strdup
+				("Name, Fontname, Fontsize, PrimaryColour, SecondaryColour,"
+				 "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut,"
+				 "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow,"
+				 "Alignment, MarginL, MarginR, MarginV, Encoding");
+	}
 
-    q = format = strdup(track->style_format);
+	q = format = strdup(track->style_format);
 
-    // Add default style first
-    if (track->n_styles == 0)
-    {
-        // will be used if track does not contain a default style (or even does not contain styles at all)
-        int sid = ass_alloc_style(track);
-        set_default_style(&track->styles[sid], TRUE);
-        track->default_style = sid;
-    }
+	// Add default style first
+	if (track->n_styles == 0)
+	{
+		// will be used if track does not contain a default style (or even does not contain styles at all)
+		int sid = ass_alloc_style(track);
+		set_default_style(&track->styles[sid], TRUE);
+		track->default_style = sid;
+	}
 
-    sid = ass_alloc_style(track);
+	sid = ass_alloc_style(track);
 
-    style = track->styles + sid;
-    target = style;
+	style = track->styles + sid;
+	target = style;
 
-    set_default_style(target, FALSE);
+	set_default_style(target, FALSE);
 
-    while (1)
-    {
-        NEXT(q, tname);
-        NEXT(p, token);
+	while (1)
+	{
+		NEXT(q, tname);
+		NEXT(p, token);
 
-        PARSE_START
-            STARREDSTRVAL(name)
-            if (strcmp(target->name, "Default") == 0)
-                track->default_style = sid;
-            STRVAL(font_name)
-            COLORVAL(primary_colour)
-            COLORVAL(secondary_colour)
-            COLORVAL(outline_colour) // TertiaryColor
-            COLORVAL(back_colour)
-            // SSA uses BackColour for both outline and shadow
-            // this will destroy SSA's TertiaryColour, but i'm not going to use it anyway
-            if (track->track_type == TRACK_TYPE_SSA)
-                target->outline_colour = target->back_colour;
-            INTVAL(font_size)
-            INTVAL(bold)
-            INTVAL(italic)
-            INTVAL(underline)
-            INTVAL(strike_out)
-            FPVAL(spacing)
-            FPVAL(angle)
-            INTVAL(border_style)
-            INTVAL(alignment)
-            if (track->track_type == TRACK_TYPE_ASS)
-            {
-                target->alignment = numpad2align(target->alignment);
-            }
-            // VSFilter compatibility
-            else if (target->alignment == 8)
-                target->alignment = 3;
-            else if (target->alignment == 4)
-                target->alignment = 11;
-            INTVAL(margin_l)
-            INTVAL(margin_r)
-            INTVAL(margin_v)
-            INTVAL(encoding)
-            FPVAL(scale_x)
-            FPVAL(scale_y)
-            INTVAL(outline)
-            INTVAL(shadow)
-        PARSE_END
-    }
-    style->scale_x    = FFMAX(style->scale_x, 0.) / 100.;
-    style->scale_y    = FFMAX(style->scale_y, 0.) / 100.;
-    style->spacing    = FFMAX(style->spacing, 0.);
-    style->angle      = FFMAX(style->spacing, 0.);
-    style->outline    = FFMAX(style->outline, 0);
-    style->shadow     = FFMAX(style->shadow,  0);
-    style->bold       = !!style->bold;
-    style->italic     = !!style->italic;
-    style->underline  = !!style->underline;
-    style->strike_out = !!style->strike_out;
-    if (!style->name)
-        style->name = strdup("Default");
-    if (!style->font_name)
-        style->font_name = strdup("Arial");
+		PARSE_START
+			STARREDSTRVAL(name)
+			if (strcmp(target->name, "Default") == 0)
+				track->default_style = sid;
+			STRVAL(font_name)
+			COLORVAL(primary_colour)
+			COLORVAL(secondary_colour)
+			COLORVAL(outline_colour) // TertiaryColor
+			COLORVAL(back_colour)
+			// SSA uses BackColour for both outline and shadow
+			// this will destroy SSA's TertiaryColour, but i'm not going to use it anyway
+			if (track->track_type == TRACK_TYPE_SSA)
+				target->outline_colour = target->back_colour;
+			INTVAL(font_size)
+			INTVAL(bold)
+			INTVAL(italic)
+			INTVAL(underline)
+			INTVAL(strike_out)
+			FPVAL(spacing)
+			FPVAL(angle)
+			INTVAL(border_style)
+			INTVAL(alignment)
+			if (track->track_type == TRACK_TYPE_ASS)
+			{
+				target->alignment = numpad2align(target->alignment);
+			}
+			// VSFilter compatibility
+			else if (target->alignment == 8)
+				target->alignment = 3;
+			else if (target->alignment == 4)
+				target->alignment = 11;
+			INTVAL(margin_l)
+			INTVAL(margin_r)
+			INTVAL(margin_v)
+			INTVAL(encoding)
+			FPVAL(scale_x)
+			FPVAL(scale_y)
+			INTVAL(outline)
+			INTVAL(shadow)
+		PARSE_END
+	}
+	style->scale_x		= FFMAX(style->scale_x, 0.) / 100.;
+	style->scale_y		= FFMAX(style->scale_y, 0.) / 100.;
+	style->spacing		= FFMAX(style->spacing, 0.);
+	style->angle		= FFMAX(style->spacing, 0.);
+	style->outline		= FFMAX(style->outline, 0);
+	style->shadow		= FFMAX(style->shadow,  0);
+	style->bold			= !!style->bold;
+	style->italic		= !!style->italic;
+	style->underline	= !!style->underline;
+	style->strike_out	= !!style->strike_out;
+	if (!style->name)
+		style->name		= strdup("Default");
+	if (!style->font_name)
+		style->font_name = strdup("Arial");
 
-    // For now, right_to_left_language is TRUE only for Arabic language. In future, it will be enabled for many others.
-    if ( !ass_strncasecmp(style->font_name, "Adobe Arabic", 12) )
-    {
-        style->right_to_left_language = TRUE;
-    }
-    else
-    {
-        style->right_to_left_language = track->right_to_left_language;
-    }
-    free(format);
-    return 0;
+	// For now, right_to_left_language is TRUE only for Arabic language. In future, it will be enabled for many others.
+	if ( !ass_strncasecmp(style->font_name, "Adobe Arabic", 12) )
+	{
+		style->right_to_left_language = TRUE;
+	}
+	else
+	{
+		style->right_to_left_language = track->right_to_left_language;
+	}
+	free(format);
+	return 0;
 
 }
 
 static int process_styles_line(ass_track_t *track, char *str, request_context_t* request_context)
 {
-    if (!strncmp(str, "Format:", 7))
-    {
-        char *p = str + 7;
-        skip_spaces(&p);
-        free(track->style_format);
-        track->style_format = strdup(p);
-    } else if (!strncmp(str, "Style:", 6))
-    {
-        char *p = str + 6;
-        skip_spaces(&p);
-        process_style(track, p, request_context);
-    }
-    return 0;
+	if (!strncmp(str, "Format:", 7))
+	{
+		char *p = str + 7;
+		skip_spaces(&p);
+		free(track->style_format);
+		track->style_format = strdup(p);
+	} else if (!strncmp(str, "Style:", 6))
+	{
+		char *p = str + 6;
+		skip_spaces(&p);
+		process_style(track, p, request_context);
+	}
+	return 0;
 }
 
 static int process_info_line(ass_track_t *track, char *str, request_context_t* request_context)
 {
-    if (!strncmp(str, "PlayResX:", 9))
-    {
-        track->play_res_x = atoi(str + 9);
-    }
-    else if (!strncmp(str, "PlayResY:", 9))
-    {
-        track->play_res_y = atoi(str + 9);
-    }
-    else if (!strncmp(str, "Timer:", 6))
-    {
-        track->timer = ass_atof(str + 6);
-    }
-    else if (!strncmp(str, "WrapStyle:", 10))
-    {
-        track->wrap_style = atoi(str + 10);
-    }
-    else if (!strncmp(str, "ScaledBorderAndShadow:", 22))
-    {
-        track->scaled_border_and_shadow = parse_bool(str + 22);
-    }
-    else if (!strncmp(str, "Kerning:", 8))
-    {
-        track->kerning = parse_bool(str + 8);
-    }
-    else if (!strncmp(str, "YCbCr Matrix:", 13))
-    {
-        // ignore for now
-    }
-    else if (!strncmp(str, "Language:", 9))
-    { // This field is not part of the ASS/SSA specs
-        char *p = str + 9;
-        while (*p && ass_isspace(*p)) p++;
-        free(track->language);
-        track->language = strndup(p, 2);
-    } else if (!strncmp(str, "Title:", 6))
-    {
-        char *p = str + 6;
-        char *strt, *end;
-        while (*p && ass_isspace(*p))
-            p++;
-        strt = p;
-        while (*p && !ass_isspace(*p))
-            p++;
-        end = p;
-        free(track->title);
-        // Title: ﺎﻠﻋﺮﺒﻳﺓ
-        track->title = strndup(p, FFMAX(14, (size_t)(end-strt)));
-        track->right_to_left_language = ((14 == (end-strt)) && (strt[0] == (char)0xD8) && (strt[13] == (char)0xA9));
-    }
-    return 0;
+	if (!strncmp(str, "PlayResX:", 9))
+	{
+		track->play_res_x = atoi(str + 9);
+	}
+	else if (!strncmp(str, "PlayResY:", 9))
+	{
+		track->play_res_y = atoi(str + 9);
+	}
+	else if (!strncmp(str, "Timer:", 6))
+	{
+		track->timer = ass_atof(str + 6);
+	}
+	else if (!strncmp(str, "WrapStyle:", 10))
+	{
+		track->wrap_style = atoi(str + 10);
+	}
+	else if (!strncmp(str, "ScaledBorderAndShadow:", 22))
+	{
+		track->scaled_border_and_shadow = parse_bool(str + 22);
+	}
+	else if (!strncmp(str, "Kerning:", 8))
+	{
+		track->kerning = parse_bool(str + 8);
+	}
+	else if (!strncmp(str, "YCbCr Matrix:", 13))
+	{
+		// ignore for now
+	}
+	else if (!strncmp(str, "Language:", 9))
+	{ // This field is not part of the ASS/SSA specs
+		char *p = str + 9;
+		while (*p && ass_isspace(*p)) p++;
+		free(track->language);
+		track->language = strndup(p, 2);
+	} else if (!strncmp(str, "Title:", 6))
+	{
+		char *p = str + 6;
+		char *strt, *end;
+		while (*p && ass_isspace(*p))
+			p++;
+		strt = p;
+		while (*p && !ass_isspace(*p))
+			p++;
+		end = p;
+		free(track->title);
+		// Title: ﺎﻠﻋﺮﺒﻳﺓ
+		track->title = strndup(p, FFMAX(14, (size_t)(end-strt)));
+		track->right_to_left_language = ((14 == (end-strt)) && (strt[0] == (char)0xD8) && (strt[13] == (char)0xA9));
+	}
+	return 0;
 }
 
 static void event_format_fallback(ass_track_t *track)
 {
-    track->state = PST_EVENTS;
-    if (track->track_type == TRACK_TYPE_SSA)
-        track->event_format = strdup("Marked, Start, End, Style, "
-            "Name, MarginL, MarginR, MarginV, Effect, Text");
-    else
-        track->event_format = strdup("Layer, Start, End, Style, "
-            "Actor, MarginL, MarginR, MarginV, Effect, Text");
+	track->state = PST_EVENTS;
+	if (track->track_type == TRACK_TYPE_SSA)
+		track->event_format = strdup("Marked, Start, End, Style, "
+			"Name, MarginL, MarginR, MarginV, Effect, Text");
+	else
+		track->event_format = strdup("Layer, Start, End, Style, "
+			"Actor, MarginL, MarginR, MarginV, Effect, Text");
 }
 
 static int process_events_line(ass_track_t *track, char *str, request_context_t* request_context)
 {
-    if (!strncmp(str, "Format:", 7))
-    {
-        char *p = str + 7;
-        skip_spaces(&p);
-        free(track->event_format);
-        track->event_format = strdup(p);
+	if (!strncmp(str, "Format:", 7))
+	{
+		char *p = str + 7;
+		skip_spaces(&p);
+		free(track->event_format);
+		track->event_format = strdup(p);
 
-    }
-    else if (!strncmp(str, "Dialogue:", 9))
-    {
-        // This should never be reached for embedded subtitles.
-        // They have slightly different format and are parsed in ass_process_chunk,
-        // called directly from demuxer
-        int eid;
-        ass_event_t *event;
+	}
+	else if (!strncmp(str, "Dialogue:", 9))
+	{
+		// This should never be reached for embedded subtitles.
+		// They have slightly different format and are parsed in ass_process_chunk,
+		// called directly from demuxer
+		int eid;
+		ass_event_t *event;
 
-        str += 9;
-        skip_spaces(&str);
+		str += 9;
+		skip_spaces(&str);
 
-        eid = ass_alloc_event(track);
-        event = track->events + eid;
+		eid = ass_alloc_event(track);
+		event = track->events + eid;
 
-        // We can't parse events without event_format
-        if (!track->event_format)
-            event_format_fallback(track);
+		// We can't parse events without event_format
+		if (!track->event_format)
+			event_format_fallback(track);
 
-        process_event_tail(track, event, str);
-    }
-    else if (!strncmp(str, "Comment:", 8))
-    {
-        // Ignore and do nothing, this is just a comment line
-    }
-    else
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "Event line not understood: %s", str);
-    }
-    return 0;
+		process_event_tail(track, event, str);
+	}
+	else if (!strncmp(str, "Comment:", 8))
+	{
+		// Ignore and do nothing, this is just a comment line
+	}
+	else
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"Event line not understood: %s", str);
+	}
+	return 0;
 }
 
 /**
@@ -1196,50 +1196,50 @@ static int process_events_line(ass_track_t *track, char *str, request_context_t*
 */
 static int process_line(ass_track_t *track, char *str, request_context_t* request_context)
 {
-    int retval = 0;
-    if (!ass_strncasecmp(str, "[Script Info]", 13))
-    {
-        track->state = PST_INFO;
-    }
-    else if (!ass_strncasecmp(str, "[V4 Styles]", 11))
-    {
-        track->state = PST_STYLES;
-        track->track_type = TRACK_TYPE_SSA;
-    }
-    else if (!ass_strncasecmp(str, "[V4+ Styles]", 12))
-    {
-        track->state = PST_STYLES;
-        track->track_type = TRACK_TYPE_ASS;
-    }
-    else if (!ass_strncasecmp(str, "[Events]", 8))
-    {
-        track->state = PST_EVENTS;
-    }
-    else if (!ass_strncasecmp(str, "[Fonts]", 7))
-    {
-        track->state = PST_FONTS;
-    }
-    else
-    {
-        switch (track->state)
-        {
-        case PST_INFO:
-            retval |= process_info_line(track, str, request_context);
-            break;
-        case PST_STYLES:
-            retval |= process_styles_line(track, str, request_context);
-            break;
-        case PST_EVENTS:
-            retval |= process_events_line(track, str, request_context);
-            break;
-        case PST_FONTS:
-            // ignore for now
-            break;
-        default:
-            break;
-        }
-    }
-    return 0;
+	int retval = 0;
+	if (!ass_strncasecmp(str, "[Script Info]", 13))
+	{
+		track->state = PST_INFO;
+	}
+	else if (!ass_strncasecmp(str, "[V4 Styles]", 11))
+	{
+		track->state = PST_STYLES;
+		track->track_type = TRACK_TYPE_SSA;
+	}
+	else if (!ass_strncasecmp(str, "[V4+ Styles]", 12))
+	{
+		track->state = PST_STYLES;
+		track->track_type = TRACK_TYPE_ASS;
+	}
+	else if (!ass_strncasecmp(str, "[Events]", 8))
+	{
+		track->state = PST_EVENTS;
+	}
+	else if (!ass_strncasecmp(str, "[Fonts]", 7))
+	{
+		track->state = PST_FONTS;
+	}
+	else
+	{
+		switch (track->state)
+		{
+		case PST_INFO:
+			retval |= process_info_line(track, str, request_context);
+			break;
+		case PST_STYLES:
+			retval |= process_styles_line(track, str, request_context);
+			break;
+		case PST_EVENTS:
+			retval |= process_events_line(track, str, request_context);
+			break;
+		case PST_FONTS:
+			// ignore for now
+			break;
+		default:
+			break;
+		}
+	}
+	return 0;
 }
 
 /**
@@ -1249,34 +1249,34 @@ static int process_line(ass_track_t *track, char *str, request_context_t* reques
 */
 static int process_text(ass_track_t *track, char *str, request_context_t* request_context)
 {
-    int retval = 0;
-    char *p = str;
+	int retval = 0;
+	char *p = str;
 
-    while (1)
-    {
-        char *q;
-        while (1)
-        {
-            if ((*p == '\r') || (*p == '\n'))
-                ++p;
-            else if (p[0] == '\xef' && p[1] == '\xbb' && p[2] == '\xbf')
-                p += 3;         // U+FFFE (BOM)
-            else
-                break;
-        }
-        for (q = p; ((*q != '\0') && (*q != '\r') && (*q != '\n')); ++q)
-        {
-        };
-        if (q == p)
-            break;
-        if (*q != '\0')
-            *(q++) = '\0';
-        retval |= process_line(track, p, request_context);
-        if (*q == '\0')
-            break;
-        p = q;
-    }
-    return retval;
+	while (1)
+	{
+		char *q;
+		while (1)
+		{
+			if ((*p == '\r') || (*p == '\n'))
+				++p;
+			else if (p[0] == '\xef' && p[1] == '\xbb' && p[2] == '\xbf')
+				p += 3;		 // U+FFFE (BOM)
+			else
+				break;
+		}
+		for (q = p; ((*q != '\0') && (*q != '\r') && (*q != '\n')); ++q)
+		{
+		};
+		if (q == p)
+			break;
+		if (*q != '\0')
+			*(q++) = '\0';
+		retval |= process_line(track, p, request_context);
+		if (*q == '\0')
+			break;
+		p = q;
+	}
+	return retval;
 }
 
 /*
@@ -1284,44 +1284,44 @@ static int process_text(ass_track_t *track, char *str, request_context_t* reques
  */
 ass_track_t *parse_memory(char *buf, int len, request_context_t* request_context)
 {
-    ass_track_t *track;
-    int bfailed;
-    // copy the input buffer, as the parsing is destructive.
-    char *pcopy = vod_alloc(request_context->pool, len+1);
-    if (pcopy == NULL)
-    {
-        vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
-            "parse_memory(): vod_alloc failed");
-        return NULL;
-    }
-    vod_memcpy(pcopy, buf, len+1);
+	ass_track_t *track;
+	int bfailed;
+	// copy the input buffer, as the parsing is destructive.
+	char *pcopy = vod_alloc(request_context->pool, len+1);
+	if (pcopy == NULL)
+	{
+		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+			"parse_memory(): vod_alloc failed");
+		return NULL;
+	}
+	vod_memcpy(pcopy, buf, len+1);
 
-    // initializes all fields to zero. If that doesn't suit your need, use another track_init function.
-    track = vod_calloc(request_context->pool, sizeof(ass_track_t));
-    if (!track)
-    {
-        vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
-            "parse_memory(): vod_calloc() failed");
-        vod_free(request_context->pool, pcopy);
-        return NULL;
-    }
+	// initializes all fields to zero. If that doesn't suit your need, use another track_init function.
+	track = vod_calloc(request_context->pool, sizeof(ass_track_t));
+	if (!track)
+	{
+		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+			"parse_memory(): vod_calloc() failed");
+		vod_free(request_context->pool, pcopy);
+		return NULL;
+	}
 
-    // destructive parsing of pcopy
-    bfailed = process_text(track, pcopy, request_context);
-    if (bfailed == 1)
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "parse_memory(): process_text failed, track_type = %d", track->track_type);
+	// destructive parsing of pcopy
+	bfailed = process_text(track, pcopy, request_context);
+	if (bfailed == 1)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"parse_memory(): process_text failed, track_type = %d", track->track_type);
 
-    }
-    vod_free(request_context->pool, pcopy); // not needed anymore either way
+	}
+	vod_free(request_context->pool, pcopy); // not needed anymore either way
 
-    if (track->track_type == TRACK_TYPE_UNKNOWN) {
-        ass_free_track(request_context->pool, track);
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "parse_memory(): track_type unknown");
-        return NULL;
-    }
+	if (track->track_type == TRACK_TYPE_UNKNOWN) {
+		ass_free_track(request_context->pool, track);
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"parse_memory(): track_type unknown");
+		return NULL;
+	}
 
-    return track;
+	return track;
 }

--- a/vod/subtitle/ass_parse.c
+++ b/vod/subtitle/ass_parse.c
@@ -606,16 +606,16 @@ void ass_free_event(ass_track_t *track, int eid)
 {
     ass_event_t *event = track->events + eid;
 
-    free(event->Name);
-    free(event->Effect);
-    free(event->Text);
+    free(event->name);
+    free(event->effect);
+    free(event->text);
 }
 void ass_free_style(ass_track_t *track, int sid)
 {
     ass_style_t *style = track->styles + sid;
 
-    free(style->Name);
-    free(style->FontName);
+    free(style->name);
+    free(style->font_name);
 }
 
 void ass_free_track(vod_pool_t* pool, ass_track_t *track)
@@ -624,8 +624,8 @@ void ass_free_track(vod_pool_t* pool, ass_track_t *track)
 
     free(track->style_format);
     free(track->event_format);
-    free(track->Language);
-    free(track->Title);
+    free(track->language);
+    free(track->title);
     if (track->styles) {
         for (i = 0; i < track->n_styles; ++i)
             ass_free_style(track, i);
@@ -652,30 +652,30 @@ static void set_default_style(ass_style_t *style, bool_t alloc_names)
 {
     if (alloc_names == TRUE)
     {
-        style->Name                 = strdup("Default");
-        style->FontName             = strdup("Arial");
+        style->name                 = strdup("Default");
+        style->font_name             = strdup("Arial");
     }
-    style->FontSize             = 18;
-    style->PrimaryColour        = 0xffffff00;
-    style->SecondaryColour      = 0x00ffff00;
-    style->OutlineColour        = 0x00000000;
-    style->BackColour           = 0x00000080;
-    style->Bold                 = FALSE;
-    style->Italic               = FALSE;
-    style->Underline            = FALSE;
-    style->StrikeOut            = FALSE;
-    style->b_right_to_left_language = FALSE;
-    style->b_output_in_cur_segment  = FALSE;
-    style->ScaleX               = 100.0;
-    style->ScaleY               = 100.0;
-    style->Spacing              = 0.0;
-    style->Angle                = 0.0;
-    style->BorderStyle          = 1;
-    style->Outline              = 2;
-    style->Shadow               = 0;
-    style->Alignment            = 2;
-    style->MarginL = style->MarginR = style->MarginV = 20;
-    style->Encoding             = 0;
+    style->font_size            = 18;
+    style->primary_colour       = 0xffffff00;
+    style->secondary_colour     = 0x00ffff00;
+    style->outline_colour       = 0x00000000;
+    style->back_colour          = 0x00000080;
+    style->bold                 = FALSE;
+    style->italic               = FALSE;
+    style->underline            = FALSE;
+    style->strike_out           = FALSE;
+    style->right_to_left_language = FALSE;
+    style->output_in_cur_segment  = FALSE;
+    style->scale_x              = 100.0;
+    style->scale_y              = 100.0;
+    style->spacing              = 0.0;
+    style->angle                = 0.0;
+    style->border_style         = 1;
+    style->outline              = 2;
+    style->shadow               = 0;
+    style->alignment            = 2;
+    style->margin_l = style->margin_r = style->margin_v = 20;
+    style->encoding             = 0;
 }
 
 static long long string2timecode(char *p)
@@ -710,7 +710,7 @@ int lookup_style(ass_track_t *track, char *name)
     if (ass_strcasecmp(name, "Default") == 0)
         name = "Default";
     for (i = track->n_styles - 1; i >= 0; --i) {
-        if (strcmp(track->styles[i].Name, name) == 0)
+        if (strcmp(track->styles[i].name, name) == 0)
             return i;
     }
     i = track->default_style;
@@ -815,15 +815,15 @@ static int process_event_tail(ass_track_t *track, ass_event_t *event, char *str)
         NEXT(q, tname);
         if (ass_strcasecmp(tname, "Text") == 0) {
             char *last;
-            event->Text = strdup(p);
-            if (*event->Text != 0) {
-                last = event->Text + strlen(event->Text) - 1;
-                if (last >= event->Text && *last == '\r')
+            event->text = strdup(p);
+            if (*event->text != 0) {
+                last = event->text + strlen(event->text) - 1;
+                if (last >= event->text && *last == '\r')
                     *last = 0;
             }
             // need to track the largest end time in all events, since they are not in chronological order
-            if (track->maxDuration < event->End) {
-                track->maxDuration = event->End;
+            if (track->max_duration < event->end) {
+                track->max_duration = event->end;
             }
             free(format);
             return 0;           // "Text" is always the last
@@ -831,15 +831,15 @@ static int process_event_tail(ass_track_t *track, ass_event_t *event, char *str)
         NEXT(p, token);
 
         PARSE_START
-            INTVAL(Layer)
-            STYLEVAL(Style)
-            STRVAL(Name)
-            STRVAL(Effect)
-            INTVAL(MarginL)
-            INTVAL(MarginR)
-            INTVAL(MarginV)
-            TIMEVAL(Start)
-            TIMEVAL(End)
+            INTVAL(layer)
+            STYLEVAL(style)
+            STRVAL(name)
+            STRVAL(effect)
+            INTVAL(margin_l)
+            INTVAL(margin_r)
+            INTVAL(margin_v)
+            TIMEVAL(start)
+            TIMEVAL(end)
         PARSE_END
     }
     free(format);
@@ -868,7 +868,7 @@ int numpad2align(int val)
 }
 
 /**
- * \brief Parse the Style line
+ * \brief Parse the style line
  * \param track track
  * \param str string to parse, zero-terminated
  * Allocates a new style struct.
@@ -925,67 +925,66 @@ static int process_style(ass_track_t *track, char *str, request_context_t* reque
         NEXT(p, token);
 
         PARSE_START
-            STARREDSTRVAL(Name)
-            if (strcmp(target->Name, "Default") == 0)
+            STARREDSTRVAL(name)
+            if (strcmp(target->name, "Default") == 0)
                 track->default_style = sid;
-            STRVAL(FontName)
-            COLORVAL(PrimaryColour)
-            COLORVAL(SecondaryColour)
-            COLORVAL(OutlineColour) // TertiaryColor
-            COLORVAL(BackColour)
+            STRVAL(font_name)
+            COLORVAL(primary_colour)
+            COLORVAL(secondary_colour)
+            COLORVAL(outline_colour) // TertiaryColor
+            COLORVAL(back_colour)
             // SSA uses BackColour for both outline and shadow
             // this will destroy SSA's TertiaryColour, but i'm not going to use it anyway
             if (track->track_type == TRACK_TYPE_SSA)
-                target->OutlineColour = target->BackColour;
-            INTVAL(FontSize)
-            INTVAL(Bold)
-            INTVAL(Italic)
-            INTVAL(Underline)
-            INTVAL(StrikeOut)
-            FPVAL(Spacing)
-            FPVAL(Angle)
-            INTVAL(BorderStyle)
-            INTVAL(Alignment)
+                target->outline_colour = target->back_colour;
+            INTVAL(font_size)
+            INTVAL(bold)
+            INTVAL(italic)
+            INTVAL(underline)
+            INTVAL(strike_out)
+            FPVAL(spacing)
+            FPVAL(angle)
+            INTVAL(border_style)
+            INTVAL(alignment)
             if (track->track_type == TRACK_TYPE_ASS)
             {
-                target->Alignment = numpad2align(target->Alignment);
+                target->alignment = numpad2align(target->alignment);
             }
             // VSFilter compatibility
-            else if (target->Alignment == 8)
-                target->Alignment = 3;
-            else if (target->Alignment == 4)
-                target->Alignment = 11;
-            INTVAL(MarginL)
-            INTVAL(MarginR)
-            INTVAL(MarginV)
-            INTVAL(Encoding)
-            FPVAL(ScaleX)
-            FPVAL(ScaleY)
-            INTVAL(Outline)
-            INTVAL(Shadow)
+            else if (target->alignment == 8)
+                target->alignment = 3;
+            else if (target->alignment == 4)
+                target->alignment = 11;
+            INTVAL(margin_l)
+            INTVAL(margin_r)
+            INTVAL(margin_v)
+            INTVAL(encoding)
+            FPVAL(scale_x)
+            FPVAL(scale_y)
+            INTVAL(outline)
+            INTVAL(shadow)
         PARSE_END
     }
-    style->ScaleX    = FFMAX(style->ScaleX,  0.) / 100.;
-    style->ScaleY    = FFMAX(style->ScaleY,  0.) / 100.;
-    style->Spacing   = FFMAX(style->Spacing, 0.);
-    style->Outline   = FFMAX(style->Outline, 0);
-    style->Shadow    = FFMAX(style->Shadow,  0);
-    style->Bold      = !!style->Bold;
-    style->Italic    = !!style->Italic;
-    style->Underline = !!style->Underline;
-    style->StrikeOut = !!style->StrikeOut;
-    if (!style->Name)
-        style->Name = strdup("Default");
-    if (!style->FontName)
-        style->FontName = strdup("Arial");
+    style->scale_x    = FFMAX(style->scale_x, 0.) / 100.;
+    style->scale_y    = FFMAX(style->scale_y, 0.) / 100.;
+    style->spacing    = FFMAX(style->spacing, 0.);
+    style->angle      = FFMAX(style->spacing, 0.);
+    style->outline    = FFMAX(style->outline, 0);
+    style->shadow     = FFMAX(style->shadow,  0);
+    style->bold       = !!style->bold;
+    style->italic     = !!style->italic;
+    style->underline  = !!style->underline;
+    style->strike_out = !!style->strike_out;
+    if (!style->name)
+        style->name = strdup("Default");
+    if (!style->font_name)
+        style->font_name = strdup("Arial");
 
-    // For now, b_right_to_left_language is TRUE only for Arabic language. In future, it will be enabled for many others.
-    if ( !ass_strncasecmp(style->FontName, "Adobe Arabic", 12) ) {
-        //vod_log_error(VOD_LOG_ERR, request_context->log, 0, "Style font was Adobe Arabic");
-        style->b_right_to_left_language = TRUE;
+    // For now, right_to_left_language is TRUE only for Arabic language. In future, it will be enabled for many others.
+    if ( !ass_strncasecmp(style->font_name, "Adobe Arabic", 12) ) {
+        style->right_to_left_language = TRUE;
     } else {
-        //vod_log_error(VOD_LOG_ERR, request_context->log, 0, "Style font was: %s", style->FontName);
-        style->b_right_to_left_language = track->b_right_to_left_language;
+        style->right_to_left_language = track->right_to_left_language;
     }
     free(format);
     return 0;
@@ -1010,24 +1009,24 @@ static int process_styles_line(ass_track_t *track, char *str, request_context_t*
 static int process_info_line(ass_track_t *track, char *str, request_context_t* request_context)
 {
     if (!strncmp(str, "PlayResX:", 9)) {
-        track->PlayResX = atoi(str + 9);
+        track->play_res_x = atoi(str + 9);
     } else if (!strncmp(str, "PlayResY:", 9)) {
-        track->PlayResY = atoi(str + 9);
+        track->play_res_y = atoi(str + 9);
     } else if (!strncmp(str, "Timer:", 6)) {
-        track->Timer = ass_atof(str + 6);
+        track->timer = ass_atof(str + 6);
     } else if (!strncmp(str, "WrapStyle:", 10)) {
-        track->WrapStyle = atoi(str + 10);
+        track->wrap_style = atoi(str + 10);
     } else if (!strncmp(str, "ScaledBorderAndShadow:", 22)) {
-        track->ScaledBorderAndShadow = parse_bool(str + 22);
+        track->scaled_border_and_shadow = parse_bool(str + 22);
     } else if (!strncmp(str, "Kerning:", 8)) {
-        track->Kerning = parse_bool(str + 8);
+        track->kerning = parse_bool(str + 8);
     } else if (!strncmp(str, "YCbCr Matrix:", 13)) {
         // ignore for now
     } else if (!strncmp(str, "Language:", 9)) { // This field is not part of the ASS/SSA specs
         char *p = str + 9;
         while (*p && ass_isspace(*p)) p++;
-        free(track->Language);
-        track->Language = strndup(p, 2);
+        free(track->language);
+        track->language = strndup(p, 2);
     } else if (!strncmp(str, "Title:", 6)) {
         char *p = str + 6;
         char *strt, *end;
@@ -1037,10 +1036,10 @@ static int process_info_line(ass_track_t *track, char *str, request_context_t* r
         while (*p && !ass_isspace(*p))
             p++;
         end = p;
-        free(track->Title);
+        free(track->title);
         // Title: ﺎﻠﻋﺮﺒﻳﺓ
-        track->Title = strndup(p, FFMAX(14, (size_t)(end-strt)));
-        track->b_right_to_left_language = ((14 == (end-strt)) && (strt[0] == (char)0xD8) && (strt[13] == (char)0xA9));
+        track->title = strndup(p, FFMAX(14, (size_t)(end-strt)));
+        track->right_to_left_language = ((14 == (end-strt)) && (strt[0] == (char)0xD8) && (strt[13] == (char)0xA9));
     }
     return 0;
 }

--- a/vod/subtitle/scc_format.c
+++ b/vod/subtitle/scc_format.c
@@ -33,7 +33,8 @@
 
 //#define ASSUME_STYLE_SUPPORT
 
-static const int utf8_len[80] = {
+static const int utf8_len[80] =
+{
     2,   // Registered
     2,   // Ring / Angestrom
     2,   // Fraction Half
@@ -120,7 +121,8 @@ static const int utf8_len[80] = {
     3    // Box bot right
 };
 
-static const char* utf8_code[80] = {
+static const char* utf8_code[80] =
+{
     "\xc2\xae",     // Registered sign
     "\xc2\xb0",     // Ring / Angestrom
     "\xc2\xbd",     // Fraction Half
@@ -222,17 +224,20 @@ static int convert_event_text(scc_event_t *event, char *textp, request_context_t
 
     for (rowidx = 0; rowidx < 15; rowidx++)
     {
-        if (event->row_used[rowidx] == 1) {
+        if (event->row_used[rowidx] == 1)
+        {
             for (colidx = 0; colidx < SCC_608_SCREEN_WIDTH+1; colidx++)
             {
                 bool_t printable = (event->characters[rowidx][colidx] != 0) ? TRUE : FALSE;
 #ifdef SCC_TEMP_VERBOSITY
                 vod_log_error(VOD_LOG_ERR, request_context->log, 0,
                 "convert_event_text(): rowidx=%d, colidx=%d, char=%c, iub=%d, printable=%d",
-                rowidx, colidx, event->characters[rowidx][colidx], event->iub[rowidx][colidx], printable==TRUE);
+                rowidx, colidx, event->characters[rowidx][colidx], event->iub[rowidx][colidx], printable);
 #endif
-                if (printable == TRUE) {
-                    if (iub_flags != event->iub[rowidx][colidx]) {
+                if (printable)
+                {
+                    if (iub_flags != event->iub[rowidx][colidx])
+                    {
                         // close b u i in order (if open)
                         if (iub_flags & 4)
                         {
@@ -392,40 +397,28 @@ static void scc_clean_known_mem(request_context_t* request_context, scc_track_t 
 
 #ifdef ASSUME_STYLE_SUPPORT
 static char* output_one_style(char* p)
-{//TODO: using style index, output name an modify the rest of this function
+{//TODO: using style index, output name and modify the rest of this function
         int len;
 
-        vod_memcpy(p, FIXED_WEBVTT_STYLE_START_STR, FIXED_WEBVTT_STYLE_START_WIDTH);           p+=FIXED_WEBVTT_STYLE_START_WIDTH;
-        len = 28; vod_memcpy(p, "RAFIK INSERT STYLE NAME HERE", len);                          p+=len;
-        vod_memcpy(p, FIXED_WEBVTT_STYLE_END_STR, FIXED_WEBVTT_STYLE_END_WIDTH);               p+=FIXED_WEBVTT_STYLE_END_WIDTH;
-        vod_memcpy(p, FIXED_WEBVTT_BRACES_START_STR, FIXED_WEBVTT_BRACES_START_WIDTH);         p+=FIXED_WEBVTT_BRACES_START_WIDTH;
+        vod_memcpy(p, FIXED_WEBVTT_STYLE_START_STR, FIXED_WEBVTT_STYLE_START_WIDTH);           p += FIXED_WEBVTT_STYLE_START_WIDTH;
+        len = 28; vod_memcpy(p, "RAFIK INSERT STYLE NAME HERE", len);                          p += len;
+        vod_memcpy(p, FIXED_WEBVTT_STYLE_END_STR, FIXED_WEBVTT_STYLE_END_WIDTH);               p += FIXED_WEBVTT_STYLE_END_WIDTH;
+        vod_memcpy(p, FIXED_WEBVTT_BRACES_START_STR, FIXED_WEBVTT_BRACES_START_WIDTH);         p += FIXED_WEBVTT_BRACES_START_WIDTH;
 
-        len = 8; vod_memcpy(p, "color: #", len);                                               p+=len;
-        vod_sprintf((u_char*)p, "%08uxD;\r\n", 0xaabbccdd);                                      p+=11;
+        len = 8; vod_memcpy(p, "color: #", len);                                               p += len;
+        vod_sprintf((u_char*)p, "%08uxD;\r\n", 0xaabbccdd);                                    p += 11;
 
 
-        len = 14; vod_memcpy(p, "font-family: \"", len);                                       p+=len;
-        len = 27; vod_memcpy(p, "RAFIK INSERT FONT NAME HERE", len);                           p+=len;
-        len = 16; vod_memcpy(p, "\", sans-serif;\r\n", len);                                   p+=len;
-        vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", 24);                                p+=19;
+        len = 14; vod_memcpy(p, "font-family: \"", len);                                       p += len;
+        len = 27; vod_memcpy(p, "RAFIK INSERT FONT NAME HERE", len);                           p += len;
+        len = 16; vod_memcpy(p, "\", sans-serif;\r\n", len);                                   p += len;
+        vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", 24);                                p += 19;
 
-        {
-            // webkit is not supported by all players, stick to adding outline using text-shadow
-            len = 13; vod_memcpy(p, "text-shadow: ", len);                                     p+=len;
-            // add outline in 4 directions with the outline color
-            vod_sprintf((u_char*)p, "#%08uxD -%01uDpx 0px, #%08uxD 0px %01uDpx, #%08uxD 0px -%01uDpx, #%08uxD %01uDpx 0px, #%08uxD %01uDpx %01uDpx 0px;\r\n",
-                         0xaabbccdd, 2,
-                         0xaabbccdd, 2,
-                         0xaabbccdd, 2,
-                         0xaabbccdd, 2,
-                         0x00bbcc00, 2, 2);         p+=102;
+        len = 19; vod_memcpy(p, "background-color: #", len);                                   p += len;
+        vod_sprintf((u_char*)p, "%08uxD;\r\n", 0xaabbccdd);                                    p += 11;
 
-        } else {
-            len = 19; vod_memcpy(p, "background-color: #", len);                               p+=len;
-            vod_sprintf((u_char*)p, "%08uxD;\r\n", 0xaabbccdd);                                p+=11;
-        }
-        vod_memcpy(p, FIXED_WEBVTT_BRACES_END_STR, FIXED_WEBVTT_BRACES_END_WIDTH);             p+=FIXED_WEBVTT_BRACES_END_WIDTH;
-        len = 2; vod_memcpy(p, "\r\n", len);                                                   p+=len;
+        vod_memcpy(p, FIXED_WEBVTT_BRACES_END_STR, FIXED_WEBVTT_BRACES_END_WIDTH);             p += FIXED_WEBVTT_BRACES_END_WIDTH;
+        len = 2; vod_memcpy(p, "\r\n", len);                                                   p += len;
 
         return p;
 }
@@ -793,16 +786,18 @@ scc_parse_frames(
             vtt_track->first_frame_index, vtt_track->first_frame_time_offset);
 #endif
         // Cues are named "c<iteration_number_in_7_digits>" starting from c0000000
-        vod_sprintf((u_char*)p, FIXED_WEBVTT_CUE_FORMAT_STR, evntcounter);      p+=FIXED_WEBVTT_CUE_NAME_WIDTH;
-        len = 2; vod_memcpy(p, "\r\n", len);                                    p+=len;
+        vod_sprintf((u_char*)p, FIXED_WEBVTT_CUE_FORMAT_STR, evntcounter);      p += FIXED_WEBVTT_CUE_NAME_WIDTH;
+        len = 2; vod_memcpy(p, "\r\n", len);                                    p += len;
         // timestamps will be inserted here, we now insert positioning and alignment changes
         {
             unsigned char align;
-            int kk, ll, pos, sizeH=0, line=14;
-            int max_num_of_chars_per_line = 0,                    lineidx_max_num_of_chars=line;
-            int min_num_of_chars_per_line = SCC_608_SCREEN_WIDTH, lineidx_min_num_of_chars=line;
+            int kk, ll, pos, sizeH = 0, line = 14;
+            int max_num_of_chars_per_line = 0;
+            int lineidx_max_num_of_chars  = line;
+            int min_num_of_chars_per_line = SCC_608_SCREEN_WIDTH;
+            int lineidx_min_num_of_chars  = line;
             int slots_before_min_chars = 0, slots_after_min_chars = 0, slots_before_max_chars = 0, slots_after_max_chars = 0;
-            for (kk=0; kk<15; kk++)
+            for (kk = 0; kk < 15; kk++)
             {
                 if (cur_event->row_used[kk] == 1)
                 {
@@ -811,12 +806,12 @@ scc_parse_frames(
                 }
             }
 
-            for (kk=line; kk<15; kk++)
+            for (kk = line; kk < 15; kk++)
             {
                 if (cur_event->row_used[kk] == 1)
                 {
                     int num_of_chars = 32;
-                    for (ll=0; ll<SCC_608_SCREEN_WIDTH; ll++)
+                    for (ll = 0; ll < SCC_608_SCREEN_WIDTH; ll++)
                     {
                         if (cur_event->characters[kk][ll] == SCC_UNUSED_CHAR)
                             num_of_chars--;
@@ -833,14 +828,14 @@ scc_parse_frames(
                     }
                 }
             }
-            for (ll=0; ll<(SCC_608_SCREEN_WIDTH-1); ll++)
+            for (ll = 0; ll < (SCC_608_SCREEN_WIDTH-1); ll++)
             {
                 if (cur_event->characters[lineidx_min_num_of_chars][ll] == SCC_UNUSED_CHAR)
                     slots_before_min_chars++;
                 else
                     break;
             }
-            for (ll=0; ll<(SCC_608_SCREEN_WIDTH-1); ll++)
+            for (ll = 0; ll < (SCC_608_SCREEN_WIDTH-1); ll++)
             {
                 if (cur_event->characters[lineidx_max_num_of_chars][ll] == SCC_UNUSED_CHAR)
                     slots_before_max_chars++;
@@ -873,37 +868,40 @@ scc_parse_frames(
                 pos = 98 - (3 * slots_after_max_chars);
             }
 
-            len = 10; vod_memcpy(p, " position:", len);                     p+=len;
-            vod_sprintf((u_char*)p, "%03uD", pos);                          p+=3;
-            len =  7; vod_memcpy(p, "% size:", len);                        p+=len;
-            vod_sprintf((u_char*)p, "%03uD", sizeH);                        p+=3;
-            len =  7; vod_memcpy(p, "% line:", len);                        p+=len;
-            vod_sprintf((u_char*)p, "%02uD", line);                         p+=2;
+            len = 10; vod_memcpy(p, " position:", len);                     p += len;
+            vod_sprintf((u_char*)p, "%03uD", pos);                          p += 3;
+            len =  7; vod_memcpy(p, "% size:", len);                        p += len;
+            vod_sprintf((u_char*)p, "%03uD", sizeH);                        p += 3;
+            len =  7; vod_memcpy(p, "% line:", len);                        p += len;
+            vod_sprintf((u_char*)p, "%02uD", line);                         p += 2;
 
 
-            len =  7; vod_memcpy(p, " align:", len);                            p+=len;
-            if (align == SCC_ALIGN_CENTER) {
-                len =  6; vod_memcpy(p, "center", len);                         p+=len;
+            len =  7; vod_memcpy(p, " align:", len);                        p += len;
+            if (align == SCC_ALIGN_CENTER)
+            {
+                len =  6; vod_memcpy(p, "center", len);                     p += len;
             }
-            else if (align == SCC_ALIGN_LEFT) {
-                len =  4; vod_memcpy(p, "left", len);                           p+=len;
+            else if (align == SCC_ALIGN_LEFT)
+            {
+                len =  4; vod_memcpy(p, "left", len);                       p += len;
             }
-            else {
-                len =  5; vod_memcpy(p, "right", len);                          p+=len;
+            else
+            {
+                len =  5; vod_memcpy(p, "right", len);                      p += len;
             }
-            len = 2; vod_memcpy(p, "\r\n", len);                                p+=len;
+            len = 2; vod_memcpy(p, "\r\n", len);                            p += len;
         }
 #ifdef ASSUME_STYLE_SUPPORT
-        vod_memcpy(p, FIXED_WEBVTT_VOICE_START_STR, FIXED_WEBVTT_VOICE_START_WIDTH);       p+=FIXED_WEBVTT_VOICE_START_WIDTH;
-        len = 28; vod_sprintf((u_char*)p, "RAFIK INSERT STYLE NAME HERE", len);            p+=len;
-        vod_memcpy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);           p+=FIXED_WEBVTT_VOICE_END_WIDTH;
+        vod_memcpy(p, FIXED_WEBVTT_VOICE_START_STR, FIXED_WEBVTT_VOICE_START_WIDTH);       p += FIXED_WEBVTT_VOICE_START_WIDTH;
+        len = 28; vod_sprintf((u_char*)p, "RAFIK INSERT STYLE NAME HERE", len);            p += len;
+        vod_memcpy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);           p += FIXED_WEBVTT_VOICE_END_WIDTH;
 #endif //ASSUME_STYLE_SUPPORT
 
-        vod_memcpy(p, event_textp, event_len);  p+=event_len;
+        vod_memcpy(p, event_textp, event_len);                              p += event_len;
 
-        len = 2; vod_memcpy(p, "\r\n", len);                                    p+=len;
+        len = 2; vod_memcpy(p, "\r\n", len);                                p += len;
         // we still need an empty line after each event/cue
-        len = 2; vod_memcpy(p, "\r\n", len);                                    p+=len;
+        len = 2; vod_memcpy(p, "\r\n", len);                                p += len;
 
         // Note: mapping of cue into input_frame_t:
         // - offset = pointer to buffer containing: cue id, cue settings list, cue payload
@@ -940,7 +938,7 @@ scc_parse_frames(
     /*for (stylecounter = 0; (stylecounter < SCC_NUM_OF_STYLES_INSERTED); stylecounter++)
     {
         scc_style_t* cur_style = scc_track->styles + stylecounter;
-        if (cur_style->b_output_in_cur_segment == TRUE)
+        if (cur_style->b_output_in_cur_segment)
             p = output_one_style(p);
 
     }*/

--- a/vod/subtitle/scc_format.c
+++ b/vod/subtitle/scc_format.c
@@ -26,481 +26,481 @@
 #define FIXED_WEBVTT_ESCAPE_FOR_RTL_STR "&lrm;"
 #define FIXED_WEBVTT_ESCAPE_FOR_RTL_WIDTH 5
 
-#define MAX_STR_SIZE_EVNT_CHUNK         1024
+#define MAX_STR_SIZE_EVNT_CHUNK		 1024
 #define MAX_STR_SIZE_ALL_WEBVTT_STYLES 20480
 
-#define NUM_OF_INLINE_TAGS_SUPPORTED 3     //iub
+#define NUM_OF_INLINE_TAGS_SUPPORTED 3	 //iub
 
 //#define ASSUME_STYLE_SUPPORT
 
 static const int utf8_len[80] =
 {
-    2,   // Registered
-    2,   // Ring / Angestrom
-    2,   // Fraction Half
-    2,   // Latin Starting Question Mark
-    2,   // Trade Mark
-    1,   // Cent Sign ??
-    1,   // Pound Sign
-    3,   // Eighth Music Note
-    2,   // Letter a with grave
-    1,   // Space
-    2,   // Letter e with grave
-    2,   // Letter a with circumflex
-    2,   // Letter e with circumflex
-    2,   // Letter i with circumflex
-    2,   // Letter o with circumflex
-    2,   // Letter u with circumflex
+	2,   // Registered
+	2,   // Ring / Angestrom
+	2,   // Fraction Half
+	2,   // Latin Starting Question Mark
+	2,   // Trade Mark
+	1,   // Cent Sign ??
+	1,   // Pound Sign
+	3,   // Eighth Music Note
+	2,   // Letter a with grave
+	1,   // Space
+	2,   // Letter e with grave
+	2,   // Letter a with circumflex
+	2,   // Letter e with circumflex
+	2,   // Letter i with circumflex
+	2,   // Letter o with circumflex
+	2,   // Letter u with circumflex
 
-    2,   // Letter A with acute
-    2,   // Letter E with acute
-    2,   // Letter O with acute
-    2,   // Letter U with acute
-    2,   // Letter U with diaeresis
-    2,   // Letter u with diaeresis
-    2,   // Inverted apostrophe
-    2,   // Inverted exclamation mark
-    2,   // Astresk
-    2,   // Apostrophe
-    3,   // Horizontal bar
-    2,   // Copyright sign
-    3,   // Service mark
-    3,   // Bullet
-    3,   // Left double quotation
-    3,   // Right double quotation
+	2,   // Letter A with acute
+	2,   // Letter E with acute
+	2,   // Letter O with acute
+	2,   // Letter U with acute
+	2,   // Letter U with diaeresis
+	2,   // Letter u with diaeresis
+	2,   // Inverted apostrophe
+	2,   // Inverted exclamation mark
+	2,   // Astresk
+	2,   // Apostrophe
+	3,   // Horizontal bar
+	2,   // Copyright sign
+	3,   // Service mark
+	3,   // Bullet
+	3,   // Left double quotation
+	3,   // Right double quotation
 
-    2,   // Letter A with grave
-    2,   // Letter A with circumflex
-    2,   // Letter C with cedilla
-    2,   // Letter E with grave
-    2,   // Letter E with circumflex
-    2,   // Letter E with diaeresis
-    2,   // Letter e with diaeresis
-    2,   // Letter I with circumflex
-    2,   // Letter I with diaeresis
-    2,   // Letter i with diaeresis
-    2,   // Letter o with circumflex
-    2,   // Letter U with grave
-    2,   // Letter u with grave
-    2,   // Letter U with circumflex
-    3,   // Much less than
-    3,   // Much greater than
+	2,   // Letter A with grave
+	2,   // Letter A with circumflex
+	2,   // Letter C with cedilla
+	2,   // Letter E with grave
+	2,   // Letter E with circumflex
+	2,   // Letter E with diaeresis
+	2,   // Letter e with diaeresis
+	2,   // Letter I with circumflex
+	2,   // Letter I with diaeresis
+	2,   // Letter i with diaeresis
+	2,   // Letter o with circumflex
+	2,   // Letter U with grave
+	2,   // Letter u with grave
+	2,   // Letter U with circumflex
+	3,   // Much less than
+	3,   // Much greater than
 
-    2,   // Letter A with tilde
-    2,   // Letter a with tilde
-    2,   // Letter I with acute
-    2,   // Letter I with grave
-    2,   // Letter i with grave
-    2,   // Letter O with grave
-    2,   // Letter o with grave
-    2,   // Letter O with tilde
-    2,   // Letter o with tilde
-    1,   // Left curly bracket
-    1,   // Right curly bracket
-    1,   // Backslash
-    1,   // Circumflex accent
-    1,   // Low line (underscore)
-    2,   // Broken bar
-    1,   // Tilde
+	2,   // Letter A with tilde
+	2,   // Letter a with tilde
+	2,   // Letter I with acute
+	2,   // Letter I with grave
+	2,   // Letter i with grave
+	2,   // Letter O with grave
+	2,   // Letter o with grave
+	2,   // Letter O with tilde
+	2,   // Letter o with tilde
+	1,   // Left curly bracket
+	1,   // Right curly bracket
+	1,   // Backslash
+	1,   // Circumflex accent
+	1,   // Low line (underscore)
+	2,   // Broken bar
+	1,   // Tilde
 
-    2,   // Letter A with diaeresis
-    2,   // Letter a with diaeresis
-    2,   // Letter O with diaeresis
-    2,   // Letter o with diaeresis
-    2,   // Small letter sharp s
-    2,   // Yen sign
-    2,   // Currency sign
-    1,   // Vertical line
-    2,   // Letter A with ring above
-    2,   // Letter a with ring above
-    2,   // Letter O with a stroke
-    2,   // Letter o with a stroke
-    3,   // Box top left
-    3,   // Box top right
-    3,   // Box bot left
-    3    // Box bot right
+	2,   // Letter A with diaeresis
+	2,   // Letter a with diaeresis
+	2,   // Letter O with diaeresis
+	2,   // Letter o with diaeresis
+	2,   // Small letter sharp s
+	2,   // Yen sign
+	2,   // Currency sign
+	1,   // Vertical line
+	2,   // Letter A with ring above
+	2,   // Letter a with ring above
+	2,   // Letter O with a stroke
+	2,   // Letter o with a stroke
+	3,   // Box top left
+	3,   // Box top right
+	3,   // Box bot left
+	3	// Box bot right
 };
 
 static const char* utf8_code[80] =
 {
-    "\xc2\xae",     // Registered sign
-    "\xc2\xb0",     // Ring / Angestrom
-    "\xc2\xbd",     // Fraction Half
-    "\xc2\xbf",     // Latin Starting Question Mark
-    "\x21\x22",     // Trade Mark
-    "\xa2",         // Cent Sign ??
-    "\xa3",         // Pound Sign
-    "\xe2\x99\xaa", // Eighth Music Note
-    "\xc3\xa0",     // Letter a with grave
-    " ",            // Space ??
-    "\xc3\xa8",     // Letter e with grave
-    "\xc3\xa2",     // Letter a with circumflex
-    "\xc3\xaa",     // Letter e with circumflex
-    "\xc3\xae",     // Letter i with circumflex
-    "\xc3\xb4",     // Letter o with circumflex
-    "\xc3\xbb",     // Letter u with circumflex
+	"\xc2\xae",	 // Registered sign
+	"\xc2\xb0",	 // Ring / Angestrom
+	"\xc2\xbd",	 // Fraction Half
+	"\xc2\xbf",	 // Latin Starting Question Mark
+	"\x21\x22",	 // Trade Mark
+	"\xa2",		 // Cent Sign ??
+	"\xa3",		 // Pound Sign
+	"\xe2\x99\xaa", // Eighth Music Note
+	"\xc3\xa0",	 // Letter a with grave
+	" ",			// Space ??
+	"\xc3\xa8",	 // Letter e with grave
+	"\xc3\xa2",	 // Letter a with circumflex
+	"\xc3\xaa",	 // Letter e with circumflex
+	"\xc3\xae",	 // Letter i with circumflex
+	"\xc3\xb4",	 // Letter o with circumflex
+	"\xc3\xbb",	 // Letter u with circumflex
 
-    "\xc3\x81",     // Letter A with acute
-    "\xc3\x89",     // Letter E with acute
-    "\xc3\x93",     // Letter O with acute
-    "\xc3\x9a",     // Letter U with acute
-    "\xc3\x9c",     // Letter U with diaeresis
-    "\xc3\xbc",     // Letter u with diaeresis
-    "\xca\xbb",     // Inverted apostrophe
-    "\xc2\xa1",     // Inverted exclamation mark
-    "\x2a",         // Asterisk
-    "\xc3\xbc",     // Apostrophe
-    "\xe2\x80\x95", // Horizontal bar
-    "\xc2\xa9",     // Copyright sign
-    "\xe2\x84\xa0", // Service mark
-    "\xe2\x80\xa2", // Bullet
-    "\xe2\x80\x9c", // Left double quotation
-    "\xe2\x80\x9d", // Right double quotation
+	"\xc3\x81",	 // Letter A with acute
+	"\xc3\x89",	 // Letter E with acute
+	"\xc3\x93",	 // Letter O with acute
+	"\xc3\x9a",	 // Letter U with acute
+	"\xc3\x9c",	 // Letter U with diaeresis
+	"\xc3\xbc",	 // Letter u with diaeresis
+	"\xca\xbb",	 // Inverted apostrophe
+	"\xc2\xa1",	 // Inverted exclamation mark
+	"\x2a",		 // Asterisk
+	"\xc3\xbc",	 // Apostrophe
+	"\xe2\x80\x95", // Horizontal bar
+	"\xc2\xa9",	 // Copyright sign
+	"\xe2\x84\xa0", // Service mark
+	"\xe2\x80\xa2", // Bullet
+	"\xe2\x80\x9c", // Left double quotation
+	"\xe2\x80\x9d", // Right double quotation
 
-    "\xc3\x80",     // Letter A with grave
-    "\xc3\x82",     // Letter A with circumflex
-    "\xc3\x87",     // Letter C with cedilla
-    "\xc3\x88",     // Letter E with grave
-    "\xc3\x8a",     // Letter E with circumflex
-    "\xc3\x8b",     // Letter E with diaeresis
-    "\xc3\xab",     // Letter e with diaeresis
-    "\xc3\x8e",     // Letter I with circumflex
-    "\xc3\x8f",     // Letter I with diaeresis
-    "\xc3\xaf",     // Letter i with diaeresis
-    "\xc3\xb4",     // Letter o with circumflex
-    "\xc3\x99",     // Letter U with grave
-    "\xc3\xb9",     // Letter u with grave
-    "\xc3\x9b",     // Letter U with circumflex
-    "\xe2\x89\xaa", // Much less than
-    "\xe2\x89\xab", // Much greater than
+	"\xc3\x80",	 // Letter A with grave
+	"\xc3\x82",	 // Letter A with circumflex
+	"\xc3\x87",	 // Letter C with cedilla
+	"\xc3\x88",	 // Letter E with grave
+	"\xc3\x8a",	 // Letter E with circumflex
+	"\xc3\x8b",	 // Letter E with diaeresis
+	"\xc3\xab",	 // Letter e with diaeresis
+	"\xc3\x8e",	 // Letter I with circumflex
+	"\xc3\x8f",	 // Letter I with diaeresis
+	"\xc3\xaf",	 // Letter i with diaeresis
+	"\xc3\xb4",	 // Letter o with circumflex
+	"\xc3\x99",	 // Letter U with grave
+	"\xc3\xb9",	 // Letter u with grave
+	"\xc3\x9b",	 // Letter U with circumflex
+	"\xe2\x89\xaa", // Much less than
+	"\xe2\x89\xab", // Much greater than
 
-    "\xc3\x83",     // Letter A with tilde
-    "\xc3\xa3",     // Letter a with tilde
-    "\xc3\x8d",     // Letter I with grave
-    "\xc3\x8c",     // Letter I with acute
-    "\xc3\xac",     // Letter i with grave
-    "\xc3\x92",     // Letter O with grave
-    "\xc3\xb2",     // Letter o with grave
-    "\xc3\x95",     // Letter O with tilde
-    "\xc3\xb5",     // Letter o with tilde
-    "\x7b",         // Left curly bracket
-    "\x7d",         // Right curly bracket
-    "\x5c",         // Backslash
-    "\x5e",         // Circumflex accent
-    "\x5f",         // Low line (underscore)
-    "\xc2\xa6",     // Broken bar
-    "\x7e",         // Tilde
+	"\xc3\x83",	 // Letter A with tilde
+	"\xc3\xa3",	 // Letter a with tilde
+	"\xc3\x8d",	 // Letter I with grave
+	"\xc3\x8c",	 // Letter I with acute
+	"\xc3\xac",	 // Letter i with grave
+	"\xc3\x92",	 // Letter O with grave
+	"\xc3\xb2",	 // Letter o with grave
+	"\xc3\x95",	 // Letter O with tilde
+	"\xc3\xb5",	 // Letter o with tilde
+	"\x7b",		 // Left curly bracket
+	"\x7d",		 // Right curly bracket
+	"\x5c",		 // Backslash
+	"\x5e",		 // Circumflex accent
+	"\x5f",		 // Low line (underscore)
+	"\xc2\xa6",	 // Broken bar
+	"\x7e",		 // Tilde
 
-    "\xc3\x84",     // Letter A with diaeresis
-    "\xc3\xa4",     // Letter a with diaeresis
-    "\xc3\x96",     // Letter O with diaeresis
-    "\xc3\xb6",     // Letter o with diaeresis
-    "\xc3\x9f",     // Small letter sharp s
-    "\xc2\xa5",     // Yen sign
-    "\xc2\xa4",     // Currency sign
-    "\x7c",         // Vertical line
-    "\xc3\x85",     // Letter A with ring above
-    "\xc3\xa5",     // Letter a with ring above
-    "\xc3\x98",     // Letter O with a stroke
-    "\xc3\xb8",     // Letter o with a stroke
-    "\xe2\x94\x8f", // Box top left
-    "\xe2\x94\x93", // Box top right
-    "\xe2\x94\x97", // Box bot left
-    "\xe2\x94\x9b"  // Box bot right
+	"\xc3\x84",	 // Letter A with diaeresis
+	"\xc3\xa4",	 // Letter a with diaeresis
+	"\xc3\x96",	 // Letter O with diaeresis
+	"\xc3\xb6",	 // Letter o with diaeresis
+	"\xc3\x9f",	 // Small letter sharp s
+	"\xc2\xa5",	 // Yen sign
+	"\xc2\xa4",	 // Currency sign
+	"\x7c",		 // Vertical line
+	"\xc3\x85",	 // Letter A with ring above
+	"\xc3\xa5",	 // Letter a with ring above
+	"\xc3\x98",	 // Letter O with a stroke
+	"\xc3\xb8",	 // Letter o with a stroke
+	"\xe2\x94\x8f", // Box top left
+	"\xe2\x94\x93", // Box top right
+	"\xe2\x94\x97", // Box bot left
+	"\xe2\x94\x9b"  // Box bot right
 };
 
 static void scc_swap_events(scc_event_t* nxt, scc_event_t* cur)
 {
-    scc_event_t tmp;
-    vod_memcpy(&tmp,  nxt, sizeof(scc_event_t));
-    vod_memcpy( nxt,  cur, sizeof(scc_event_t));
-    vod_memcpy( cur, &tmp, sizeof(scc_event_t));
+	scc_event_t tmp;
+	vod_memcpy(&tmp,  nxt, sizeof(scc_event_t));
+	vod_memcpy( nxt,  cur, sizeof(scc_event_t));
+	vod_memcpy( cur, &tmp, sizeof(scc_event_t));
 }
 
 static int convert_event_text(scc_event_t *event, char *textp, request_context_t* request_context)
 {
-    int colidx, rowidx, dstidx = 0;
-    unsigned char iub_flags = 0; // non-italic, non-underlined, non-bold/flash font
+	int colidx, rowidx, dstidx = 0;
+	unsigned char iub_flags = 0; // non-italic, non-underlined, non-bold/flash font
 
-    for (rowidx = 0; rowidx < 15; rowidx++)
-    {
-        if (event->row_used[rowidx] == 1)
-        {
-            for (colidx = 0; colidx < SCC_608_SCREEN_WIDTH+1; colidx++)
-            {
-                bool_t printable = (event->characters[rowidx][colidx] != 0) ? TRUE : FALSE;
+	for (rowidx = 0; rowidx < 15; rowidx++)
+	{
+		if (event->row_used[rowidx] == 1)
+		{
+			for (colidx = 0; colidx < SCC_608_SCREEN_WIDTH+1; colidx++)
+			{
+				bool_t printable = (event->characters[rowidx][colidx] != 0) ? TRUE : FALSE;
 #ifdef SCC_TEMP_VERBOSITY
-                vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-                "convert_event_text(): rowidx=%d, colidx=%d, char=%c, iub=%d, printable=%d",
-                rowidx, colidx, event->characters[rowidx][colidx], event->iub[rowidx][colidx], printable);
+				vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"convert_event_text(): rowidx=%d, colidx=%d, char=%c, iub=%d, printable=%d",
+				rowidx, colidx, event->characters[rowidx][colidx], event->iub[rowidx][colidx], printable);
 #endif
-                if (printable)
-                {
-                    if (iub_flags != event->iub[rowidx][colidx])
-                    {
-                        // close b u i in order (if open)
-                        if (iub_flags & 4)
-                        {
-                            vod_memcpy(textp + dstidx, "</b>", 4); dstidx += 4;
-                        }
-                        if (iub_flags & 2)
-                        {
-                            vod_memcpy(textp + dstidx, "</u>", 4); dstidx += 4;
-                        }
-                        if (iub_flags & 1)
-                        {
-                            vod_memcpy(textp + dstidx, "</i>", 4); dstidx += 4;
-                        }
-                        // set the running flags
-                        iub_flags = event->iub[rowidx][colidx];
+				if (printable)
+				{
+					if (iub_flags != event->iub[rowidx][colidx])
+					{
+						// close b u i in order (if open)
+						if (iub_flags & 4)
+						{
+							vod_memcpy(textp + dstidx, "</b>", 4); dstidx += 4;
+						}
+						if (iub_flags & 2)
+						{
+							vod_memcpy(textp + dstidx, "</u>", 4); dstidx += 4;
+						}
+						if (iub_flags & 1)
+						{
+							vod_memcpy(textp + dstidx, "</i>", 4); dstidx += 4;
+						}
+						// set the running flags
+						iub_flags = event->iub[rowidx][colidx];
 
-                        // open i u b in order (if open)
-                        if (iub_flags & 1)
-                        {
-                            vod_memcpy(textp+ dstidx, "<i>", 3); dstidx += 3;
-                        }
-                        if (iub_flags & 2)
-                        {
-                            vod_memcpy(textp+ dstidx, "<u>", 3); dstidx += 3;
-                        }
-                        if (iub_flags & 4)
-                        {
-                            vod_memcpy(textp+ dstidx, "<b>", 3); dstidx += 3;
-                        }
-                    }
+						// open i u b in order (if open)
+						if (iub_flags & 1)
+						{
+							vod_memcpy(textp+ dstidx, "<i>", 3); dstidx += 3;
+						}
+						if (iub_flags & 2)
+						{
+							vod_memcpy(textp+ dstidx, "<u>", 3); dstidx += 3;
+						}
+						if (iub_flags & 4)
+						{
+							vod_memcpy(textp+ dstidx, "<b>", 3); dstidx += 3;
+						}
+					}
 
-                    if (event->characters[rowidx][colidx] >= 0x80 && event->characters[rowidx][colidx] <= 0xcf)
-                    {
-                        // special and extended characters
-                        int utf8_idx = event->characters[rowidx][colidx] - 0x80;
-                        vod_memcpy(textp+dstidx, utf8_code[utf8_idx], utf8_len[utf8_idx]);
-                        dstidx      += utf8_len[utf8_idx];
-                        continue;
-                    }
-                    else if (colidx == SCC_608_SCREEN_WIDTH && event->characters[rowidx][colidx] == '\n')
-                    {
-                        textp[dstidx++] = '\r';
-                    }
-                    else if (event->characters[rowidx][colidx] == '<')
-                    {   // Less than is unique in WebVTT
-                        vod_memcpy(textp+dstidx, "&lt;", 4);
-                        dstidx += 4;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '>')
-                    {   // Greater than is unique in WebVTT
-                        vod_memcpy(textp+dstidx, "&gt;", 4);
-                        dstidx += 4;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '&')
-                    {   // Ampersand is unique in WebVTT
-                        vod_memcpy(textp+dstidx, "&amp;", 5);
-                        dstidx += 5;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '\x2a')
-                    {   // Letter a with acute
-                        vod_memcpy(textp+dstidx, "\xc3\xa1", 2);
-                        dstidx += 2;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '\x5c')
-                    {   // Letter e with acute
-                        vod_memcpy(textp+dstidx, "\xc3\xa9", 2);
-                        dstidx += 2;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '\x5e')
-                    {   // Letter i with acute
-                        vod_memcpy(textp+dstidx, "\xc3\xad", 2);
-                        dstidx += 2;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '\x5f')
-                    {   // Letter o with acute
-                        vod_memcpy(textp+dstidx, "\xc3\xb3", 2);
-                        dstidx += 2;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '\x7b')
-                    {   // Letter c withh cedilla
-                        vod_memcpy(textp+dstidx, "\xc3\xa7", 2);
-                        dstidx += 2;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '\x7c')
-                    {   // Division sign
-                        vod_memcpy(textp+dstidx, "\xc3\xb7", 2);
-                        dstidx += 2;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '\x7d')
-                    {   // Letter N with tilde
-                        vod_memcpy(textp+dstidx, "\xc3\x91", 2);
-                        dstidx += 2;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '\x7e')
-                    {   // Letter n with tilde
-                        vod_memcpy(textp+dstidx, "\xc3\xb1", 2);
-                        dstidx += 2;
-                        continue;
-                    }
-                    else if (event->characters[rowidx][colidx] == '\x7f')
-                    {   // Cursor block full
-                        vod_memcpy(textp+dstidx, "\xe2\x96\x88", 3);
-                        dstidx += 3;
-                        continue;
-                    }
+					if (event->characters[rowidx][colidx] >= 0x80 && event->characters[rowidx][colidx] <= 0xcf)
+					{
+						// special and extended characters
+						int utf8_idx = event->characters[rowidx][colidx] - 0x80;
+						vod_memcpy(textp+dstidx, utf8_code[utf8_idx], utf8_len[utf8_idx]);
+						dstidx	  += utf8_len[utf8_idx];
+						continue;
+					}
+					else if (colidx == SCC_608_SCREEN_WIDTH && event->characters[rowidx][colidx] == '\n')
+					{
+						textp[dstidx++] = '\r';
+					}
+					else if (event->characters[rowidx][colidx] == '<')
+					{   // Less than is unique in WebVTT
+						vod_memcpy(textp+dstidx, "&lt;", 4);
+						dstidx += 4;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '>')
+					{   // Greater than is unique in WebVTT
+						vod_memcpy(textp+dstidx, "&gt;", 4);
+						dstidx += 4;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '&')
+					{   // Ampersand is unique in WebVTT
+						vod_memcpy(textp+dstidx, "&amp;", 5);
+						dstidx += 5;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '\x2a')
+					{   // Letter a with acute
+						vod_memcpy(textp+dstidx, "\xc3\xa1", 2);
+						dstidx += 2;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '\x5c')
+					{   // Letter e with acute
+						vod_memcpy(textp+dstidx, "\xc3\xa9", 2);
+						dstidx += 2;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '\x5e')
+					{   // Letter i with acute
+						vod_memcpy(textp+dstidx, "\xc3\xad", 2);
+						dstidx += 2;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '\x5f')
+					{   // Letter o with acute
+						vod_memcpy(textp+dstidx, "\xc3\xb3", 2);
+						dstidx += 2;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '\x7b')
+					{   // Letter c withh cedilla
+						vod_memcpy(textp+dstidx, "\xc3\xa7", 2);
+						dstidx += 2;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '\x7c')
+					{   // Division sign
+						vod_memcpy(textp+dstidx, "\xc3\xb7", 2);
+						dstidx += 2;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '\x7d')
+					{   // Letter N with tilde
+						vod_memcpy(textp+dstidx, "\xc3\x91", 2);
+						dstidx += 2;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '\x7e')
+					{   // Letter n with tilde
+						vod_memcpy(textp+dstidx, "\xc3\xb1", 2);
+						dstidx += 2;
+						continue;
+					}
+					else if (event->characters[rowidx][colidx] == '\x7f')
+					{   // Cursor block full
+						vod_memcpy(textp+dstidx, "\xe2\x96\x88", 3);
+						dstidx += 3;
+						continue;
+					}
 
-                    textp[dstidx++] = event->characters[rowidx][colidx];
-                }
-            }
-        }
-    }
-    // insert closures to open spans, ordered as </b></u></i>
-    if (iub_flags & 4)
-    {
-        vod_memcpy(textp + dstidx, "</b>", 4); dstidx += 4;
-    }
-    if (iub_flags & 2)
-    {
-        vod_memcpy(textp + dstidx, "</u>", 4); dstidx += 4;
-    }
-    if (iub_flags & 1)
-    {
-        vod_memcpy(textp + dstidx, "</i>", 4); dstidx += 4;
-    }
+					textp[dstidx++] = event->characters[rowidx][colidx];
+				}
+			}
+		}
+	}
+	// insert closures to open spans, ordered as </b></u></i>
+	if (iub_flags & 4)
+	{
+		vod_memcpy(textp + dstidx, "</b>", 4); dstidx += 4;
+	}
+	if (iub_flags & 2)
+	{
+		vod_memcpy(textp + dstidx, "</u>", 4); dstidx += 4;
+	}
+	if (iub_flags & 1)
+	{
+		vod_memcpy(textp + dstidx, "</i>", 4); dstidx += 4;
+	}
 
-    return dstidx;
+	return dstidx;
 }
 
 static void scc_free_track(vod_pool_t* pool, scc_track_t *track, request_context_t* request_context)
 {
-    free(track->events);
-    return;
+	free(track->events);
+	return;
 }
 
 static void scc_clean_known_mem(request_context_t* request_context, scc_track_t *scc_track, char* event_textp)
 {
-    if (scc_track != NULL)
-        scc_free_track(request_context->pool, scc_track, request_context);
+	if (scc_track != NULL)
+		scc_free_track(request_context->pool, scc_track, request_context);
 
-    if (event_textp != NULL)
-    {
-        vod_free(request_context->pool, event_textp);
-    }
+	if (event_textp != NULL)
+	{
+		vod_free(request_context->pool, event_textp);
+	}
 
-    return;
+	return;
 }
 
 #ifdef ASSUME_STYLE_SUPPORT
 static char* output_one_style(char* p)
 {//TODO: using style index, output name and modify the rest of this function
-        int len;
+		int len;
 
-        vod_memcpy(p, FIXED_WEBVTT_STYLE_START_STR, FIXED_WEBVTT_STYLE_START_WIDTH);           p += FIXED_WEBVTT_STYLE_START_WIDTH;
-        len = 28; vod_memcpy(p, "RAFIK INSERT STYLE NAME HERE", len);                          p += len;
-        vod_memcpy(p, FIXED_WEBVTT_STYLE_END_STR, FIXED_WEBVTT_STYLE_END_WIDTH);               p += FIXED_WEBVTT_STYLE_END_WIDTH;
-        vod_memcpy(p, FIXED_WEBVTT_BRACES_START_STR, FIXED_WEBVTT_BRACES_START_WIDTH);         p += FIXED_WEBVTT_BRACES_START_WIDTH;
+		vod_memcpy(p, FIXED_WEBVTT_STYLE_START_STR, FIXED_WEBVTT_STYLE_START_WIDTH);		p += FIXED_WEBVTT_STYLE_START_WIDTH;
+		len = 28; vod_memcpy(p, "RAFIK INSERT STYLE NAME HERE", len);						p += len;
+		vod_memcpy(p, FIXED_WEBVTT_STYLE_END_STR, FIXED_WEBVTT_STYLE_END_WIDTH);			p += FIXED_WEBVTT_STYLE_END_WIDTH;
+		vod_memcpy(p, FIXED_WEBVTT_BRACES_START_STR, FIXED_WEBVTT_BRACES_START_WIDTH);		p += FIXED_WEBVTT_BRACES_START_WIDTH;
 
-        len = 8; vod_memcpy(p, "color: #", len);                                               p += len;
-        vod_sprintf((u_char*)p, "%08uxD;\r\n", 0xaabbccdd);                                    p += 11;
+		len = 8; vod_memcpy(p, "color: #", len);											p += len;
+		vod_sprintf((u_char*)p, "%08uxD;\r\n", 0xaabbccdd);									p += 11;
 
 
-        len = 14; vod_memcpy(p, "font-family: \"", len);                                       p += len;
-        len = 27; vod_memcpy(p, "RAFIK INSERT FONT NAME HERE", len);                           p += len;
-        len = 16; vod_memcpy(p, "\", sans-serif;\r\n", len);                                   p += len;
-        vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", 24);                                p += 19;
+		len = 14; vod_memcpy(p, "font-family: \"", len);									p += len;
+		len = 27; vod_memcpy(p, "RAFIK INSERT FONT NAME HERE", len);						p += len;
+		len = 16; vod_memcpy(p, "\", sans-serif;\r\n", len);								p += len;
+		vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", 24);								p += 19;
 
-        len = 19; vod_memcpy(p, "background-color: #", len);                                   p += len;
-        vod_sprintf((u_char*)p, "%08uxD;\r\n", 0xaabbccdd);                                    p += 11;
+		len = 19; vod_memcpy(p, "background-color: #", len);								p += len;
+		vod_sprintf((u_char*)p, "%08uxD;\r\n", 0xaabbccdd);									p += 11;
 
-        vod_memcpy(p, FIXED_WEBVTT_BRACES_END_STR, FIXED_WEBVTT_BRACES_END_WIDTH);             p += FIXED_WEBVTT_BRACES_END_WIDTH;
-        len = 2; vod_memcpy(p, "\r\n", len);                                                   p += len;
+		vod_memcpy(p, FIXED_WEBVTT_BRACES_END_STR, FIXED_WEBVTT_BRACES_END_WIDTH);			p += FIXED_WEBVTT_BRACES_END_WIDTH;
+		len = 2; vod_memcpy(p, "\r\n", len);												p += len;
 
-        return p;
+		return p;
 }
 #endif //ASSUME_STYLE_SUPPORT
 
 static vod_status_t
 scc_reader_init(
-    request_context_t* request_context,
-    vod_str_t* buffer,
-    size_t initial_read_size,
-    size_t max_metadata_size,
-    void** ctx)
+	request_context_t* request_context,
+	vod_str_t* buffer,
+	size_t initial_read_size,
+	size_t max_metadata_size,
+	void** ctx)
 {
-    vod_status_t  ret_val;
-    u_char* p = buffer->data;
+	vod_status_t  ret_val;
+	u_char* p = buffer->data;
 
-    if (vod_strncmp(p, UTF8_BOM, sizeof(UTF8_BOM) - 1) == 0)
-    {
-        p += sizeof(UTF8_BOM) - 1;
-    }
+	if (vod_strncmp(p, UTF8_BOM, sizeof(UTF8_BOM) - 1) == 0)
+	{
+		p += sizeof(UTF8_BOM) - 1;
+	}
 
-    // The line that says “Scenarist_SCC V1.0” must be the first line in a v4/v4+ script.
-    if (buffer->len > 0 && vod_strncmp(p, SCC_SCRIPT_INFO_HEADER, sizeof(SCC_SCRIPT_INFO_HEADER) - 1) != 0)
-    {
-        return VOD_NOT_FOUND;
-    }
+	// The line that says “Scenarist_SCC V1.0” must be the first line in a v4/v4+ script.
+	if (buffer->len > 0 && vod_strncmp(p, SCC_SCRIPT_INFO_HEADER, sizeof(SCC_SCRIPT_INFO_HEADER) - 1) != 0)
+	{
+		return VOD_NOT_FOUND;
+	}
 
-    ret_val = subtitle_reader_init(
-        request_context,
-        initial_read_size,
-        ctx);
+	ret_val = subtitle_reader_init(
+		request_context,
+		initial_read_size,
+		ctx);
 
-    return ret_val;
+	return ret_val;
 }
 
 static vod_status_t
 scc_parse(
-    request_context_t* request_context,
-    media_parse_params_t* parse_params,
-    vod_str_t* source,
-    size_t metadata_part_count,
-    media_base_metadata_t** result)
+	request_context_t* request_context,
+	media_parse_params_t* parse_params,
+	vod_str_t* source,
+	size_t metadata_part_count,
+	media_base_metadata_t** result)
 {
-    scc_track_t *scc_track;
-    vod_status_t ret_status;
-    scc_track = scc_parse_memory((char *)(source->data), source->len, request_context);
+	scc_track_t *scc_track;
+	vod_status_t ret_status;
+	scc_track = scc_parse_memory((char *)(source->data), source->len, request_context);
 
-    if (scc_track == NULL)
-    {
-        // scc_track was de-allocated already inside the function, for failure cases
-        vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
-            "scc_parse_memory failed");
-        return VOD_BAD_DATA;
-    }
+	if (scc_track == NULL)
+	{
+		// scc_track was de-allocated already inside the function, for failure cases
+		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
+			"scc_parse_memory failed");
+		return VOD_BAD_DATA;
+	}
 
-    ret_status = subtitle_parse(
-        request_context,
-        parse_params,
-        source,
-        NULL,
-        (uint64_t)(scc_track->max_duration),
-        metadata_part_count,
-        result);
+	ret_status = subtitle_parse(
+		request_context,
+		parse_params,
+		source,
+		NULL,
+		(uint64_t)(scc_track->max_duration),
+		metadata_part_count,
+		result);
 
 #ifdef  SCC_TEMP_VERBOSITY
-    vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-        "scc_parse(): scc_parse_memory() succeeded: len of data = %d, max_duration = %D, max_frame = %d, nEvents = %d, ret_status=%d",
-        source->len, scc_track->max_duration, scc_track->max_frame_count, scc_track->n_events, ret_status);
+	vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+		"scc_parse(): scc_parse_memory() succeeded: len of data = %d, max_duration = %D, max_frame = %d, nEvents = %d, ret_status=%d",
+		source->len, scc_track->max_duration, scc_track->max_frame_count, scc_track->n_events, ret_status);
 #endif
-    // now that we used max_duration, we need to free the memory used by the track
-    scc_free_track(request_context->pool, scc_track, request_context);
-    return ret_status;
+	// now that we used max_duration, we need to free the memory used by the track
+	scc_free_track(request_context->pool, scc_track, request_context);
+	return ret_status;
 }
 
 // correct start_time depending on fps and initial offset, then add SCC_OFFSET_FOR_SHORTER_LEAD
 static long long scale_sub_sec(long long time, long long offset, int fps)
 {
-    if (fps <= 0)
-        return time;
-    long long frame_count = time % 1000;
-    long long frames_in_msec = frame_count * 1000 / fps;
-    return (time + frames_in_msec - offset - frame_count + SCC_OFFSET_FOR_SHORTER_LEAD);
+	if (fps <= 0)
+		return time;
+	long long frame_count = time % 1000;
+	long long frames_in_msec = frame_count * 1000 / fps;
+	return (time + frames_in_msec - offset - frame_count + SCC_OFFSET_FOR_SHORTER_LEAD);
 }
 /**
  * \brief Parse the .scc file, convert to webvtt, output all cues as frames
@@ -508,19 +508,19 @@ static long long scale_sub_sec(long long time, long long offset, int fps)
  *
  * \output vtt_track->media_info.extra_data   (WEBVTT header + all STYLE cues)
  * \output vtt_track->total_frames_duration   (sum of output frame durations)
- * \output vtt_track->first_frame_index       (event index for very first event output in this segment)
+ * \output vtt_track->first_frame_index	   (event index for very first event output in this segment)
  * \output vtt_track->first_frame_time_offset (Start time of the very first event output in this segment)
- * \output vtt_track->total_frames_size       (Number of String Bytes used in all events that were output)
- * \output vtt_track->frame_count             (Number of events output in this segment)
- * \output vtt_track->frames.clip_to          (the upper clipping bound of this segment)
- * \output vtt_track->frames.first_frame      (pointer to first frame structure in the linked list)
- * \output vtt_track->frames.last_frame       (pointer to last frame structure in the linked list)
+ * \output vtt_track->total_frames_size	   (Number of String Bytes used in all events that were output)
+ * \output vtt_track->frame_count			 (Number of events output in this segment)
+ * \output vtt_track->frames.clip_to		  (the upper clipping bound of this segment)
+ * \output vtt_track->frames.first_frame	  (pointer to first frame structure in the linked list)
+ * \output vtt_track->frames.last_frame	   (pointer to last frame structure in the linked list)
  * \output result (media track in the track array)
  *
  * individual cues in the frames array
- * \output cur_frame->duration                      (start time of next  output event - start time of current event)
- * if last event to be output but not last in file: (start time of next         event - start time of current event)
- * if last event in whole file:                     (end time of current output event - start time of current event)
+ * \output cur_frame->duration					  (start time of next  output event - start time of current event)
+ * if last event to be output but not last in file: (start time of next		 event - start time of current event)
+ * if last event in whole file:					 (end time of current output event - start time of current event)
  * \output cur_frame->offset
  * \output cur_frame->size
  * \output cur_frame->pts_delay
@@ -530,439 +530,438 @@ static long long scale_sub_sec(long long time, long long offset, int fps)
 */
 static vod_status_t
 scc_parse_frames(
-    request_context_t* request_context,
-    media_base_metadata_t* base,
-    media_parse_params_t* parse_params,
-    struct segmenter_conf_s* segmenter,     // unused
-    read_cache_state_t* read_cache_state,   // unused
-    vod_str_t* frame_data,                  // unused
-    media_format_read_request_t* read_req,  // unused
-    media_track_array_t* result)
+	request_context_t* request_context,
+	media_base_metadata_t* base,
+	media_parse_params_t* parse_params,
+	struct segmenter_conf_s* segmenter,	 // unused
+	read_cache_state_t* read_cache_state,   // unused
+	vod_str_t* frame_data,				  // unused
+	media_format_read_request_t* read_req,  // unused
+	media_track_array_t* result)
 {
-    scc_track_t *scc_track;
-    vod_array_t frames;
-    subtitle_base_metadata_t* metadata
-                              = vod_container_of(base, subtitle_base_metadata_t, base);
-    vod_str_t*     source     = &metadata->source;
-    media_track_t* vtt_track  = base->tracks.elts;
-    input_frame_t* cur_frame  = NULL;
-    scc_event_t*   cur_event  = NULL;
-    vod_str_t* header         = &vtt_track->media_info.extra_data;
-    char *p, *pfixed;
-    int len, evntcounter, jj;
-    uint64_t base_time, clip_to, seg_start, seg_end, last_start_time;
+	scc_track_t *scc_track;
+	vod_array_t frames;
+	subtitle_base_metadata_t* metadata
+							  = vod_container_of(base, subtitle_base_metadata_t, base);
+	vod_str_t*	 source	 = &metadata->source;
+	media_track_t* vtt_track  = base->tracks.elts;
+	input_frame_t* cur_frame  = NULL;
+	scc_event_t*   cur_event  = NULL;
+	vod_str_t* header		 = &vtt_track->media_info.extra_data;
+	char *p, *pfixed;
+	int len, evntcounter, jj;
+	uint64_t base_time, clip_to, seg_start, seg_end, last_start_time;
 
-    vod_memzero(result, sizeof(*result));
-    result->first_track       = vtt_track;
-    result->last_track        = vtt_track + 1;
-    result->track_count[MEDIA_TYPE_SUBTITLE] = 1;
-    result->total_track_count = 1;
+	vod_memzero(result, sizeof(*result));
+	result->first_track	   = vtt_track;
+	result->last_track		= vtt_track + 1;
+	result->track_count[MEDIA_TYPE_SUBTITLE] = 1;
+	result->total_track_count = 1;
 
-    vtt_track->first_frame_index       = 0;
-    vtt_track->first_frame_time_offset = -1;
-    vtt_track->total_frames_size       = 0;
-    vtt_track->total_frames_duration   = 0;
-    last_start_time = 0;
+	vtt_track->first_frame_index	   = 0;
+	vtt_track->first_frame_time_offset = -1;
+	vtt_track->total_frames_size	   = 0;
+	vtt_track->total_frames_duration   = 0;
+	last_start_time = 0;
 
-    if ((parse_params->parse_type & (PARSE_FLAG_FRAMES_ALL | PARSE_FLAG_EXTRA_DATA | PARSE_FLAG_EXTRA_DATA_SIZE)) == 0)
-    {
-        return VOD_OK;
-    }
+	if ((parse_params->parse_type & (PARSE_FLAG_FRAMES_ALL | PARSE_FLAG_EXTRA_DATA | PARSE_FLAG_EXTRA_DATA_SIZE)) == 0)
+	{
+		return VOD_OK;
+	}
 
-    scc_track = scc_parse_memory((char *)(source->data), source->len, request_context);
+	scc_track = scc_parse_memory((char *)(source->data), source->len, request_context);
 
-    if (scc_track == NULL)
-    {
-        // scc_track was de-allocated already inside the function, for failure cases
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "scc_parse_frames(): failed to parse memory into scc track");
-        return VOD_BAD_MAPPING;
-    }
-    else if (scc_track->n_events < 1)
-    {
-        // File had no valid events
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "scc_parse_frames(): file empty or has no valid events");
-        return VOD_BAD_DATA;
-    }
+	if (scc_track == NULL)
+	{
+		// scc_track was de-allocated already inside the function, for failure cases
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"scc_parse_frames(): failed to parse memory into scc track");
+		return VOD_BAD_MAPPING;
+	}
+	else if (scc_track->n_events < 1)
+	{
+		// File had no valid events
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"scc_parse_frames(): file empty or has no valid events");
+		return VOD_BAD_DATA;
+	}
 #ifdef  SCC_TEMP_VERBOSITY
-    else
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "frames scc_parse_memory() succeeded, len of data = %d, max_frame = %d, init_offset = %D, max_duration = %D, nEvents = %d",
-            source->len, scc_track->max_frame_count, scc_track->initial_offset, scc_track->max_duration, scc_track->n_events);
-    }
+	else
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"frames scc_parse_memory() succeeded, len of data = %d, max_frame = %d, init_offset = %D, max_duration = %D, nEvents = %d",
+			source->len, scc_track->max_frame_count, scc_track->initial_offset, scc_track->max_duration, scc_track->n_events);
+	}
 #endif
 
-    // Re-order events so that each event has a starting time that is bigger than or equal than the one before it.
-    // This matches WebVTT expectations of cue order. And allows us to calculate frame duration correctly.
-    // We don't sort it inside scc_parse_memory() because that function is called twice, and first time no sorting is needed.
-    // BUBBLE SORT was chosen to optimize the best-case scenario O(n), since most scripts are already ordered.
-    for (evntcounter = 0; evntcounter < scc_track->n_events - 1; evntcounter++)
-    {
-        // Last evntcounter elements are already in place
-        for (jj = 0; jj < scc_track->n_events - evntcounter - 1; jj++)
-        {
-            scc_event_t*   next_event = scc_track->events + jj + 1;
-                           cur_event  = scc_track->events + jj;
-            // We use >= instead of > so simultaneous events get ordered first-in last-out
-            // so WebVTT would move the earlier cues up instead of the newer cues.
-            if (cur_event->start_time >= next_event->start_time)
-            {
-                //  Swap the two events
-                scc_swap_events(next_event, cur_event);
-            }
-        }
-    }
+	// Re-order events so that each event has a starting time that is bigger than or equal than the one before it.
+	// This matches WebVTT expectations of cue order. And allows us to calculate frame duration correctly.
+	// We don't sort it inside scc_parse_memory() because that function is called twice, and first time no sorting is needed.
+	// BUBBLE SORT was chosen to optimize the best-case scenario O(n), since most scripts are already ordered.
+	for (evntcounter = 0; evntcounter < scc_track->n_events - 1; evntcounter++)
+	{
+		// Last evntcounter elements are already in place
+		for (jj = 0; jj < scc_track->n_events - evntcounter - 1; jj++)
+		{
+			scc_event_t*   next_event = scc_track->events + jj + 1;
+						   cur_event  = scc_track->events + jj;
+			// We use >= instead of > so simultaneous events get ordered first-in last-out
+			// so WebVTT would move the earlier cues up instead of the newer cues.
+			if (cur_event->start_time >= next_event->start_time)
+			{
+				//  Swap the two events
+				scc_swap_events(next_event, cur_event);
+			}
+		}
+	}
 
-    int  fps = (scc_track->max_frame_count < 24) ? 24 :
-               (scc_track->max_frame_count < 30) ? 30 :
-               (scc_track->max_frame_count < 60) ? 60 :
-               (scc_track->max_frame_count + 1);      // inaccurate sub-second times, just to avoid overflow
+	int  fps = (scc_track->max_frame_count < 24) ? 24 :
+			   (scc_track->max_frame_count < 30) ? 30 :
+			   (scc_track->max_frame_count < 60) ? 60 :
+			   (scc_track->max_frame_count + 1);	  // inaccurate sub-second times, just to avoid overflow
 
-    // set the end_time of each event depending on next event's start_time, capping to 3 seconds.
-    // Set duration of last event in the file to 3 seconds for any input file.
-    scc_event_t*  last_event = scc_track->events + scc_track->n_events - 1;
-    if (last_event != NULL && fps != 0)
-    {
-        // correct start_time depending on fps and initial offset, then add one second
-        last_event->start_time = scale_sub_sec(last_event->start_time, scc_track->initial_offset, fps);
-        last_event->end_time = last_event->start_time + SCC_MAX_CUE_DURATION_MSEC;
-    }
-    for (evntcounter = scc_track->n_events - 1; evntcounter > 0 ; evntcounter--)
-    {
-        scc_event_t*  next_event = scc_track->events + evntcounter;     // has times scaled already
-                      cur_event  = scc_track->events + evntcounter - 1; // time not adjusted for start, no end calculated
+	// set the end_time of each event depending on next event's start_time, capping to 3 seconds.
+	// Set duration of last event in the file to 3 seconds for any input file.
+	scc_event_t*  last_event = scc_track->events + scc_track->n_events - 1;
+	if (last_event != NULL && fps != 0)
+	{
+		// correct start_time depending on fps and initial offset, then add one second
+		last_event->start_time = scale_sub_sec(last_event->start_time, scc_track->initial_offset, fps);
+		last_event->end_time = last_event->start_time + SCC_MAX_CUE_DURATION_MSEC;
+	}
+	for (evntcounter = scc_track->n_events - 1; evntcounter > 0 ; evntcounter--)
+	{
+		scc_event_t*  next_event = scc_track->events + evntcounter;	 // has times scaled already
+					  cur_event  = scc_track->events + evntcounter - 1; // time not adjusted for start, no end calculated
 
-        cur_event->start_time = scale_sub_sec(cur_event->start_time, scc_track->initial_offset, fps);
+		cur_event->start_time = scale_sub_sec(cur_event->start_time, scc_track->initial_offset, fps);
 
-        if (cur_event->start_time == next_event->start_time)
-            // multiple events starting at the same exact time will have same duration (appear simultaneously on screen)
-            cur_event->end_time = next_event->end_time;
-        else
-        {
-            // duration is capped to no less than 1 sec, no more than 3 seconds
-            // we should cap it to no less than some value
-            long long expected_end = next_event->start_time - SCC_MIN_INTER_CUE_DUR_MSEC;
-            if (expected_end < (cur_event->start_time + SCC_MIN_CUE_DURATION_MSEC))
-                expected_end = (cur_event->start_time + SCC_MIN_CUE_DURATION_MSEC);
-            if (expected_end > (cur_event->start_time + SCC_MAX_CUE_DURATION_MSEC))
-                expected_end = (cur_event->start_time + SCC_MAX_CUE_DURATION_MSEC);
+		if (cur_event->start_time == next_event->start_time)
+			// multiple events starting at the same exact time will have same duration (appear simultaneously on screen)
+			cur_event->end_time = next_event->end_time;
+		else
+		{
+			// duration is capped to no less than 1 sec, no more than 3 seconds
+			// we should cap it to no less than some value
+			long long expected_end = next_event->start_time - SCC_MIN_INTER_CUE_DUR_MSEC;
+			if (expected_end < (cur_event->start_time + SCC_MIN_CUE_DURATION_MSEC))
+				expected_end = (cur_event->start_time + SCC_MIN_CUE_DURATION_MSEC);
+			if (expected_end > (cur_event->start_time + SCC_MAX_CUE_DURATION_MSEC))
+				expected_end = (cur_event->start_time + SCC_MAX_CUE_DURATION_MSEC);
 
-            cur_event->end_time  = (expected_end > SCC_MIN_CUE_DURATION_MSEC)
-                                 ? expected_end
-                                 : SCC_MIN_CUE_DURATION_MSEC;
-        }
-    }
+			cur_event->end_time  = (expected_end > SCC_MIN_CUE_DURATION_MSEC)
+								 ? expected_end
+								 : SCC_MIN_CUE_DURATION_MSEC;
+		}
+	}
 
-    // allocate initial array of cues/styles, to be augmented as needed after the first 5
-    if (vod_array_init(&frames, request_context->pool, 5, sizeof(input_frame_t)) != VOD_OK)
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "scc_parse_frames: vod_array_init failed");
-        scc_free_track(request_context->pool, scc_track, request_context);
-        return VOD_ALLOC_FAILED;
-    }
+	// allocate initial array of cues/styles, to be augmented as needed after the first 5
+	if (vod_array_init(&frames, request_context->pool, 5, sizeof(input_frame_t)) != VOD_OK)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"scc_parse_frames: vod_array_init failed");
+		scc_free_track(request_context->pool, scc_track, request_context);
+		return VOD_ALLOC_FAILED;
+	}
 
-    seg_start = parse_params->range->start + parse_params->clip_from;
+	seg_start = parse_params->range->start + parse_params->clip_from;
 
-    if ((parse_params->parse_type & PARSE_FLAG_RELATIVE_TIMESTAMPS) != 0)
-    {
-        base_time = seg_start;
-        clip_to = parse_params->range->end - parse_params->range->start;
-        seg_end = clip_to;
-    }
-    else
-    {
-        base_time = parse_params->clip_from;
-        clip_to = parse_params->clip_to;
-        seg_end = parse_params->range->end;
-    }
+	if ((parse_params->parse_type & PARSE_FLAG_RELATIVE_TIMESTAMPS) != 0)
+	{
+		base_time = seg_start;
+		clip_to = parse_params->range->end - parse_params->range->start;
+		seg_end = clip_to;
+	}
+	else
+	{
+		base_time = parse_params->clip_from;
+		clip_to = parse_params->clip_to;
+		seg_end = parse_params->range->end;
+	}
 
-    // We now insert all cues that include their positioning info
-    // Events are assumed already ordered by their start time. As required for WebVTT output Cues.
-    for (evntcounter = 0; evntcounter < scc_track->n_events; evntcounter++)
-    {
-        cur_event = scc_track->events + evntcounter;
+	// We now insert all cues that include their positioning info
+	// Events are assumed already ordered by their start time. As required for WebVTT output Cues.
+	for (evntcounter = 0; evntcounter < scc_track->n_events; evntcounter++)
+	{
+		cur_event = scc_track->events + evntcounter;
 
-        // make all timing checks and clipping, before we decide to read the text or output it.
-        // to make sure this event should be included in the segment.
-        if (cur_event->end_time < 0 || cur_event->start_time < 0 || cur_event->start_time >= cur_event->end_time)
-        {
-            continue;
-        }
-        if ((uint64_t)cur_event->end_time < seg_start)
-        {
-            continue;
-        }
+		// make all timing checks and clipping, before we decide to read the text or output it.
+		// to make sure this event should be included in the segment.
+		if (cur_event->end_time < 0 || cur_event->start_time < 0 || cur_event->start_time >= cur_event->end_time)
+		{
+			continue;
+		}
+		if ((uint64_t)cur_event->end_time < seg_start)
+		{
+			continue;
+		}
 
-        // apply clipping
-        if (cur_event->start_time >= (int64_t)base_time)
-        {
-            cur_event->start_time -= base_time;
-            if ((uint64_t)cur_event->start_time > clip_to)
-            {
-                cur_event->start_time = (long long)(clip_to);
-            }
-        }
-        else
-        {
-            cur_event->start_time = 0;
-        }
+		// apply clipping
+		if (cur_event->start_time >= (int64_t)base_time)
+		{
+			cur_event->start_time -= base_time;
+			if ((uint64_t)cur_event->start_time > clip_to)
+			{
+				cur_event->start_time = (long long)(clip_to);
+			}
+		}
+		else
+		{
+			cur_event->start_time = 0;
+		}
 
-        cur_event->end_time -= base_time;
-        if ((uint64_t)cur_event->end_time > clip_to)
-        {
-            cur_event->end_time = (long long)(clip_to);
-        }
+		cur_event->end_time -= base_time;
+		if ((uint64_t)cur_event->end_time > clip_to)
+		{
+			cur_event->end_time = (long long)(clip_to);
+		}
 
-        if (cur_frame != NULL)
-        {
-            cur_frame->duration = cur_event->start_time - last_start_time;
-            vtt_track->total_frames_duration += cur_frame->duration;
-        }
-        else
-        {
-            // if this is the very first event intersecting with segment, this is the first start in the segment
-            vtt_track->first_frame_time_offset = cur_event->start_time;
-            vtt_track->first_frame_index       = evntcounter;
-        }
+		if (cur_frame != NULL)
+		{
+			cur_frame->duration = cur_event->start_time - last_start_time;
+			vtt_track->total_frames_duration += cur_frame->duration;
+		}
+		else
+		{
+			// if this is the very first event intersecting with segment, this is the first start in the segment
+			vtt_track->first_frame_time_offset = cur_event->start_time;
+			vtt_track->first_frame_index	   = evntcounter;
+		}
 
-        if ((uint64_t)cur_event->start_time >= seg_end)
-        {
-            // events are already ordered by start-time
-            break;
-        }
+		if ((uint64_t)cur_event->start_time >= seg_end)
+		{
+			// events are already ordered by start-time
+			break;
+		}
 
-        ///// This EVENT is within the segment duration. Parse its text, and output it after conversion to WebVTT valid tags./////
+		///// This EVENT is within the segment duration. Parse its text, and output it after conversion to WebVTT valid tags./////
 
-        // Split the event text into multiple chunks so we can insert each chunk as a separate frame in webVTT, all under a single cue
-        char* event_textp = vod_alloc(request_context->pool, MAX_STR_SIZE_EVNT_CHUNK);
-        if (event_textp == NULL)
-        {
-            vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-                "scc_parse_frames: vod_alloc failed");
-            scc_clean_known_mem(request_context, scc_track, event_textp);
-            return VOD_ALLOC_FAILED;
-        }
+		// Split the event text into multiple chunks so we can insert each chunk as a separate frame in webVTT, all under a single cue
+		char* event_textp = vod_alloc(request_context->pool, MAX_STR_SIZE_EVNT_CHUNK);
+		if (event_textp == NULL)
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"scc_parse_frames: vod_alloc failed");
+			scc_clean_known_mem(request_context, scc_track, event_textp);
+			return VOD_ALLOC_FAILED;
+		}
 
-        int  event_len = convert_event_text(cur_event,  event_textp, request_context);
-
-#ifdef  SCC_TEMP_VERBOSITY
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "scc_parse_frames: event=%d len0=%d",
-            evntcounter, event_len);
-#endif
-
-        // allocate the output frame
-        cur_frame = vod_array_push(&frames);
-        if (cur_frame == NULL)
-        {
-            vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-                "scc_parse_frames: vod_array_push failed");
-            scc_clean_known_mem(request_context, scc_track, event_textp);
-            return VOD_ALLOC_FAILED;
-        }
-        // allocate the text of output frame
-        p = pfixed = vod_alloc(request_context->pool, MAX_STR_SIZE_EVNT_CHUNK);
-        if (p == NULL)
-        {
-            vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-                "scc_parse_frames: vod_alloc failed");
-            scc_clean_known_mem(request_context, scc_track, event_textp);
-            return VOD_ALLOC_FAILED;
-        }
-
-        if (evntcounter == (scc_track->n_events - 1))
-        {
-            cur_frame->duration = cur_event->end_time - cur_event->start_time;
-            vtt_track->total_frames_duration += cur_frame->duration;
-        }
+		int  event_len = convert_event_text(cur_event,  event_textp, request_context);
 
 #ifdef  SCC_TEMP_VERBOSITY
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "UPDATEDURATION: evntCounter=%d, Start=%D, End=%D,duration=%D, total_frames_duration=%D, firstFrmIdx=%d, firstFrmOffset=%D",
-            evntcounter, cur_event->start_time, cur_event->end_time, cur_frame->duration, vtt_track->total_frames_duration,
-            vtt_track->first_frame_index, vtt_track->first_frame_time_offset);
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"scc_parse_frames: event=%d len0=%d",
+			evntcounter, event_len);
 #endif
-        // Cues are named "c<iteration_number_in_7_digits>" starting from c0000000
-        vod_sprintf((u_char*)p, FIXED_WEBVTT_CUE_FORMAT_STR, evntcounter);      p += FIXED_WEBVTT_CUE_NAME_WIDTH;
-        len = 2; vod_memcpy(p, "\r\n", len);                                    p += len;
-        // timestamps will be inserted here, we now insert positioning and alignment changes
-        {
-            unsigned char align;
-            int kk, ll, pos, sizeH = 0, line = 14;
-            int max_num_of_chars_per_line = 0;
-            int lineidx_max_num_of_chars  = line;
-            int min_num_of_chars_per_line = SCC_608_SCREEN_WIDTH;
-            int lineidx_min_num_of_chars  = line;
-            int slots_before_min_chars = 0, slots_after_min_chars = 0, slots_before_max_chars = 0, slots_after_max_chars = 0;
-            for (kk = 0; kk < 15; kk++)
-            {
-                if (cur_event->row_used[kk] == 1)
-                {
-                    line = kk; // should never be 15
-                    break;
-                }
-            }
 
-            for (kk = line; kk < 15; kk++)
-            {
-                if (cur_event->row_used[kk] == 1)
-                {
-                    int num_of_chars = 32;
-                    for (ll = 0; ll < SCC_608_SCREEN_WIDTH; ll++)
-                    {
-                        if (cur_event->characters[kk][ll] == SCC_UNUSED_CHAR)
-                            num_of_chars--;
-                    }
-                    if (num_of_chars > max_num_of_chars_per_line)
-                    {
-                        max_num_of_chars_per_line = num_of_chars;
-                        lineidx_max_num_of_chars = kk;
-                    }
-                    if (num_of_chars < min_num_of_chars_per_line)
-                    {
-                        min_num_of_chars_per_line = num_of_chars;
-                        lineidx_min_num_of_chars = kk;
-                    }
-                }
-            }
-            for (ll = 0; ll < (SCC_608_SCREEN_WIDTH-1); ll++)
-            {
-                if (cur_event->characters[lineidx_min_num_of_chars][ll] == SCC_UNUSED_CHAR)
-                    slots_before_min_chars++;
-                else
-                    break;
-            }
-            for (ll = 0; ll < (SCC_608_SCREEN_WIDTH-1); ll++)
-            {
-                if (cur_event->characters[lineidx_max_num_of_chars][ll] == SCC_UNUSED_CHAR)
-                    slots_before_max_chars++;
-                else
-                    break;
-            }
-            sizeH = 3 * max_num_of_chars_per_line;
-            slots_after_min_chars = SCC_608_SCREEN_WIDTH - min_num_of_chars_per_line - slots_before_min_chars;
-            slots_after_max_chars = SCC_608_SCREEN_WIDTH - max_num_of_chars_per_line - slots_before_max_chars;
+		// allocate the output frame
+		cur_frame = vod_array_push(&frames);
+		if (cur_frame == NULL)
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"scc_parse_frames: vod_array_push failed");
+			scc_clean_known_mem(request_context, scc_track, event_textp);
+			return VOD_ALLOC_FAILED;
+		}
+		// allocate the text of output frame
+		p = pfixed = vod_alloc(request_context->pool, MAX_STR_SIZE_EVNT_CHUNK);
+		if (p == NULL)
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+				"scc_parse_frames: vod_alloc failed");
+			scc_clean_known_mem(request_context, scc_track, event_textp);
+			return VOD_ALLOC_FAILED;
+		}
+
+		if (evntcounter == (scc_track->n_events - 1))
+		{
+			cur_frame->duration = cur_event->end_time - cur_event->start_time;
+			vtt_track->total_frames_duration += cur_frame->duration;
+		}
+
 #ifdef  SCC_TEMP_VERBOSITY
-            vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "event number %d, spaces_before=%d, max=%d, spaces_after=%d, lineidx=%d",
-            evntcounter, slots_before_max_chars, max_num_of_chars_per_line, slots_after_max_chars, lineidx_max_num_of_chars);
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"UPDATEDURATION: evntCounter=%d, Start=%D, End=%D,duration=%D, total_frames_duration=%D, firstFrmIdx=%d, firstFrmOffset=%D",
+			evntcounter, cur_event->start_time, cur_event->end_time, cur_frame->duration, vtt_track->total_frames_duration,
+			vtt_track->first_frame_index, vtt_track->first_frame_time_offset);
 #endif
-            if ((slots_after_min_chars ==  slots_before_min_chars   ) ||
-                (slots_after_min_chars == (slots_before_min_chars+1)) ||
-                (slots_after_min_chars == (slots_before_min_chars-1)))
-            {
-                align = SCC_ALIGN_CENTER;
-                pos = 50;
-            }
-            else if (slots_after_min_chars > slots_before_min_chars)
-            {
-                align = SCC_ALIGN_LEFT;
-                pos = 2 + (3 * slots_before_max_chars);
-            }
-            else
-            {
-                align = SCC_ALIGN_RIGHT;
-                pos = 98 - (3 * slots_after_max_chars);
-            }
+		// Cues are named "c<iteration_number_in_7_digits>" starting from c0000000
+		vod_sprintf((u_char*)p, FIXED_WEBVTT_CUE_FORMAT_STR, evntcounter);	  p += FIXED_WEBVTT_CUE_NAME_WIDTH;
+		len = 2; vod_memcpy(p, "\r\n", len);									p += len;
+		// timestamps will be inserted here, we now insert positioning and alignment changes
+		{
+			unsigned char align;
+			int kk, ll, pos, sizeH = 0, line = 14;
+			int max_num_of_chars_per_line = 0;
+			int lineidx_max_num_of_chars  = line;
+			int min_num_of_chars_per_line = SCC_608_SCREEN_WIDTH;
+			int lineidx_min_num_of_chars  = line;
+			int slots_before_min_chars = 0, slots_after_min_chars = 0, slots_before_max_chars = 0, slots_after_max_chars = 0;
+			for (kk = 0; kk < 15; kk++)
+			{
+				if (cur_event->row_used[kk] == 1)
+				{
+					line = kk; // should never be 15
+					break;
+				}
+			}
 
-            len = 10; vod_memcpy(p, " position:", len);                     p += len;
-            vod_sprintf((u_char*)p, "%03uD", pos);                          p += 3;
-            len =  7; vod_memcpy(p, "% size:", len);                        p += len;
-            vod_sprintf((u_char*)p, "%03uD", sizeH);                        p += 3;
-            len =  7; vod_memcpy(p, "% line:", len);                        p += len;
-            vod_sprintf((u_char*)p, "%02uD", line);                         p += 2;
+			for (kk = line; kk < 15; kk++)
+			{
+				if (cur_event->row_used[kk] == 1)
+				{
+					int num_of_chars = 32;
+					for (ll = 0; ll < SCC_608_SCREEN_WIDTH; ll++)
+					{
+						if (cur_event->characters[kk][ll] == SCC_UNUSED_CHAR)
+							num_of_chars--;
+					}
+					if (num_of_chars > max_num_of_chars_per_line)
+					{
+						max_num_of_chars_per_line = num_of_chars;
+						lineidx_max_num_of_chars = kk;
+					}
+					if (num_of_chars < min_num_of_chars_per_line)
+					{
+						min_num_of_chars_per_line = num_of_chars;
+						lineidx_min_num_of_chars = kk;
+					}
+				}
+			}
+			for (ll = 0; ll < (SCC_608_SCREEN_WIDTH-1); ll++)
+			{
+				if (cur_event->characters[lineidx_min_num_of_chars][ll] == SCC_UNUSED_CHAR)
+					slots_before_min_chars++;
+				else
+					break;
+			}
+			for (ll = 0; ll < (SCC_608_SCREEN_WIDTH-1); ll++)
+			{
+				if (cur_event->characters[lineidx_max_num_of_chars][ll] == SCC_UNUSED_CHAR)
+					slots_before_max_chars++;
+				else
+					break;
+			}
+			sizeH = 3 * max_num_of_chars_per_line;
+			slots_after_min_chars = SCC_608_SCREEN_WIDTH - min_num_of_chars_per_line - slots_before_min_chars;
+			slots_after_max_chars = SCC_608_SCREEN_WIDTH - max_num_of_chars_per_line - slots_before_max_chars;
+#ifdef  SCC_TEMP_VERBOSITY
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"event number %d, spaces_before=%d, max=%d, spaces_after=%d, lineidx=%d",
+			evntcounter, slots_before_max_chars, max_num_of_chars_per_line, slots_after_max_chars, lineidx_max_num_of_chars);
+#endif
+			if ((slots_after_min_chars ==  slots_before_min_chars   ) ||
+				(slots_after_min_chars == (slots_before_min_chars+1)) ||
+				(slots_after_min_chars == (slots_before_min_chars-1)))
+			{
+				align = SCC_ALIGN_CENTER;
+				pos = 50;
+			}
+			else if (slots_after_min_chars > slots_before_min_chars)
+			{
+				align = SCC_ALIGN_LEFT;
+				pos = 2 + (3 * slots_before_max_chars);
+			}
+			else
+			{
+				align = SCC_ALIGN_RIGHT;
+				pos = 98 - (3 * slots_after_max_chars);
+			}
+
+			len = 10; vod_memcpy(p, " position:", len);									p += len;
+			vod_sprintf((u_char*)p, "%03uD", pos);										p += 3;
+			len =  7; vod_memcpy(p, "% size:", len);									p += len;
+			vod_sprintf((u_char*)p, "%03uD", sizeH);									p += 3;
+			len =  7; vod_memcpy(p, "% line:", len);									p += len;
+			vod_sprintf((u_char*)p, "%02uD", line);										p += 2;
 
 
-            len =  7; vod_memcpy(p, " align:", len);                        p += len;
-            if (align == SCC_ALIGN_CENTER)
-            {
-                len =  6; vod_memcpy(p, "center", len);                     p += len;
-            }
-            else if (align == SCC_ALIGN_LEFT)
-            {
-                len =  4; vod_memcpy(p, "left", len);                       p += len;
-            }
-            else
-            {
-                len =  5; vod_memcpy(p, "right", len);                      p += len;
-            }
-            len = 2; vod_memcpy(p, "\r\n", len);                            p += len;
-        }
+			len =  7; vod_memcpy(p, " align:", len);									p += len;
+			if (align == SCC_ALIGN_CENTER)
+			{
+				len =  6; vod_memcpy(p, "center", len);									p += len;
+			}
+			else if (align == SCC_ALIGN_LEFT)
+			{
+				len =  4; vod_memcpy(p, "left", len);									p += len;
+			}
+			else
+			{
+				len =  5; vod_memcpy(p, "right", len);									p += len;
+			}
+			len = 2; vod_memcpy(p, "\r\n", len);										p += len;
+		}
 #ifdef ASSUME_STYLE_SUPPORT
-        vod_memcpy(p, FIXED_WEBVTT_VOICE_START_STR, FIXED_WEBVTT_VOICE_START_WIDTH);       p += FIXED_WEBVTT_VOICE_START_WIDTH;
-        len = 28; vod_sprintf((u_char*)p, "RAFIK INSERT STYLE NAME HERE", len);            p += len;
-        vod_memcpy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);           p += FIXED_WEBVTT_VOICE_END_WIDTH;
+		vod_memcpy(p, FIXED_WEBVTT_VOICE_START_STR, FIXED_WEBVTT_VOICE_START_WIDTH);	p += FIXED_WEBVTT_VOICE_START_WIDTH;
+		len = 28; vod_sprintf((u_char*)p, "RAFIK INSERT STYLE NAME HERE", len);			p += len;
+		vod_memcpy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);		p += FIXED_WEBVTT_VOICE_END_WIDTH;
 #endif //ASSUME_STYLE_SUPPORT
 
-        vod_memcpy(p, event_textp, event_len);                              p += event_len;
+		vod_memcpy(p, event_textp, event_len);											p += event_len;
 
-        len = 2; vod_memcpy(p, "\r\n", len);                                p += len;
-        // we still need an empty line after each event/cue
-        len = 2; vod_memcpy(p, "\r\n", len);                                p += len;
+		len = 2; vod_memcpy(p, "\r\n", len);											p += len;
+		len = 2; vod_memcpy(p, "\r\n", len);											p += len;
 
-        // Note: mapping of cue into input_frame_t:
-        // - offset = pointer to buffer containing: cue id, cue settings list, cue payload
-        // - size = size of data pointed by offset
-        // - key_frame = cue id length
-        // - duration = start time of next event - start time of current event
-        // - pts_delay = end time - start time = duration this subtitle event is on screen
+		// Note: mapping of cue into input_frame_t:
+		// - offset = pointer to buffer containing: cue id, cue settings list, cue payload
+		// - size = size of data pointed by offset
+		// - key_frame = cue id length
+		// - duration = start time of next event - start time of current event
+		// - pts_delay = end time - start time = duration this subtitle event is on screen
 
-        cur_frame->offset    = (uintptr_t)pfixed;
-        cur_frame->size      = (uint32_t)(p - pfixed);
-        cur_frame->key_frame = FIXED_WEBVTT_CUE_NAME_WIDTH + 2; // cue name + \r\n
-        cur_frame->pts_delay = cur_event->end_time - cur_event->start_time;
+		cur_frame->offset			= (uintptr_t)pfixed;
+		cur_frame->size	  			= (uint32_t)(p - pfixed);
+		cur_frame->key_frame 		= FIXED_WEBVTT_CUE_NAME_WIDTH + 2; // cue name + \r\n
+		cur_frame->pts_delay 		= cur_event->end_time - cur_event->start_time;
 
-        vtt_track->total_frames_size += cur_frame->size;
+		vtt_track->total_frames_size += cur_frame->size;
 
-        last_start_time = cur_event->start_time;
-    }
+		last_start_time = cur_event->start_time;
+	}
 
-    //allocate memory for the style's text string
-    p = pfixed = vod_alloc(request_context->pool, MAX_STR_SIZE_ALL_WEBVTT_STYLES);
-    if (p == NULL)
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "scc_parse_frames: vod_alloc failed");
-        scc_free_track(request_context->pool, scc_track, request_context);
-        return VOD_ALLOC_FAILED;
-    }
+	//allocate memory for the style's text string
+	p = pfixed = vod_alloc(request_context->pool, MAX_STR_SIZE_ALL_WEBVTT_STYLES);
+	if (p == NULL)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"scc_parse_frames: vod_alloc failed");
+		scc_free_track(request_context->pool, scc_track, request_context);
+		return VOD_ALLOC_FAILED;
+	}
 
-    // We now insert header and all Style definitions
-    header->data              = (u_char*)pfixed;
-    len = sizeof(WEBVTT_HEADER_NEWLINES) - 1; vod_memcpy(p, WEBVTT_HEADER_NEWLINES, len);  p+=len;
+	// We now insert header and all Style definitions
+	header->data					= (u_char*)pfixed;
+	len = sizeof(WEBVTT_HEADER_NEWLINES) - 1; vod_memcpy(p, WEBVTT_HEADER_NEWLINES, len);  p+=len;
 #ifdef ASSUME_STYLE_SUPPORT
-    int stylecounter;
-    /*for (stylecounter = 0; (stylecounter < SCC_NUM_OF_STYLES_INSERTED); stylecounter++)
-    {
-        scc_style_t* cur_style = scc_track->styles + stylecounter;
-        if (cur_style->b_output_in_cur_segment)
-            p = output_one_style(p);
+	int stylecounter;
+	/*for (stylecounter = 0; (stylecounter < SCC_NUM_OF_STYLES_INSERTED); stylecounter++)
+	{
+		scc_style_t* cur_style = scc_track->styles + stylecounter;
+		if (cur_style->b_output_in_cur_segment)
+			p = output_one_style(p);
 
-    }*/
+	}*/
 #endif //ASSUME_STYLE_SUPPORT
-    header->len               = (size_t)(p - pfixed);
+	header->len						= (size_t)(p - pfixed);
 
-    // now we got all the info from scc_track, deallocate its memory
-    scc_free_track(request_context->pool, scc_track, request_context);
+	// now we got all the info from scc_track, deallocate its memory
+	scc_free_track(request_context->pool, scc_track, request_context);
 
-    vtt_track->frame_count        = frames.nelts;
-    vtt_track->frames.clip_to     = clip_to;
-    vtt_track->frames.first_frame = frames.elts;
-    vtt_track->frames.last_frame  = vtt_track->frames.first_frame + frames.nelts;
+	vtt_track->frame_count			= frames.nelts;
+	vtt_track->frames.clip_to		= clip_to;
+	vtt_track->frames.first_frame	= frames.elts;
+	vtt_track->frames.last_frame	= vtt_track->frames.first_frame + frames.nelts;
 
-    return VOD_OK;
+	return VOD_OK;
 }
 
 media_format_t scc_format = {
-    FORMAT_ID_SCC,
-    vod_string("scc CEA-608"),
-    scc_reader_init,
-    subtitle_reader_read,
-    NULL,
-    NULL,
-    scc_parse,
-    scc_parse_frames,
+	FORMAT_ID_SCC,
+	vod_string("scc CEA-608"),
+	scc_reader_init,
+	subtitle_reader_read,
+	NULL,
+	NULL,
+	scc_parse,
+	scc_parse_frames,
 };

--- a/vod/subtitle/scc_format.h
+++ b/vod/subtitle/scc_format.h
@@ -6,20 +6,20 @@
 
 //#define SCC_TEMP_VERBOSITY
 
-#define VALIGN_SUB 0
-#define VALIGN_CENTER 8
-#define VALIGN_TOP 4
+#define VALIGN_SUB						0
+#define VALIGN_CENTER					8
+#define VALIGN_TOP						4
 
-#define SCC_608_SCREEN_WIDTH		  32
-#define SCC_NUM_OF_STYLES_INSERTED	10
-#define SCC_UNUSED_CHAR			   0
-#define SCC_MAX_LONG_LONG			 0xefffffffLL
-#define SCC_THRESH_LONG_LONG		  (55*60*1000)
+#define SCC_608_SCREEN_WIDTH			32
+#define SCC_NUM_OF_STYLES_INSERTED		10
+#define SCC_UNUSED_CHAR					0
+#define SCC_MAX_LONG_LONG				0xefffffffLL
+#define SCC_THRESH_LONG_LONG			(55*60*1000)
 
-#define SCC_MAX_CUE_DURATION_MSEC	 3000
-#define SCC_MIN_CUE_DURATION_MSEC	 1000
-#define SCC_MIN_INTER_CUE_DUR_MSEC	100
-#define SCC_OFFSET_FOR_SHORTER_LEAD   1000
+#define SCC_MAX_CUE_DURATION_MSEC		3000
+#define SCC_MIN_CUE_DURATION_MSEC		1000
+#define SCC_MIN_INTER_CUE_DUR_MSEC		100
+#define SCC_OFFSET_FOR_SHORTER_LEAD		1000
 
 
 // globals
@@ -27,8 +27,8 @@ extern media_format_t scc_format;
 
 enum cc_text_done
 {
-	EVENT_TEXT_OPEN = 0,
-	EVENT_TEXT_DONE = 1
+	EVENT_TEXT_OPEN	=	0,
+	EVENT_TEXT_DONE	=	1
 };
 
 /*
@@ -37,16 +37,16 @@ enum cc_text_done
  */
 typedef struct scc_event
 {
-	unsigned char	  characters[15][33]; // Extra char at the end for potential '\n'
-	unsigned char	  iub	   [15][33]; // Right-most bit is Italic flag, bit 1 is Underline, bit 2 is Flash/Bold
-			 char	  row_used  [15];	 // Any data in row?
-	unsigned char	  color;
-	unsigned char	  bk_color;
-	int				len_text;		   // number of visible characters added to this screen
-	enum cc_text_done  event_text_done;	// when set to EVENT_TEXT_DONE, no further text is added. EOC was received already.
+	unsigned char	characters[15][33];		// Extra char at the end for potential '\n'
+	unsigned char	iub	   [15][33];		// Right-most bit is Italic flag, bit 1 is Underline, bit 2 is Flash/Bold
+			 char	row_used  [15];			// Any data in row?
+	unsigned char	color;
+	unsigned char	bk_color;
+	int				len_text;				// number of visible characters added to this screen
+	enum cc_text_done	event_text_done;	// when set to EVENT_TEXT_DONE, no further text is added. EOC was received already.
 
-	long long		  start_time;		 // ms
-	long long		  end_time;		   // ms
+	long long		start_time;				// ms
+	long long		end_time;				// ms
 } scc_event_t;
 
 /*
@@ -55,20 +55,21 @@ typedef struct scc_event
  */
 typedef struct scc_track
 {
-	long long	   max_duration;		  // ms, added for needs of the vod-module
-	long long	   initial_offset;		// ms, sometimes Broadcast shift the cues by some 59 minutes relative to video
-	int			 max_frame_count;	   // to identify FPS without external information
+	long long		max_duration;			// ms, added for needs of the vod-module
+	long long		initial_offset;			// ms, sometimes Broadcast shift the cues by some 59 minutes relative to video
+	int				max_frame_count;		// to identify FPS without external information
 
-	int			 n_events;
-	int			 max_events;
-	scc_event_t	*events;
+	int				n_events;
+	int				max_events;
+	scc_event_t		*events;
 
-	long long	   cue_time;			 // ms
-	int			 cursor_row, cursor_column;
-	unsigned char   last_c1, last_c2;
-	unsigned char   current_color;		// Color we are currently using to write
-	unsigned char   current_bk_color;	 // Background color we are currently using to write
-	unsigned char   current_iub;		  // Current flag values. RMS bit is Italic flag, bit 1 is Underline, bit 2 is Flash/Bold
+	long long		cue_time;				// ms
+	int				cursor_row;
+	int				cursor_column;
+	unsigned char	last_c1, last_c2;
+	unsigned char	current_color;			// Color we are currently using to write
+	unsigned char	current_bk_color;		// Background color we are currently using to write
+	unsigned char	current_iub;			// Current flag values. RMS bit is Italic flag, bit 1 is Underline, bit 2 is Flash/Bold
 } scc_track_t;
 
 scc_track_t *scc_parse_memory(char *data, int length, request_context_t* request_context);
@@ -82,51 +83,51 @@ enum scc_alignment
 
 enum scc_color_code
 {
-	COL_WHITE	   = 0,
-	COL_GREEN	   = 1,
+	COL_WHITE		= 0,
+	COL_GREEN		= 1,
 	COL_BLUE		= 2,
 	COL_CYAN		= 3,
-	COL_RED		 = 4,
-	COL_YELLOW	  = 5,
-	COL_MAGENTA	 = 6,
-	COL_USERDEFINED = 7,
-	COL_BLACK	   = 8,
-	COL_TRANSPARENT = 9
+	COL_RED			= 4,
+	COL_YELLOW		= 5,
+	COL_MAGENTA		= 6,
+	COL_USERDEFINED	= 7,
+	COL_BLACK		= 8,
+	COL_TRANSPARENT	= 9
 } scc_color_code_t;
 
 enum font_bits
 {
 	FONT_REGULAR				= 0,
-	FONT_ITALIC				 = 1,
-	FONT_UNDERLINED			 = 2,
-	FONT_UNDERLINED_ITALIC	  = 3,
-	FONT_BOLD				   = 4,
+	FONT_ITALIC					= 1,
+	FONT_UNDERLINED				= 2,
+	FONT_UNDERLINED_ITALIC		= 3,
+	FONT_BOLD					= 4,
 	FONT_BOLD_ITALIC			= 5,
 	FONT_BOLD_UNDERLINED		= 6,
-	FONT_BOLD_UNDERLINED_ITALIC = 7
+	FONT_BOLD_UNDERLINED_ITALIC	= 7
 };
 
 enum command_code
 {
-	COM_UNKNOWN = 0,
-	COM_ERASEDISPLAYEDMEMORY = 1,
-	COM_RESUMECAPTIONLOADING = 2,
-	COM_ENDOFCAPTION = 3,
-	COM_TABOFFSET1 = 4,
-	COM_TABOFFSET2 = 5,
-	COM_TABOFFSET3 = 6,
-	COM_ROLLUP2 = 7,
-	COM_ROLLUP3 = 8,
-	COM_ROLLUP4 = 9,
-	COM_CARRIAGERETURN = 10,
-	COM_ERASENONDISPLAYEDMEMORY = 11,
-	COM_BACKSPACE = 12,
-	COM_RESUMETEXTDISPLAY = 13,
-	COM_ALARMOFF =14,
-	COM_ALARMON = 15,
-	COM_DELETETOENDOFROW = 16,
-	COM_RESUMEDIRECTCAPTIONING = 17,
-	COM_FLASHON = 18
+	COM_UNKNOWN					= 0,
+	COM_ERASEDISPLAYEDMEMORY	= 1,
+	COM_RESUMECAPTIONLOADING	= 2,
+	COM_ENDOFCAPTION			= 3,
+	COM_TABOFFSET1				= 4,
+	COM_TABOFFSET2				= 5,
+	COM_TABOFFSET3				= 6,
+	COM_ROLLUP2					= 7,
+	COM_ROLLUP3					= 8,
+	COM_ROLLUP4					= 9,
+	COM_CARRIAGERETURN			= 10,
+	COM_ERASENONDISPLAYEDMEMORY	= 11,
+	COM_BACKSPACE				= 12,
+	COM_RESUMETEXTDISPLAY		= 13,
+	COM_ALARMOFF				= 14,
+	COM_ALARMON					= 15,
+	COM_DELETETOENDOFROW		= 16,
+	COM_RESUMEDIRECTCAPTIONING	= 17,
+	COM_FLASHON					= 18
 };
 
 #endif //__SCC_FORMAT_H__

--- a/vod/subtitle/scc_format.h
+++ b/vod/subtitle/scc_format.h
@@ -35,7 +35,8 @@ enum cc_text_done
  * scc_event corresponds to a single Dialogue line;
  * text is stored as-is, style overrides gets applied later.
  */
-typedef struct scc_event {
+typedef struct scc_event
+{
     unsigned char      characters[15][33]; // Extra char at the end for potential '\n'
     unsigned char      iub       [15][33]; // Right-most bit is Italic flag, bit 1 is Underline, bit 2 is Flash/Bold
              char      row_used  [15];     // Any data in row?
@@ -52,7 +53,8 @@ typedef struct scc_event {
  * scc_track represents a fully parsed SCC file.
  * It is entirely parsed before events are rendered into WebVTT cues.
  */
-typedef struct scc_track {
+typedef struct scc_track
+{
     long long       max_duration;          // ms, added for needs of the vod-module
     long long       initial_offset;        // ms, sometimes Broadcast shift the cues by some 59 minutes relative to video
     int             max_frame_count;       // to identify FPS without external information

--- a/vod/subtitle/scc_format.h
+++ b/vod/subtitle/scc_format.h
@@ -10,15 +10,15 @@
 #define VALIGN_CENTER 8
 #define VALIGN_TOP 4
 
-#define SCC_608_SCREEN_WIDTH          32
-#define SCC_NUM_OF_STYLES_INSERTED    10
-#define SCC_UNUSED_CHAR               0
-#define SCC_MAX_LONG_LONG             0xefffffffLL
-#define SCC_THRESH_LONG_LONG          (55*60*1000)
+#define SCC_608_SCREEN_WIDTH		  32
+#define SCC_NUM_OF_STYLES_INSERTED	10
+#define SCC_UNUSED_CHAR			   0
+#define SCC_MAX_LONG_LONG			 0xefffffffLL
+#define SCC_THRESH_LONG_LONG		  (55*60*1000)
 
-#define SCC_MAX_CUE_DURATION_MSEC     3000
-#define SCC_MIN_CUE_DURATION_MSEC     1000
-#define SCC_MIN_INTER_CUE_DUR_MSEC    100
+#define SCC_MAX_CUE_DURATION_MSEC	 3000
+#define SCC_MIN_CUE_DURATION_MSEC	 1000
+#define SCC_MIN_INTER_CUE_DUR_MSEC	100
 #define SCC_OFFSET_FOR_SHORTER_LEAD   1000
 
 
@@ -27,8 +27,8 @@ extern media_format_t scc_format;
 
 enum cc_text_done
 {
-    EVENT_TEXT_OPEN = 0,
-    EVENT_TEXT_DONE = 1
+	EVENT_TEXT_OPEN = 0,
+	EVENT_TEXT_DONE = 1
 };
 
 /*
@@ -37,16 +37,16 @@ enum cc_text_done
  */
 typedef struct scc_event
 {
-    unsigned char      characters[15][33]; // Extra char at the end for potential '\n'
-    unsigned char      iub       [15][33]; // Right-most bit is Italic flag, bit 1 is Underline, bit 2 is Flash/Bold
-             char      row_used  [15];     // Any data in row?
-    unsigned char      color;
-    unsigned char      bk_color;
-    int                len_text;           // number of visible characters added to this screen
-    enum cc_text_done  event_text_done;    // when set to EVENT_TEXT_DONE, no further text is added. EOC was received already.
+	unsigned char	  characters[15][33]; // Extra char at the end for potential '\n'
+	unsigned char	  iub	   [15][33]; // Right-most bit is Italic flag, bit 1 is Underline, bit 2 is Flash/Bold
+			 char	  row_used  [15];	 // Any data in row?
+	unsigned char	  color;
+	unsigned char	  bk_color;
+	int				len_text;		   // number of visible characters added to this screen
+	enum cc_text_done  event_text_done;	// when set to EVENT_TEXT_DONE, no further text is added. EOC was received already.
 
-    long long          start_time;         // ms
-    long long          end_time;           // ms
+	long long		  start_time;		 // ms
+	long long		  end_time;		   // ms
 } scc_event_t;
 
 /*
@@ -55,78 +55,78 @@ typedef struct scc_event
  */
 typedef struct scc_track
 {
-    long long       max_duration;          // ms, added for needs of the vod-module
-    long long       initial_offset;        // ms, sometimes Broadcast shift the cues by some 59 minutes relative to video
-    int             max_frame_count;       // to identify FPS without external information
+	long long	   max_duration;		  // ms, added for needs of the vod-module
+	long long	   initial_offset;		// ms, sometimes Broadcast shift the cues by some 59 minutes relative to video
+	int			 max_frame_count;	   // to identify FPS without external information
 
-    int             n_events;
-    int             max_events;
-    scc_event_t    *events;
+	int			 n_events;
+	int			 max_events;
+	scc_event_t	*events;
 
-    long long       cue_time;             // ms
-    int             cursor_row, cursor_column;
-    unsigned char   last_c1, last_c2;
-    unsigned char   current_color;        // Color we are currently using to write
-    unsigned char   current_bk_color;     // Background color we are currently using to write
-    unsigned char   current_iub;          // Current flag values. RMS bit is Italic flag, bit 1 is Underline, bit 2 is Flash/Bold
+	long long	   cue_time;			 // ms
+	int			 cursor_row, cursor_column;
+	unsigned char   last_c1, last_c2;
+	unsigned char   current_color;		// Color we are currently using to write
+	unsigned char   current_bk_color;	 // Background color we are currently using to write
+	unsigned char   current_iub;		  // Current flag values. RMS bit is Italic flag, bit 1 is Underline, bit 2 is Flash/Bold
 } scc_track_t;
 
 scc_track_t *scc_parse_memory(char *data, int length, request_context_t* request_context);
 
 enum scc_alignment
 {
-    SCC_ALIGN_CENTER = 0,
-    SCC_ALIGN_LEFT   = 1,
-    SCC_ALIGN_RIGHT  = 2
+	SCC_ALIGN_CENTER = 0,
+	SCC_ALIGN_LEFT   = 1,
+	SCC_ALIGN_RIGHT  = 2
 } scc_alignment_t;
 
 enum scc_color_code
 {
-    COL_WHITE       = 0,
-    COL_GREEN       = 1,
-    COL_BLUE        = 2,
-    COL_CYAN        = 3,
-    COL_RED         = 4,
-    COL_YELLOW      = 5,
-    COL_MAGENTA     = 6,
-    COL_USERDEFINED = 7,
-    COL_BLACK       = 8,
-    COL_TRANSPARENT = 9
+	COL_WHITE	   = 0,
+	COL_GREEN	   = 1,
+	COL_BLUE		= 2,
+	COL_CYAN		= 3,
+	COL_RED		 = 4,
+	COL_YELLOW	  = 5,
+	COL_MAGENTA	 = 6,
+	COL_USERDEFINED = 7,
+	COL_BLACK	   = 8,
+	COL_TRANSPARENT = 9
 } scc_color_code_t;
 
 enum font_bits
 {
-    FONT_REGULAR                = 0,
-    FONT_ITALIC                 = 1,
-    FONT_UNDERLINED             = 2,
-    FONT_UNDERLINED_ITALIC      = 3,
-    FONT_BOLD                   = 4,
-    FONT_BOLD_ITALIC            = 5,
-    FONT_BOLD_UNDERLINED        = 6,
-    FONT_BOLD_UNDERLINED_ITALIC = 7
+	FONT_REGULAR				= 0,
+	FONT_ITALIC				 = 1,
+	FONT_UNDERLINED			 = 2,
+	FONT_UNDERLINED_ITALIC	  = 3,
+	FONT_BOLD				   = 4,
+	FONT_BOLD_ITALIC			= 5,
+	FONT_BOLD_UNDERLINED		= 6,
+	FONT_BOLD_UNDERLINED_ITALIC = 7
 };
 
 enum command_code
 {
-    COM_UNKNOWN = 0,
-    COM_ERASEDISPLAYEDMEMORY = 1,
-    COM_RESUMECAPTIONLOADING = 2,
-    COM_ENDOFCAPTION = 3,
-    COM_TABOFFSET1 = 4,
-    COM_TABOFFSET2 = 5,
-    COM_TABOFFSET3 = 6,
-    COM_ROLLUP2 = 7,
-    COM_ROLLUP3 = 8,
-    COM_ROLLUP4 = 9,
-    COM_CARRIAGERETURN = 10,
-    COM_ERASENONDISPLAYEDMEMORY = 11,
-    COM_BACKSPACE = 12,
-    COM_RESUMETEXTDISPLAY = 13,
-    COM_ALARMOFF =14,
-    COM_ALARMON = 15,
-    COM_DELETETOENDOFROW = 16,
-    COM_RESUMEDIRECTCAPTIONING = 17,
-    COM_FLASHON = 18
+	COM_UNKNOWN = 0,
+	COM_ERASEDISPLAYEDMEMORY = 1,
+	COM_RESUMECAPTIONLOADING = 2,
+	COM_ENDOFCAPTION = 3,
+	COM_TABOFFSET1 = 4,
+	COM_TABOFFSET2 = 5,
+	COM_TABOFFSET3 = 6,
+	COM_ROLLUP2 = 7,
+	COM_ROLLUP3 = 8,
+	COM_ROLLUP4 = 9,
+	COM_CARRIAGERETURN = 10,
+	COM_ERASENONDISPLAYEDMEMORY = 11,
+	COM_BACKSPACE = 12,
+	COM_RESUMETEXTDISPLAY = 13,
+	COM_ALARMOFF =14,
+	COM_ALARMON = 15,
+	COM_DELETETOENDOFROW = 16,
+	COM_RESUMEDIRECTCAPTIONING = 17,
+	COM_FLASHON = 18
 };
 
 #endif //__SCC_FORMAT_H__

--- a/vod/subtitle/scc_parse.c
+++ b/vod/subtitle/scc_parse.c
@@ -22,38 +22,38 @@ static const int rowdata[] = {11,-1,1,2,3,4,12,13,14,15,5,6,7,8,9,10};
 
 static const unsigned char pac2_attribs[][3] = // Color, font, indent
 {
-	{ COL_WHITE,   FONT_REGULAR,           0 }, // 0x40 || 0x60
-	{ COL_WHITE,   FONT_UNDERLINED,        0 }, // 0x41 || 0x61
-	{ COL_GREEN,   FONT_REGULAR,           0 }, // 0x42 || 0x62
-	{ COL_GREEN,   FONT_UNDERLINED,        0 }, // 0x43 || 0x63
-	{ COL_BLUE,    FONT_REGULAR,           0 }, // 0x44 || 0x64
-	{ COL_BLUE,    FONT_UNDERLINED,        0 }, // 0x45 || 0x65
-	{ COL_CYAN,    FONT_REGULAR,           0 }, // 0x46 || 0x66
-	{ COL_CYAN,    FONT_UNDERLINED,        0 }, // 0x47 || 0x67
-	{ COL_RED,     FONT_REGULAR,           0 }, // 0x48 || 0x68
-	{ COL_RED,     FONT_UNDERLINED,        0 }, // 0x49 || 0x69
-	{ COL_YELLOW,  FONT_REGULAR,           0 }, // 0x4a || 0x6a
-	{ COL_YELLOW,  FONT_UNDERLINED,        0 }, // 0x4b || 0x6b
-	{ COL_MAGENTA, FONT_REGULAR,           0 }, // 0x4c || 0x6c
-	{ COL_MAGENTA, FONT_UNDERLINED,        0 }, // 0x4d || 0x6d
-	{ COL_WHITE,   FONT_ITALIC,            0 }, // 0x4e || 0x6e
-	{ COL_WHITE,   FONT_UNDERLINED_ITALIC, 0 }, // 0x4f || 0x6f
-	{ COL_WHITE,   FONT_REGULAR,           0 }, // 0x50 || 0x70
-	{ COL_WHITE,   FONT_UNDERLINED,        0 }, // 0x51 || 0x71
-	{ COL_WHITE,   FONT_REGULAR,           4 }, // 0x52 || 0x72
-	{ COL_WHITE,   FONT_UNDERLINED,        4 }, // 0x53 || 0x73
-	{ COL_WHITE,   FONT_REGULAR,           8 }, // 0x54 || 0x74
-	{ COL_WHITE,   FONT_UNDERLINED,        8 }, // 0x55 || 0x75
-	{ COL_WHITE,   FONT_REGULAR,          12 }, // 0x56 || 0x76
-	{ COL_WHITE,   FONT_UNDERLINED,       12 }, // 0x57 || 0x77
-	{ COL_WHITE,   FONT_REGULAR,          16 }, // 0x58 || 0x78
-	{ COL_WHITE,   FONT_UNDERLINED,       16 }, // 0x59 || 0x79
-	{ COL_WHITE,   FONT_REGULAR,          20 }, // 0x5a || 0x7a
-	{ COL_WHITE,   FONT_UNDERLINED,       20 }, // 0x5b || 0x7b
-	{ COL_WHITE,   FONT_REGULAR,          24 }, // 0x5c || 0x7c
-	{ COL_WHITE,   FONT_UNDERLINED,       24 }, // 0x5d || 0x7d
-	{ COL_WHITE,   FONT_REGULAR,          28 }, // 0x5e || 0x7e
-	{ COL_WHITE,   FONT_UNDERLINED,       28 }  // 0x5f || 0x7f
+	{ COL_WHITE,	FONT_REGULAR,			 0 }, // 0x40 || 0x60
+	{ COL_WHITE,	FONT_UNDERLINED,		 0 }, // 0x41 || 0x61
+	{ COL_GREEN,	FONT_REGULAR,			 0 }, // 0x42 || 0x62
+	{ COL_GREEN,	FONT_UNDERLINED,		 0 }, // 0x43 || 0x63
+	{ COL_BLUE,		FONT_REGULAR,			 0 }, // 0x44 || 0x64
+	{ COL_BLUE,		FONT_UNDERLINED,		 0 }, // 0x45 || 0x65
+	{ COL_CYAN,		FONT_REGULAR,			 0 }, // 0x46 || 0x66
+	{ COL_CYAN,		FONT_UNDERLINED,		 0 }, // 0x47 || 0x67
+	{ COL_RED,		FONT_REGULAR,			 0 }, // 0x48 || 0x68
+	{ COL_RED,		FONT_UNDERLINED,		 0 }, // 0x49 || 0x69
+	{ COL_YELLOW,	FONT_REGULAR,			 0 }, // 0x4a || 0x6a
+	{ COL_YELLOW,	FONT_UNDERLINED,		 0 }, // 0x4b || 0x6b
+	{ COL_MAGENTA,	FONT_REGULAR,			 0 }, // 0x4c || 0x6c
+	{ COL_MAGENTA,	FONT_UNDERLINED,		 0 }, // 0x4d || 0x6d
+	{ COL_WHITE,	FONT_ITALIC,			 0 }, // 0x4e || 0x6e
+	{ COL_WHITE,	FONT_UNDERLINED_ITALIC,	 0 }, // 0x4f || 0x6f
+	{ COL_WHITE,	FONT_REGULAR,			 0 }, // 0x50 || 0x70
+	{ COL_WHITE,	FONT_UNDERLINED,		 0 }, // 0x51 || 0x71
+	{ COL_WHITE,	FONT_REGULAR,			 4 }, // 0x52 || 0x72
+	{ COL_WHITE,	FONT_UNDERLINED,		 4 }, // 0x53 || 0x73
+	{ COL_WHITE,	FONT_REGULAR,			 8 }, // 0x54 || 0x74
+	{ COL_WHITE,	FONT_UNDERLINED,		 8 }, // 0x55 || 0x75
+	{ COL_WHITE,	FONT_REGULAR,			12 }, // 0x56 || 0x76
+	{ COL_WHITE,	FONT_UNDERLINED,		12 }, // 0x57 || 0x77
+	{ COL_WHITE,	FONT_REGULAR,			16 }, // 0x58 || 0x78
+	{ COL_WHITE,	FONT_UNDERLINED,		16 }, // 0x59 || 0x79
+	{ COL_WHITE,	FONT_REGULAR,			20 }, // 0x5a || 0x7a
+	{ COL_WHITE,	FONT_UNDERLINED,		20 }, // 0x5b || 0x7b
+	{ COL_WHITE,	FONT_REGULAR,			24 }, // 0x5c || 0x7c
+	{ COL_WHITE,	FONT_UNDERLINED,		24 }, // 0x5d || 0x7d
+	{ COL_WHITE,	FONT_REGULAR,			28 }, // 0x5e || 0x7e
+	{ COL_WHITE,	FONT_UNDERLINED,		28 }  // 0x5f || 0x7f
 };
 
 #ifdef SCC_TEMP_VERBOSITY
@@ -95,161 +95,161 @@ static const char *font_text[] =
 #define MAX_COLOR 10
 static const char *color_text[MAX_COLOR][2] =
 {
-	{"white",""},
-	{"green","<font color=\"#00ff00\">"},
-	{"blue","<font color=\"#0000ff\">"},
-	{"cyan","<font color=\"#00ffff\">"},
-	{"red","<font color=\"#ff0000\">"},
-	{"yellow","<font color=\"#ffff00\">"},
-	{"magenta","<font color=\"#ff00ff\">"},
-	{"userdefined","<font color=\""},
-	{"black",""},
-	{"transparent",""}
+	{"white",		""},
+	{"green",		"<font color=\"#00ff00\">"},
+	{"blue",		"<font color=\"#0000ff\">"},
+	{"cyan",		"<font color=\"#00ffff\">"},
+	{"red",			"<font color=\"#ff0000\">"},
+	{"yellow",		"<font color=\"#ffff00\">"},
+	{"magenta",		"<font color=\"#ff00ff\">"},
+	{"userdefined",	"<font color=\""},
+	{"black",		""},
+	{"transparent",	""}
 };
 #endif
 
 scc_event_t *get_writing_buffer(scc_track_t *track, request_context_t* request_context)
 {
-    if (track->n_events > 0)
-        return (track->events + (track->n_events - 1)); // currently open event
-    else
-	    return NULL;
+	if (track->n_events > 0)
+		return (track->events + (track->n_events - 1)); // currently open event
+	else
+		return NULL;
 }
 
 
 scc_event_t *scc_alloc_event(scc_track_t *track)
 {
-    if (track->n_events == track->max_events) {
-        track->max_events = track->max_events * 2 + 1; // keep the +1 for the case max_events is init to 0
-        track->events =
-            (scc_event_t *) realloc(track->events,
-                                    sizeof(scc_event_t) *
-                                    track->max_events);
-    }
+	if (track->n_events == track->max_events) {
+		track->max_events = track->max_events * 2 + 1; // keep the +1 for the case max_events is init to 0
+		track->events =
+			(scc_event_t *) realloc(track->events,
+									sizeof(scc_event_t) *
+									track->max_events);
+	}
 
-    int eid = track->n_events++;
-    return (track->events + eid);
+	int eid = track->n_events++;
+	return (track->events + eid);
 }
 scc_event_t *new_event(scc_track_t *track, request_context_t* request_context)
 {
-    scc_event_t *event = scc_alloc_event(track);
+	scc_event_t *event = scc_alloc_event(track);
 
-    if (event == NULL)
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "FAILED TO ALLOC EVENT. nevents=%d", track->n_events);
-        return NULL;
-    }
+	if (event == NULL)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"FAILED TO ALLOC EVENT. nevents=%d", track->n_events);
+		return NULL;
+	}
 
-    int i;
+	int i;
 	for (i = 0;i < 15;i++)
 	{
 		memset(event->characters[i], 0, SCC_608_SCREEN_WIDTH+1);
-		memset(event->iub[i],        0, SCC_608_SCREEN_WIDTH+1);
+		memset(event->iub[i],		0, SCC_608_SCREEN_WIDTH+1);
 		event->row_used[i] = 0;
 	}
-	event->color           = COL_WHITE;
-	event->bk_color        = COL_CYAN;
-	event->len_text        = 0;
+	event->color		   = COL_WHITE;
+	event->bk_color		= COL_CYAN;
+	event->len_text		= 0;
 	event->event_text_done = EVENT_TEXT_OPEN;
-	event->start_time      = event->end_time
-	                       = track->cue_time;
+	event->start_time	  = event->end_time
+						   = track->cue_time;
 	return event;
 }
 
 /* Process PREAMBLE ACCESS CODES (PAC) */
 void handle_pac(unsigned char c1, unsigned char c2, scc_track_t *track, request_context_t* request_context)
 {
-    int row = rowdata[((c1<<1)&14)|((c2>>5)&1)];
+	int row = rowdata[((c1<<1)&14)|((c2>>5)&1)];
 
-    if (c2 >= 0x40 && c2 <= 0x5f)
-    {
-        c2 = c2-0x40;
-    }
-    else
-    {
-        if (c2 >= 0x60 && c2 <= 0x7f)
-        {
-            c2 = c2-0x60;
-        }
-        else
-        {
-            vod_log_error(VOD_LOG_ERR, request_context->log, 0, "THIS IS NOT A PAC");
-            return;
-        }
-    }
+	if (c2 >= 0x40 && c2 <= 0x5f)
+	{
+		c2 = c2-0x40;
+	}
+	else
+	{
+		if (c2 >= 0x60 && c2 <= 0x7f)
+		{
+			c2 = c2-0x60;
+		}
+		else
+		{
+			vod_log_error(VOD_LOG_ERR, request_context->log, 0, "THIS IS NOT A PAC");
+			return;
+		}
+	}
 
-    int           new_cursor_row = row - 1; // Since the array is 0 based
-    int           new_cursor_col = pac2_attribs[c2][2];
-    unsigned char new_color      = pac2_attribs[c2][0];
-    unsigned char new_bk_color   = COL_CYAN;    // TODO: read from PACs
-    scc_event_t * event = get_writing_buffer(track, request_context);
+	int		   new_cursor_row	= row - 1; // Since the array is 0 based
+	int		   new_cursor_col	= pac2_attribs[c2][2];
+	unsigned char new_color		= pac2_attribs[c2][0];
+	unsigned char new_bk_color	= COL_CYAN;	// TODO: read from PACs
+	scc_event_t * event			= get_writing_buffer(track, request_context);
 
 #ifdef SCC_TEMP_VERBOSITY
-    vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-        "handle_pac() c1=%d, c2=%d, new_cursor_row=%d, track_cursor_row=%d, new_col=%d, track_cursor_col=%d, new_color=%d, track_color=%d",
-        c1, c2, new_cursor_row, track->cursor_row, new_cursor_col, track->cursor_column, new_color, track->current_color);
+	vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+		"handle_pac() c1=%d, c2=%d, new_cursor_row=%d, track_cursor_row=%d, new_col=%d, track_cursor_col=%d, new_color=%d, track_color=%d",
+		c1, c2, new_cursor_row, track->cursor_row, new_cursor_col, track->cursor_column, new_color, track->current_color);
 #endif
 
-    if (((new_cursor_row != track->cursor_row) && (new_cursor_row  != (track->cursor_row+1)))  ||
-        new_color        != track->current_color    ||
-        new_bk_color     != track->current_bk_color ||
-        (track->n_events == 0)                      ||
-        (event != NULL	&&  event->event_text_done == EVENT_TEXT_DONE))
-    {
-        // close previous event, open new one so we store them as 2 separate text cues with different positions
-        if (event != NULL && event->event_text_done == EVENT_TEXT_OPEN)
-        {
-            // close last event text against further writing
-            event->event_text_done = EVENT_TEXT_DONE;
-        }
+	if (((new_cursor_row != track->cursor_row) && (new_cursor_row  != (track->cursor_row+1)))  ||
+		new_color		!= track->current_color	||
+		new_bk_color	 != track->current_bk_color ||
+		(track->n_events == 0)					  ||
+		(event != NULL	&&  event->event_text_done == EVENT_TEXT_DONE))
+	{
+		// close previous event, open new one so we store them as 2 separate text cues with different positions
+		if (event != NULL && event->event_text_done == EVENT_TEXT_OPEN)
+		{
+			// close last event text against further writing
+			event->event_text_done = EVENT_TEXT_DONE;
+		}
 
-        track->cursor_row           = new_cursor_row;
-        track->cursor_column        = new_cursor_col;
-        track->current_color        = new_color;
-        track->current_bk_color     = new_bk_color;
-        track->current_iub          = 0;
-        event = new_event(track, request_context);
-    }
+		track->cursor_row		   = new_cursor_row;
+		track->cursor_column		= new_cursor_col;
+		track->current_color		= new_color;
+		track->current_bk_color	 = new_bk_color;
+		track->current_iub		  = 0;
+		event = new_event(track, request_context);
+	}
 
-    if ((new_cursor_col !=  track->cursor_column   )     &&
-        (new_cursor_col != (track->cursor_column+1))     &&
-        (new_cursor_row == (track->cursor_row+1   )))
-    {
-        // new line in the same event, just insert new line in index 32, and update the track values
-        event->characters[track->cursor_row][SCC_608_SCREEN_WIDTH] = '\n';
-        event->iub       [track->cursor_row][SCC_608_SCREEN_WIDTH] = track->current_iub;
-        track->cursor_row           = new_cursor_row;
-        track->cursor_column        = new_cursor_col;
-    }
+	if ((new_cursor_col !=  track->cursor_column   )	 &&
+		(new_cursor_col != (track->cursor_column+1))	 &&
+		(new_cursor_row == (track->cursor_row+1   )))
+	{
+		// new line in the same event, just insert new line in index 32, and update the track values
+		event->characters[track->cursor_row][SCC_608_SCREEN_WIDTH] = '\n';
+		event->iub	   [track->cursor_row][SCC_608_SCREEN_WIDTH] = track->current_iub;
+		track->cursor_row		   = new_cursor_row;
+		track->cursor_column		= new_cursor_col;
+	}
 
-    // now that newline was added, update the track's italic/underline/bold
-    track->current_iub =  ((pac2_attribs[c2][1] == FONT_ITALIC)     || (pac2_attribs[c2][1] == FONT_UNDERLINED_ITALIC))       |
-                         (((pac2_attribs[c2][1] == FONT_UNDERLINED) || (pac2_attribs[c2][1] == FONT_UNDERLINED_ITALIC)) << 1) |
-                         (track->current_iub & 4);
+	// now that newline was added, update the track's italic/underline/bold
+	track->current_iub =  ((pac2_attribs[c2][1] == FONT_ITALIC)	 || (pac2_attribs[c2][1] == FONT_UNDERLINED_ITALIC))	   |
+						 (((pac2_attribs[c2][1] == FONT_UNDERLINED) || (pac2_attribs[c2][1] == FONT_UNDERLINED_ITALIC)) << 1) |
+						 (track->current_iub & 4);
 
 #ifdef SCC_TEMP_VERBOSITY
-    vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-        "handle_pac: %d %d  nevents=%d, trackrow=%d, col=%d, color=%d, iub=%d",
-        c1, c2, track->n_events, track->cursor_row, track->cursor_column, track->current_color, track->current_iub);
+	vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+		"handle_pac: %d %d  nevents=%d, trackrow=%d, col=%d, color=%d, iub=%d",
+		c1, c2, track->n_events, track->cursor_row, track->cursor_column, track->current_color, track->current_iub);
 #endif
 }
 
 void write_char(const unsigned char c, scc_track_t *track, request_context_t* request_context)
 {
-    scc_event_t *event = get_writing_buffer(track, request_context);
-    if (event == NULL || event->event_text_done == EVENT_TEXT_DONE)
-        return; // do nothing
-    else
-    {
-        event->characters[track->cursor_row][track->cursor_column] = c;
-        event->iub       [track->cursor_row][track->cursor_column] = track->current_iub;
-        event->row_used[track->cursor_row] = 1;
-        event->len_text++;
-    }
+	scc_event_t *event = get_writing_buffer(track, request_context);
+	if (event == NULL || event->event_text_done == EVENT_TEXT_DONE)
+		return; // do nothing
+	else
+	{
+		event->characters[track->cursor_row][track->cursor_column] = c;
+		event->iub	   [track->cursor_row][track->cursor_column] = track->current_iub;
+		event->row_used[track->cursor_row] = 1;
+		event->len_text++;
+	}
 
-    if (track->cursor_column < SCC_608_SCREEN_WIDTH - 1)
-        track->cursor_column++;
+	if (track->cursor_column < SCC_608_SCREEN_WIDTH - 1)
+		track->cursor_column++;
 }
 
 /* Handle MID-ROW CODES. */
@@ -262,11 +262,11 @@ void handle_text_attr(const unsigned char c1, const unsigned char c2, scc_track_
 	else
 	{
 		int i = c2-0x20;
-		track->current_color     = pac2_attribs[i][0];
+		track->current_color	 = pac2_attribs[i][0];
 		track->current_bk_color  = COL_CYAN;
 		// Mid-row codes turn flashing off, so we reset bit 2 in the track's iub bit field
-		track->current_iub       =  ((pac2_attribs[i][1] == FONT_ITALIC)     || (pac2_attribs[i][1] == FONT_UNDERLINED_ITALIC))      |
-		                           (((pac2_attribs[i][1] == FONT_UNDERLINED) || (pac2_attribs[i][1] == FONT_UNDERLINED_ITALIC)) << 1);
+		track->current_iub	   =  ((pac2_attribs[i][1] == FONT_ITALIC)	 || (pac2_attribs[i][1] == FONT_UNDERLINED_ITALIC))	  |
+								   (((pac2_attribs[i][1] == FONT_UNDERLINED) || (pac2_attribs[i][1] == FONT_UNDERLINED_ITALIC)) << 1);
 #ifdef SCC_TEMP_VERBOSITY
 		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
 			"handle_text_attr() --  Color: %s,  iub: %s",
@@ -317,7 +317,7 @@ unsigned char handle_extended(unsigned char hi, unsigned char lo, scc_track_t *t
 		// the previous character (which is sent for basic decoders
 		// to show something similar to the real char)
 		//if (track->cursor_column>0)
-        //    track->cursor_column--;
+		//	track->cursor_column--;
 
 		write_char(c, track, request_context);
 	}
@@ -370,11 +370,11 @@ void handle_command(unsigned char c1, const unsigned char c2, scc_track_t *track
 
 #ifdef SCC_TEMP_VERBOSITY
 	vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-	    "BEGIN{ handle_command(): %0d %0d (%s), Position=%d,%d  n_events=%d",
-	    c1, c2, command_type[command], track->cursor_row, track->cursor_column, track->n_events);
+		"BEGIN{ handle_command(): %0d %0d (%s), Position=%d,%d  n_events=%d",
+		c1, c2, command_type[command], track->cursor_row, track->cursor_column, track->n_events);
 #endif
 
-    scc_event_t * event = get_writing_buffer(track, request_context);
+	scc_event_t * event = get_writing_buffer(track, request_context);
 	switch (command)
 	{
 		case COM_BACKSPACE:
@@ -400,39 +400,39 @@ void handle_command(unsigned char c1, const unsigned char c2, scc_track_t *track
 			break;
 		case COM_RESUMECAPTIONLOADING:
 		case COM_RESUMEDIRECTCAPTIONING:
-		    if (event != NULL && event->event_text_done == EVENT_TEXT_OPEN)
-		    {
-		        // close last event if not done
-		        event->event_text_done = EVENT_TEXT_DONE;
-            }
+			if (event != NULL && event->event_text_done == EVENT_TEXT_OPEN)
+			{
+				// close last event if not done
+				event->event_text_done = EVENT_TEXT_DONE;
+			}
 			break;
 		case COM_CARRIAGERETURN:
-            track->cursor_column = 0;
-            if (track->cursor_row < 15)
-                track->cursor_row++;
-            break;
+			track->cursor_column = 0;
+			if (track->cursor_row < 15)
+				track->cursor_row++;
+			break;
 		case COM_ERASEDISPLAYEDMEMORY:
-		    if (event != NULL && event->event_text_done == EVENT_TEXT_OPEN)
-		    {
-		        // close last event if not done
-		        event->event_text_done = EVENT_TEXT_DONE;
-            }
-            track->cursor_row        = track->cursor_column = 0;
-            track->current_color     = COL_WHITE;
-            track->current_bk_color  = COL_CYAN;
-            track->current_iub       = 0;
+			if (event != NULL && event->event_text_done == EVENT_TEXT_OPEN)
+			{
+				// close last event if not done
+				event->event_text_done = EVENT_TEXT_DONE;
+			}
+			track->cursor_row		= track->cursor_column = 0;
+			track->current_color	 = COL_WHITE;
+			track->current_bk_color  = COL_CYAN;
+			track->current_iub	   = 0;
 			break;
 		case COM_ENDOFCAPTION:
-		    if (event != NULL && event->event_text_done == EVENT_TEXT_OPEN)
-		    {
-		        // close last event if not done
-		        event->event_text_done = EVENT_TEXT_DONE;
-            }
-		    // TODO: make sure you check this flag when writing char
+			if (event != NULL && event->event_text_done == EVENT_TEXT_OPEN)
+			{
+				// close last event if not done
+				event->event_text_done = EVENT_TEXT_DONE;
+			}
+			// TODO: make sure you check this flag when writing char
 			break;
 		case COM_FLASHON:
-		    track->current_iub |= 4;
-		    break;
+			track->current_iub |= 4;
+			break;
 		case COM_DELETETOENDOFROW:
 		case COM_ROLLUP2:
 		case COM_ROLLUP3:
@@ -459,59 +459,59 @@ void handle_command(unsigned char c1, const unsigned char c2, scc_track_t *track
 void disCommand(unsigned char hi, unsigned char lo, scc_track_t *track, request_context_t* request_context)
 {
 #ifdef SCC_TEMP_VERBOSITY
-    vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-        "disCommand(): hi = %d, lo = %d", hi, lo);
+	vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+		"disCommand(): hi = %d, lo = %d", hi, lo);
 #endif
 
-        // Treat Ch 2,4 as Ch 1,3 respectively
+		// Treat Ch 2,4 as Ch 1,3 respectively
 	if (hi >= 0x18 && hi <= 0x1f)
-            hi=hi-8;
+			hi=hi-8;
 	// Treat Ch 3 as Ch 1 in Global codes and {BS, DER, CR}.
-        if (hi == 0x15 && lo >= 0x20 && lo <= 0x2f)
-            hi--;
+		if (hi == 0x15 && lo >= 0x20 && lo <= 0x2f)
+			hi--;
 
 	switch (hi)
 	{
 		case 0x10:
-			if (lo >= 0x40 && lo <= 0x5f)                                // row 11 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x5f)								// row 11 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 		case 0x11:
-			if (lo >= 0x20 && lo <= 0x2f)                                // mid-row color/underline PAC (ch 1&3)
+			if (lo >= 0x20 && lo <= 0x2f)								// mid-row color/underline PAC (ch 1&3)
 				handle_text_attr(hi, lo, track, request_context);
-			if (lo >= 0x30 && lo <= 0x3f)                                // Special Characters
+			if (lo >= 0x30 && lo <= 0x3f)								// Special Characters
 			{
 				handle_special_doublebytes(hi, lo, track, request_context);
 			}
-			if (lo >= 0x40 && lo <= 0x7f)                                // rows 01/02 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x7f)								// rows 01/02 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 		case 0x12:
 		case 0x13:
-			if (lo >= 0x20 && lo <= 0x3f)                                // Extended Characters
+			if (lo >= 0x20 && lo <= 0x3f)								// Extended Characters
 			{
 				handle_extended(hi, lo, track, request_context);
 			}
-			if (lo >= 0x40 && lo <= 0x7f)                                // rows 03/04 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x7f)								// rows 03/04 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 		case 0x14:
 		case 0x15:
-			if (lo >= 0x20 && lo <= 0x2f)                                // Global Codes PAC (ch 1&3)
+			if (lo >= 0x20 && lo <= 0x2f)								// Global Codes PAC (ch 1&3)
 				handle_command(hi, lo, track, request_context);
-			if (lo >= 0x40 && lo <= 0x7f)                                // rows 05/06 and 14/15 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x7f)								// rows 05/06 and 14/15 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 		case 0x16:
-			if (lo >= 0x40 && lo <= 0x7f)                                // rows 07/08 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x7f)								// rows 07/08 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 		case 0x17:
-			if (lo >= 0x21 && lo <= 0x23)                                // Tab Offsets 1,2,3 (ch 1&3)
+			if (lo >= 0x21 && lo <= 0x23)								// Tab Offsets 1,2,3 (ch 1&3)
 				handle_command(hi, lo, track, request_context);
-			if (lo >= 0x2e && lo <= 0x2f)                                // mid-row Black and BlackUnderline PAC (ch 1&3)
+			if (lo >= 0x2e && lo <= 0x2f)								// mid-row Black and BlackUnderline PAC (ch 1&3)
 				handle_text_attr(hi, lo, track, request_context);
-			if (lo >= 0x40 && lo <= 0x7f)                                // rows 09/10 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x7f)								// rows 09/10 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 	}
@@ -527,91 +527,91 @@ void disCommand(unsigned char hi, unsigned char lo, scc_track_t *track, request_
 */
 static int scc_process_line(scc_track_t *track, const char *str, request_context_t* request_context)
 {
-    int hr, mn, sc, fr, i, length;
-    //bool_t ndp = FALSE;
+	int hr, mn, sc, fr, i, length;
+	//bool_t ndp = FALSE;
 
-    int res1 = sscanf(str, "%d:%d:%d:%d", &hr, &mn, &sc, &fr);
-    if (res1 != 4)
-    {
-        int res2 = sscanf(str, "%d:%d:%d;%d", &hr, &mn, &sc, &fr);
-        if (res2 != 4)
-            return 0;  // no timing at the start of the line, ignore this line altogether
-        //else
-            //ndp = TRUE;
-    }
-    str+=11;
+	int res1 = sscanf(str, "%d:%d:%d:%d", &hr, &mn, &sc, &fr);
+	if (res1 != 4)
+	{
+		int res2 = sscanf(str, "%d:%d:%d;%d", &hr, &mn, &sc, &fr);
+		if (res2 != 4)
+			return 0;  // no timing at the start of the line, ignore this line altogether
+		//else
+			//ndp = TRUE;
+	}
+	str+=11;
 
-    // sub-second timing is stored in each event as-is. Will be corrected while outputting cue, after whole file is parsed.
-    track->cue_time = fr + (1000 * (sc + 60 * (mn + 60LL * hr)));
+	// sub-second timing is stored in each event as-is. Will be corrected while outputting cue, after whole file is parsed.
+	track->cue_time = fr + (1000 * (sc + 60 * (mn + 60LL * hr)));
 
-    if (track->max_duration    < track->cue_time)
-        track->max_duration    = track->cue_time;
-    if (track->initial_offset  > track->cue_time)
-        track->initial_offset  = track->cue_time;
-    if (track->max_frame_count < fr)
-        track->max_frame_count = fr;
+	if (track->max_duration	< track->cue_time)
+		track->max_duration	= track->cue_time;
+	if (track->initial_offset  > track->cue_time)
+		track->initial_offset  = track->cue_time;
+	if (track->max_frame_count < fr)
+		track->max_frame_count = fr;
 
 	length = vod_strlen(str);
 
 #ifdef SCC_TEMP_VERBOSITY
-    vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-        "line_time= %D, lengthstr=%d, str = %s", track->cue_time, length, str);
+	vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+		"line_time= %D, lengthstr=%d, str = %s", track->cue_time, length, str);
 #endif
 
 
-    for (i = 0; i < length; i += 4)
-    {
-        // code is still in ASCII text, need to convert every 2 consecutive chars to their equivalent hexadecimal digit
-        unsigned char hi, lo;
-        unsigned int fullword;
+	for (i = 0; i < length; i += 4)
+	{
+		// code is still in ASCII text, need to convert every 2 consecutive chars to their equivalent hexadecimal digit
+		unsigned char hi, lo;
+		unsigned int fullword;
 
-        // skip tabs and spaces
-        while ((*(str+i) == ' ') || (*(str+i) == '\t'))
-             i++;
+		// skip tabs and spaces
+		while ((*(str+i) == ' ') || (*(str+i) == '\t'))
+			 i++;
 
-        sscanf(str+i, "%x ", &fullword);
-        hi = (fullword >> 8) & 0x7F; // Get rid of parity bit
-        lo = fullword        & 0x7F; // Get rid of parity bit
-            //vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            //" FULLWORD:%d, hi=%d lo=%d", fullword, hi, lo);
+		sscanf(str+i, "%x ", &fullword);
+		hi = (fullword >> 8) & 0x7F; // Get rid of parity bit
+		lo = fullword		& 0x7F; // Get rid of parity bit
+			//vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			//" FULLWORD:%d, hi=%d lo=%d", fullword, hi, lo);
 
-        if (hi == 0 && lo == 0) // Just padding
-            continue;
+		if (hi == 0 && lo == 0) // Just padding
+			continue;
 
-        if (hi >= 0x10 && hi <= 0x1F) // Non-character code or special/extended char
-        // http://www.theneitherworld.com/mcpoodle/SCC_TOOLS/DOCS/CC_CODES.HTML
-        // http://www.theneitherworld.com/mcpoodle/SCC_TOOLS/DOCS/CC_CHARS.HTML
-        {
-            if (track->last_c1 == hi && track->last_c2 == lo)
-            {
-                // Duplicate dual code, discard. Correct to do it only in
-                // non-XDS, XDS codes shall not be repeated.
-                // Ignore only the first repetition
-                track->last_c1 = -1;
-                track->last_c2 = -1;
-                continue;
-            }
-            track->last_c1 = hi;
-            track->last_c2 = lo;
+		if (hi >= 0x10 && hi <= 0x1F) // Non-character code or special/extended char
+		// http://www.theneitherworld.com/mcpoodle/SCC_TOOLS/DOCS/CC_CODES.HTML
+		// http://www.theneitherworld.com/mcpoodle/SCC_TOOLS/DOCS/CC_CHARS.HTML
+		{
+			if (track->last_c1 == hi && track->last_c2 == lo)
+			{
+				// Duplicate dual code, discard. Correct to do it only in
+				// non-XDS, XDS codes shall not be repeated.
+				// Ignore only the first repetition
+				track->last_c1 = -1;
+				track->last_c2 = -1;
+				continue;
+			}
+			track->last_c1 = hi;
+			track->last_c2 = lo;
 
-            disCommand(hi, lo, track, request_context);
-        }
-        else
-        {
-            track->last_c1 = -1;
-            track->last_c2 = -1;
+			disCommand(hi, lo, track, request_context);
+		}
+		else
+		{
+			track->last_c1 = -1;
+			track->last_c2 = -1;
 
-            if (hi >= 0x20) // Standard characters (always in pairs)
-            {
-                handle_single(hi, track, request_context);
-                handle_single(lo, track, request_context);
+			if (hi >= 0x20) // Standard characters (always in pairs)
+			{
+				handle_single(hi, track, request_context);
+				handle_single(lo, track, request_context);
 
-                track->last_c1 = 0;
-                track->last_c2 = 0;
+				track->last_c1 = 0;
+				track->last_c2 = 0;
 
-            }
-        }
-    } // for
+			}
+		}
+	} // for
 
 	return 0; // Success
 }
@@ -623,94 +623,94 @@ static int scc_process_line(scc_track_t *track, const char *str, request_context
 */
 static int scc_process_text(scc_track_t *track, char *str, request_context_t* request_context)
 {
-    int retval = 0;
-    char *p = str;
+	int retval = 0;
+	char *p = str;
 
-    while (1)
-    {
-        char *q;
-        while (1)
-        {
-            if ((*p == '\r') || (*p == '\n'))
-                ++p;
-            else if (p[0] == '\xef' && p[1] == '\xbb' && p[2] == '\xbf')
-                p += 3;         // U+FFFE (BOM)
-            else
-                break;
-        }
-        for (q = p; ((*q != '\0') && (*q != '\r') && (*q != '\n')); ++q)
-        {
-        };
-        if (q == p)
-            break;
-        if (*q != '\0')
-            *(q++) = '\0';
-        retval |= scc_process_line(track, p, request_context);
-        if (*q == '\0')
-            break;
-        p = q;
-    }
+	while (1)
+	{
+		char *q;
+		while (1)
+		{
+			if ((*p == '\r') || (*p == '\n'))
+				++p;
+			else if (p[0] == '\xef' && p[1] == '\xbb' && p[2] == '\xbf')
+				p += 3;		 // U+FFFE (BOM)
+			else
+				break;
+		}
+		for (q = p; ((*q != '\0') && (*q != '\r') && (*q != '\n')); ++q)
+		{
+		};
+		if (q == p)
+			break;
+		if (*q != '\0')
+			*(q++) = '\0';
+		retval |= scc_process_line(track, p, request_context);
+		if (*q == '\0')
+			break;
+		p = q;
+	}
 
-    if (track->initial_offset == SCC_MAX_LONG_LONG)
-    { // no cues with valid timing
-        track->initial_offset = 0x0LL;
-        track->max_duration   = 0x0LL;
-    }
-    else if (track->initial_offset > SCC_THRESH_LONG_LONG)
-    { // lowest start_time is bigger than 55 minutes, we assume it is the one-hour shift used by some Broadcasters.
-        track->initial_offset = (track->initial_offset / 1000) * 1000; // we quantize to nearest second to make subtraction easier
-        track->max_duration   = track->max_duration - track->initial_offset + SCC_MAX_CUE_DURATION_MSEC + SCC_OFFSET_FOR_SHORTER_LEAD;
-    }
-    else
-    {
-        track->initial_offset = 0x0LL;
-        track->max_duration = track->max_duration + SCC_MAX_CUE_DURATION_MSEC + SCC_OFFSET_FOR_SHORTER_LEAD;
-    }
+	if (track->initial_offset == SCC_MAX_LONG_LONG)
+	{ // no cues with valid timing
+		track->initial_offset = 0x0LL;
+		track->max_duration   = 0x0LL;
+	}
+	else if (track->initial_offset > SCC_THRESH_LONG_LONG)
+	{ // lowest start_time is bigger than 55 minutes, we assume it is the one-hour shift used by some Broadcasters.
+		track->initial_offset = (track->initial_offset / 1000) * 1000; // we quantize to nearest second to make subtraction easier
+		track->max_duration   = track->max_duration - track->initial_offset + SCC_MAX_CUE_DURATION_MSEC + SCC_OFFSET_FOR_SHORTER_LEAD;
+	}
+	else
+	{
+		track->initial_offset = 0x0LL;
+		track->max_duration = track->max_duration + SCC_MAX_CUE_DURATION_MSEC + SCC_OFFSET_FOR_SHORTER_LEAD;
+	}
 
-    return retval;
+	return retval;
 }
 
 
 /* Allocates scc_track_t, assumes caller will free the returned pointer. Cleans up everything else allocated internally. */
 scc_track_t *scc_parse_memory(char *data, int length, request_context_t* request_context)
 {
-    int failed;
+	int failed;
 	if (!data)
 	{
 		return NULL;
 	}
 
-    // copy the input buffer, as the parsing is destructive.
-    char *pcopy = vod_alloc(request_context->pool, length+1);
-    if (pcopy == NULL)
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "scc_parse_memory(): vod_alloc of pcopy failed");
-        return NULL;
-    }
-    vod_memcpy(pcopy, data, length+1);
+	// copy the input buffer, as the parsing is destructive.
+	char *pcopy = vod_alloc(request_context->pool, length+1);
+	if (pcopy == NULL)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"scc_parse_memory(): vod_alloc of pcopy failed");
+		return NULL;
+	}
+	vod_memcpy(pcopy, data, length+1);
 
-    // initializes all fields to zero. If that doesn't suit your need, use another track_init function.
-    scc_track_t *track = vod_calloc(request_context->pool, sizeof(scc_track_t));
-    track->initial_offset = (long long) SCC_MAX_LONG_LONG;
-    if (track == NULL)
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "scc_parse_memory(): vod_callocof 608_context failed");
-        vod_free(request_context->pool, pcopy);
-        return NULL;
-    }
+	// initializes all fields to zero. If that doesn't suit your need, use another track_init function.
+	scc_track_t *track = vod_calloc(request_context->pool, sizeof(scc_track_t));
+	track->initial_offset = (long long) SCC_MAX_LONG_LONG;
+	if (track == NULL)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"scc_parse_memory(): vod_callocof 608_context failed");
+		vod_free(request_context->pool, pcopy);
+		return NULL;
+	}
 
-    // destructive parsing of pcopy
-    failed = scc_process_text(track, pcopy, request_context);
-    vod_free(request_context->pool, pcopy);   // not needed anymore whether parsing succeeded or failed
-    if (failed == -1)
-    {
-        vod_log_error(VOD_LOG_ERR, request_context->log, 0,
-            "scc_parse_memory(): process_text failed");
-        return NULL;
+	// destructive parsing of pcopy
+	failed = scc_process_text(track, pcopy, request_context);
+	vod_free(request_context->pool, pcopy);   // not needed anymore whether parsing succeeded or failed
+	if (failed == -1)
+	{
+		vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+			"scc_parse_memory(): process_text failed");
+		return NULL;
 
-    }
+	}
 
 	return track;
 }

--- a/vod/subtitle/scc_parse.c
+++ b/vod/subtitle/scc_parse.c
@@ -80,7 +80,7 @@ static const char *command_type[] =
 	"FON - Flash turened ON"
 };
 
-static const char *font_text[]=
+static const char *font_text[] =
 {
 	"regular",
 	"italic",
@@ -93,7 +93,7 @@ static const char *font_text[]=
 };
 
 #define MAX_COLOR 10
-static const char *color_text[MAX_COLOR][2]=
+static const char *color_text[MAX_COLOR][2] =
 {
 	{"white",""},
 	{"green","<font color=\"#00ff00\">"},
@@ -107,7 +107,6 @@ static const char *color_text[MAX_COLOR][2]=
 	{"transparent",""}
 };
 #endif
-//====================================================================================
 
 scc_event_t *get_writing_buffer(scc_track_t *track, request_context_t* request_context)
 {
@@ -143,7 +142,7 @@ scc_event_t *new_event(scc_track_t *track, request_context_t* request_context)
     }
 
     int i;
-	for (i=0;i<15;i++)
+	for (i = 0;i < 15;i++)
 	{
 		memset(event->characters[i], 0, SCC_608_SCREEN_WIDTH+1);
 		memset(event->iub[i],        0, SCC_608_SCREEN_WIDTH+1);
@@ -161,17 +160,17 @@ scc_event_t *new_event(scc_track_t *track, request_context_t* request_context)
 /* Process PREAMBLE ACCESS CODES (PAC) */
 void handle_pac(unsigned char c1, unsigned char c2, scc_track_t *track, request_context_t* request_context)
 {
-    int row=rowdata[((c1<<1)&14)|((c2>>5)&1)];
+    int row = rowdata[((c1<<1)&14)|((c2>>5)&1)];
 
-    if (c2>=0x40 && c2<=0x5f)
+    if (c2 >= 0x40 && c2 <= 0x5f)
     {
-        c2=c2-0x40;
+        c2 = c2-0x40;
     }
     else
     {
-        if (c2>=0x60 && c2<=0x7f)
+        if (c2 >= 0x60 && c2 <= 0x7f)
         {
-            c2=c2-0x60;
+            c2 = c2-0x60;
         }
         else
         {
@@ -256,7 +255,7 @@ void write_char(const unsigned char c, scc_track_t *track, request_context_t* re
 /* Handle MID-ROW CODES. */
 void handle_text_attr(const unsigned char c1, const unsigned char c2, scc_track_t *track, request_context_t* request_context)
 {
-	if ((c1!=0x11 && c1!=0x19) || (c2<0x20 || c2>0x2f))
+	if ((c1 != 0x11 && c1 != 0x19) || (c2 < 0x20 || c2 > 0x2f))
 	{
 		vod_log_error(VOD_LOG_ERR, request_context->log, 0, "This is not a text attribute! c1=%d, c2=%d", c1, c2);
 	}
@@ -282,7 +281,7 @@ void handle_text_attr(const unsigned char c1, const unsigned char c2, scc_track_
 
 void handle_single(const unsigned char c1, scc_track_t *track, request_context_t* request_context)
 {
-	if (c1<0x20)
+	if (c1 < 0x20)
 		return; // We don't allow teleprinting stuff here
 	write_char (c1,track, request_context);
 }
@@ -291,9 +290,9 @@ void handle_single(const unsigned char c1, scc_track_t *track, request_context_t
 void handle_special_doublebytes(const unsigned char c1, const unsigned char c2, scc_track_t *track, request_context_t* request_context)
 {
 	unsigned char c;
-	if (c2>=0x30 && c2<=0x3f)
+	if (c2 >= 0x30 && c2 <= 0x3f)
 	{
-		c=c2 + 0x50; // So if c>=0x80 && c<=0x8f, it comes from here
+		c = c2 + 0x50; // So if c >= 0x80 && c <= 0x8f, it comes from here
 		write_char(c, track, request_context);
 	}
 }
@@ -301,17 +300,17 @@ void handle_special_doublebytes(const unsigned char c1, const unsigned char c2, 
 /* Process EXTENDED CHARACTERS */
 unsigned char handle_extended(unsigned char hi, unsigned char lo, scc_track_t *track, request_context_t* request_context)
 {
-	unsigned char c=0;
+	unsigned char c = 0;
 	// For lo values between 0x20-0x3f
-	if (lo>=0x20 && lo<=0x3f && (hi==0x12 || hi==0x13))
+	if (lo >= 0x20 && lo <= 0x3f && (hi == 0x12 || hi == 0x13))
 	{
 		switch (hi)
 		{
 			case 0x12:
-				c=lo+0x70; // So if c>=0x90 && c<=0xaf it comes from here
+				c = lo + 0x70; // So if c >= 0x90 && c <= 0xaf it comes from here
 				break;
 			case 0x13:
-				c=lo+0x90; // So if c>=0xb0 && c<=0xcf it comes from here
+				c = lo + 0x90; // So if c >= 0xb0 && c <= 0xcf it comes from here
 				break;
 		}
 		// This column change is because extended characters replace
@@ -330,43 +329,43 @@ void handle_command(unsigned char c1, const unsigned char c2, scc_track_t *track
 {
 	enum command_code command = COM_UNKNOWN;
 
-	if (c1==0x15)
-		c1=0x14;
-	if ((c1==0x14 || c1==0x1C) && c2==0x2C)
+	if (c1 == 0x15)
+		c1 = 0x14;
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x2C)
 		command = COM_ERASEDISPLAYEDMEMORY;
-	if ((c1==0x14 || c1==0x1C) && c2==0x20)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x20)
 		command = COM_RESUMECAPTIONLOADING;
-	if ((c1==0x14 || c1==0x1C) && c2==0x2F)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x2F)
 		command = COM_ENDOFCAPTION;
-	if ((c1==0x14 || c1==0x1C) && c2==0x22)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x22)
 		command = COM_ALARMOFF;
-	if ((c1==0x14 || c1==0x1C) && c2==0x23)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x23)
 		command = COM_ALARMON;
-	if ((c1==0x14 || c1==0x1C) && c2==0x24)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x24)
 		command = COM_DELETETOENDOFROW;
-	if ((c1==0x17 || c1==0x1F) && c2==0x21)
+	if ((c1 == 0x17 || c1 == 0x1F) && c2 == 0x21)
 		command = COM_TABOFFSET1;
-	if ((c1==0x17 || c1==0x1F) && c2==0x22)
+	if ((c1 == 0x17 || c1 == 0x1F) && c2 == 0x22)
 		command = COM_TABOFFSET2;
-	if ((c1==0x17 || c1==0x1F) && c2==0x23)
+	if ((c1 == 0x17 || c1 == 0x1F) && c2 == 0x23)
 		command = COM_TABOFFSET3;
-	if ((c1==0x14 || c1==0x1C) && c2==0x25)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x25)
 		command = COM_ROLLUP2;
-	if ((c1==0x14 || c1==0x1C) && c2==0x26)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x26)
 		command = COM_ROLLUP3;
-	if ((c1==0x14 || c1==0x1C) && c2==0x27)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x27)
 		command = COM_ROLLUP4;
-	if ((c1==0x14 || c1==0x1C) && c2==0x28)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x28)
 		command = COM_FLASHON;
-	if ((c1==0x14 || c1==0x1C) && c2==0x29)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x29)
 		command = COM_RESUMEDIRECTCAPTIONING;
-	if ((c1==0x14 || c1==0x1C) && c2==0x2D)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x2D)
 		command = COM_CARRIAGERETURN;
-	if ((c1==0x14 || c1==0x1C) && c2==0x2E)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x2E)
 		command = COM_ERASENONDISPLAYEDMEMORY;
-	if ((c1==0x14 || c1==0x1C) && c2==0x21)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x21)
 		command = COM_BACKSPACE;
-	if ((c1==0x14 || c1==0x1C) && c2==0x2b)
+	if ((c1 == 0x14 || c1 == 0x1C) && c2 == 0x2b)
 		command = COM_RESUMETEXTDISPLAY;
 
 #ifdef SCC_TEMP_VERBOSITY
@@ -465,54 +464,54 @@ void disCommand(unsigned char hi, unsigned char lo, scc_track_t *track, request_
 #endif
 
         // Treat Ch 2,4 as Ch 1,3 respectively
-	if (hi>=0x18 && hi<=0x1f)
+	if (hi >= 0x18 && hi <= 0x1f)
             hi=hi-8;
 	// Treat Ch 3 as Ch 1 in Global codes and {BS, DER, CR}.
-        if (hi==0x15 && lo>=0x20 && lo<=0x2f)
+        if (hi == 0x15 && lo >= 0x20 && lo <= 0x2f)
             hi--;
 
 	switch (hi)
 	{
 		case 0x10:
-			if (lo>=0x40 && lo<=0x5f)                                // row 11 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x5f)                                // row 11 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 		case 0x11:
-			if (lo>=0x20 && lo<=0x2f)                                // mid-row color/underline PAC (ch 1&3)
+			if (lo >= 0x20 && lo <= 0x2f)                                // mid-row color/underline PAC (ch 1&3)
 				handle_text_attr(hi, lo, track, request_context);
-			if (lo>=0x30 && lo<=0x3f)                                // Special Characters
+			if (lo >= 0x30 && lo <= 0x3f)                                // Special Characters
 			{
 				handle_special_doublebytes(hi, lo, track, request_context);
 			}
-			if (lo>=0x40 && lo<=0x7f)                                // rows 01/02 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x7f)                                // rows 01/02 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 		case 0x12:
 		case 0x13:
-			if (lo>=0x20 && lo<=0x3f)                                // Extended Characters
+			if (lo >= 0x20 && lo <= 0x3f)                                // Extended Characters
 			{
 				handle_extended(hi, lo, track, request_context);
 			}
-			if (lo>=0x40 && lo<=0x7f)                                // rows 03/04 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x7f)                                // rows 03/04 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 		case 0x14:
 		case 0x15:
-			if (lo>=0x20 && lo<=0x2f)                                // Global Codes PAC (ch 1&3)
+			if (lo >= 0x20 && lo <= 0x2f)                                // Global Codes PAC (ch 1&3)
 				handle_command(hi, lo, track, request_context);
-			if (lo>=0x40 && lo<=0x7f)                                // rows 05/06 and 14/15 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x7f)                                // rows 05/06 and 14/15 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 		case 0x16:
-			if (lo>=0x40 && lo<=0x7f)                                // rows 07/08 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x7f)                                // rows 07/08 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 		case 0x17:
-			if (lo>=0x21 && lo<=0x23)                                // Tab Offsets 1,2,3 (ch 1&3)
+			if (lo >= 0x21 && lo <= 0x23)                                // Tab Offsets 1,2,3 (ch 1&3)
 				handle_command(hi, lo, track, request_context);
-			if (lo>=0x2e && lo<=0x2f)                                // mid-row Black and BlackUnderline PAC (ch 1&3)
+			if (lo >= 0x2e && lo <= 0x2f)                                // mid-row Black and BlackUnderline PAC (ch 1&3)
 				handle_text_attr(hi, lo, track, request_context);
-			if (lo>=0x40 && lo<=0x7f)                                // rows 09/10 PAC (ch 1&3)
+			if (lo >= 0x40 && lo <= 0x7f)                                // rows 09/10 PAC (ch 1&3)
 				handle_pac(hi, lo, track, request_context);
 			break;
 	}
@@ -560,7 +559,7 @@ static int scc_process_line(scc_track_t *track, const char *str, request_context
 #endif
 
 
-    for (i=0; i < length; i+=4)
+    for (i = 0; i < length; i += 4)
     {
         // code is still in ASCII text, need to convert every 2 consecutive chars to their equivalent hexadecimal digit
         unsigned char hi, lo;
@@ -576,10 +575,10 @@ static int scc_process_line(scc_track_t *track, const char *str, request_context
             //vod_log_error(VOD_LOG_ERR, request_context->log, 0,
             //" FULLWORD:%d, hi=%d lo=%d", fullword, hi, lo);
 
-        if (hi==0 && lo==0) // Just padding
+        if (hi == 0 && lo == 0) // Just padding
             continue;
 
-        if (hi>=0x10 && hi<=0x1F) // Non-character code or special/extended char
+        if (hi >= 0x10 && hi <= 0x1F) // Non-character code or special/extended char
         // http://www.theneitherworld.com/mcpoodle/SCC_TOOLS/DOCS/CC_CODES.HTML
         // http://www.theneitherworld.com/mcpoodle/SCC_TOOLS/DOCS/CC_CHARS.HTML
         {
@@ -602,7 +601,7 @@ static int scc_process_line(scc_track_t *track, const char *str, request_context
             track->last_c1 = -1;
             track->last_c2 = -1;
 
-            if (hi>=0x20) // Standard characters (always in pairs)
+            if (hi >= 0x20) // Standard characters (always in pairs)
             {
                 handle_single(hi, track, request_context);
                 handle_single(lo, track, request_context);
@@ -627,9 +626,11 @@ static int scc_process_text(scc_track_t *track, char *str, request_context_t* re
     int retval = 0;
     char *p = str;
 
-    while (1) {
+    while (1)
+    {
         char *q;
-        while (1) {
+        while (1)
+        {
             if ((*p == '\r') || (*p == '\n'))
                 ++p;
             else if (p[0] == '\xef' && p[1] == '\xbb' && p[2] == '\xbf')
@@ -637,7 +638,8 @@ static int scc_process_text(scc_track_t *track, char *str, request_context_t* re
             else
                 break;
         }
-        for (q = p; ((*q != '\0') && (*q != '\r') && (*q != '\n')); ++q) {
+        for (q = p; ((*q != '\0') && (*q != '\r') && (*q != '\n')); ++q)
+        {
         };
         if (q == p)
             break;

--- a/vod/subtitle/webvtt_format.c
+++ b/vod/subtitle/webvtt_format.c
@@ -99,7 +99,7 @@ webvtt_utf16_to_utf8(
 		1) != VOD_OK)
 	{
 		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
-			"webvtt_utf16le_to_utf8: vod_array_init failed");
+			"webvtt_utf16_to_utf8: vod_array_init failed");
 		return VOD_ALLOC_FAILED;
 	}
 
@@ -124,7 +124,7 @@ webvtt_utf16_to_utf8(
 		if (err != E2BIG)
 		{
 			vod_log_error(VOD_LOG_WARN, request_context->log, err,
-				"webvtt_utf16le_to_utf8: iconv failed");
+				"webvtt_utf16_to_utf8: iconv failed");
 			return VOD_UNEXPECTED;
 		}
 
@@ -134,7 +134,7 @@ webvtt_utf16_to_utf8(
 		if (vod_array_push_n(&output_arr, ICONV_SIZE_INCREMENT) == NULL)
 		{
 			vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
-				"webvtt_utf16le_to_utf8: vod_array_push_n failed");
+				"webvtt_utf16_to_utf8: vod_array_push_n failed");
 			return VOD_ALLOC_FAILED;
 		}
 
@@ -148,7 +148,7 @@ webvtt_utf16_to_utf8(
 	if (end == NULL)
 	{
 		vod_log_debug0(VOD_LOG_DEBUG_LEVEL, request_context->log, 0,
-			"webvtt_utf16le_to_utf8: vod_array_push failed");
+			"webvtt_utf16_to_utf8: vod_array_push failed");
 		return VOD_ALLOC_FAILED;
 	}
 


### PR DESCRIPTION
Three changes going into this:
1. Merging latest hash from Kaltura's branch to ours. This shouldn't change anything in behavior. These are all the changes not under the /vod/subtitle/ directory.
2. Updating ASS/SCC code to match the style advised (details below) by Kaltura in their feedback. This shouldn't change anything in behavior. This also include changing the use of vod_memcpy() to vod_copy() to benefit from nginx' optimizations for copying based on compiler used...
3. create function ass_alloc_track() to allocate and initialize track, in case the input file has some field missing. We can now handle files where the whole [SCRIPT_INFO] section is empty, whereas before it would crash for division by zero.

Here are the 9 points requested by Kaltura for style:
. Spaces - before and after operators, e.g. x += y not x+=y.
. New lines for braces
. Booleans are considered zero vs. nonzero, we are not checking for if (x == true), but either if (x) or if (!x)
. Indentation should use tabs. Large indentation should be avoided - in some cases this can be achieved by reversing ifs (e.g. if (x) { ... } becomes if (!x) { continue; }) in other cases it may be done by moving the internal code to a function.
. Variable names should be lower case with underscores (some of the code is already like that, some is not). When there is a matching core-nginx convention for the name, I'm using it, e.g. p usually means a running pointer. But in other cases, I'm using longer more informative names.
. Comments are used only when there is something non-trivial to document
. All the tables at the beginning of the file can be arranged better using the x-macros pattern (like languages_x.h)
. Single variable definition per line / single code statement per line
. split_event_text_to_chunks should use a running pointer instead of incrementing dstidx, this will enable the use of vod_copy, and more in general, the return value of vod_sprintf / vod_copy can be used to advance the pointer instead of all these +='s

Note: If you want to see the tab/indent accurately as 4 spaces on GitHub, please install the chrome extension at https://chrome.google.com/webstore/detail/tab-size-on-github/ofjbgncegkdemndciafljngjbdpfmbkn