### PR TITLE
Add support to ASS->VTT referencing a static CSS file

### DIFF
--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -14,7 +14,7 @@
 #define NUM_OF_TAGS_ALLOWED_PER_LINE 1
 
 //#define ASSUME_STYLE_SUPPORT
-#define ASSUME_CSS_SUPPORT
+//#define ASSUME_CSS_SUPPORT
 #ifdef ASSUME_STYLE_SUPPORT
 #undef ASSUME_CSS_SUPPORT
 #endif
@@ -186,17 +186,56 @@ static const char*  palette[/*Red*/ 5][/*Green*/ 5][/*Blue*/ 5] =
 		{"amber",			"yelloworange",		"macncheese",		"yourpink",			"pinklace"		},
 		{"yellow",			"goldenfizz",		"dolly",			"shalimar",			"white"			}
 	}
-}
-
-/* color_name() returns a string with the name of the color corresponding to these RGB u8 values */
-static char* color_name(uint8_t red, uint8_t green, uint8_t blue)
+};
+static const int color_name_size[/*Red*/ 5][/*Green*/ 5][/*Blue*/ 5] =
 {
-	red		= ((red		+ 25) / 51);
-	green	= ((green	+ 25) / 51);
-	blue	= ((blue	+ 25) / 51);
-	return palette[red][green][blue];
+	{
+		{5,					7,					4,					10,					4				},
+		{7,					6,					12,					6,					10				},
+		{9,					8,					4,					8,					5				},
+		{6,					9,					9,					7,					8				},
+		{5,					4,					11,					10,					4				}
+	},
+	{
+		{9,					10,					6,					10,					7				},
+		{6,					7,					7,					8,					9				},
+		{7,					6,					9,					9,					6				},
+		{9,					7,					8,					8,					10				},
+		{11,				11,					14,					10,					4				}
+	},
+	{
+		{6,					5,					8,					6,					8				},
+		{8,					5,					10,					11,					10				},
+		{5,					11,					4,					6,					6				},
+		{9,					6,					6,					7,					7				},
+		{10,				11,					9,					9,					9				}
+	},
+	{
+		{9,					5,					5,					6,					11				},
+		{10,				5,					8,					8,					6				},
+		{10,				7,					8,					5,					6				},
+		{10,				8,					9,					6,					7				},
+		{9,					8,					4,					9,					6				}
+	},
+	{
+		{3,					8,					4,					7,					7				},
+		{9,					5,					10,					12,					8				},
+		{11,				6,					14,					7,					9				},
+		{5,					12,					10,					8,					8				},
+		{6,					10,					5,					8,					5				}
+	}
+};
+
+static u_char* insert_color_string(u_char *p, uint32_t abgr_word, request_context_t* request_context)
+{
+	uint32_t red, green, blue;
+	blue	= (((abgr_word >> 16) & 0xFF) + 32) >> 6;
+	green	= (((abgr_word >>  8) & 0xFF) + 32) >> 6;
+	red		= (((abgr_word      ) & 0xFF) + 32) >> 6;
+	return vod_sprintf(p, palette[red][green][blue], color_name_size[red][green][blue]);
 }
-#endif
+#endif   //ASSUME_CSS_SUPPORT
+
 void swap_events(ass_event_t* nxt, ass_event_t* cur)
 {
 	ass_event_t tmp;
@@ -411,13 +450,13 @@ static u_char* output_one_style(ass_style_t* cur_style, u_char* p)
 		p = vod_copy(p, FIXED_WEBVTT_BRACES_START_STR, FIXED_WEBVTT_BRACES_START_WIDTH);
 
 		p = vod_copy(p, "color: #", 8);
-		p = vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->primary_colour);
+		p = vod_sprintf(p, "%08uxD;\r\n", cur_style->primary_colour);
 
 
 		p = vod_copy(p, "font-family: \"", 14);
 		p = vod_copy(p, cur_style->font_name, vod_strlen(cur_style->font_name));
 		p = vod_copy(p, "\", sans-serif;\r\n", 16);
-		p = vod_sprintf((u_char*)p, "font-size: %03uDpx;\r\n", cur_style->font_size);
+		p = vod_sprintf(p, "font-size: %03uDpx;\r\n", cur_style->font_size);
 
 		/*if (cur_style->bold)
 		{
@@ -445,7 +484,7 @@ static u_char* output_one_style(ass_style_t* cur_style, u_char* p)
 			// webkit is not supported by all players, stick to adding outline using text-shadow
 			p = vod_copy(p, "text-shadow: ", 13);
 			// add outline in 4 directions with the outline color
-			p = vod_sprintf((u_char*)p,
+			p = vod_sprintf(p,
 				"#%08uxD -%01uDpx 0px, #%08uxD 0px %01uDpx, #%08uxD 0px -%01uDpx, #%08uxD %01uDpx 0px, #%08uxD %01uDpx %01uDpx 0px;\r\n",
 				cur_style->outline_colour, cur_style->outline,
 				cur_style->outline_colour, cur_style->outline,
@@ -456,7 +495,7 @@ static u_char* output_one_style(ass_style_t* cur_style, u_char* p)
 		else
 		{
 			p = vod_copy(p, "background-color: #", 19);
-			p = vod_sprintf((u_char*)p, "%08uxD;\r\n", cur_style->back_colour);
+			p = vod_sprintf(p, "%08uxD;\r\n", cur_style->back_colour);
 		}
 		p = vod_copy(p, FIXED_WEBVTT_BRACES_END_STR, FIXED_WEBVTT_BRACES_END_WIDTH);
 		p = vod_copy(p, "\r\n", 2);
@@ -843,7 +882,7 @@ ass_parse_frames(
 		}
 #ifdef ASSUME_STYLE_SUPPORT
 		p = vod_copy(p, FIXED_WEBVTT_VOICE_START_STR, FIXED_WEBVTT_VOICE_START_WIDTH);
-		p = vod_sprintf((u_char*)p, cur_style->name, vod_strlen(cur_style->name));
+		p = vod_sprintf(p, cur_style->name, vod_strlen(cur_style->name));
 		p = vod_copy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);
 #endif //ASSUME_STYLE_SUPPORT
 
@@ -851,13 +890,9 @@ ass_parse_frames(
 		p = vod_copy(p, FIXED_WEBVTT_CLASSOPEN_START_STR, FIXED_WEBVTT_CLASSOPEN_START_WIDTH);
 		// insert primary color class
 		{
-			uint8_t alpha, red, green, blue;
-			alpha	= uint8_t(cur_style->primary_colour >> 24);
-			blue	= uint8_t(cur_style->primary_colour >> 16) && 0xFF;
-			green	= uint8_t(cur_style->primary_colour >>  8) && 0xFF;
-			red		= uint8_t(cur_style->primary_colour      ) && 0xFF;
+			uint32_t alpha = ((cur_style->primary_colour >> 24) & 0xFF);
 			p = vod_copy(p, FIXED_WEBVTT_COLOR_FULL_STR, FIXED_WEBVTT_COLOR_FULL_WIDTH);
-			p = vod_sprintf((u_char*)p, color_name(red, green, blue), vod_strlen(color_name(red, green, blue));
+			p = insert_color_string(p, cur_style->primary_colour, request_context);
 			if (alpha <= 64)
 				p = vod_copy(p, FIXED_WEBVTT_ALPHA_FULL_STR, FIXED_WEBVTT_ALPHA_FULL_WIDTH);
 			else
@@ -867,13 +902,9 @@ ass_parse_frames(
 		if (cur_style->border_style == 3)
 		{
 			// Opaque box with background color
-			uint8_t alpha, red, green, blue;
-			alpha	= uint8_t(cur_style->back_colour >> 24);
-			blue	= uint8_t(cur_style->back_colour >> 16) && 0xFF;
-			green	= uint8_t(cur_style->back_colour >>  8) && 0xFF;
-			red		= uint8_t(cur_style->back_colour      ) && 0xFF;
+			uint32_t alpha = ((cur_style->back_colour >> 24) & 0xFF);
 			p = vod_copy(p, FIXED_WEBVTT_BACKGROUND_FULL_STR, FIXED_WEBVTT_BACKGROUND_FULL_WIDTH);
-			p = vod_sprintf((u_char*)p, color_name(red, green, blue), vod_strlen(color_name(red, green, blue));
+			p = insert_color_string(p, cur_style->back_colour, request_context);
 			if (alpha <= 64)
 				p = vod_copy(p, FIXED_WEBVTT_ALPHA_FULL_STR, FIXED_WEBVTT_ALPHA_FULL_WIDTH);
 			else
@@ -882,11 +913,6 @@ ass_parse_frames(
 		else if (cur_style->outline > 0 && cur_style->outline <= 4)
 		{
 			// Outline color as dictated, with size in pixels as dictated
-			uint8_t alpha, red, green, blue;
-			alpha	= uint8_t(cur_style->outline_colour >> 24);
-			blue	= uint8_t(cur_style->outline_colour >> 16) && 0xFF;
-			green	= uint8_t(cur_style->outline_colour >>  8) && 0xFF;
-			red		= uint8_t(cur_style->outline_colour      ) && 0xFF;
 			p = vod_copy(p, FIXED_WEBVTT_OUTLINE_FULL_STR, FIXED_WEBVTT_OUTLINE_FULL_WIDTH);
 			if (cur_style->outline == 1)
 				p 	= vod_copy(p, "1", 1);
@@ -894,41 +920,46 @@ ass_parse_frames(
 				p 	= vod_copy(p, "2", 1);
 			else
 				p 	= vod_copy(p, "3", 1);
-			p = vod_sprintf((u_char*)p, color_name(red, green, blue), vod_strlen(color_name(red, green, blue));
+			p = insert_color_string(p, cur_style->outline_colour, request_context);
 		}
+
 		// insert strikethrough
 		if (cur_style->strike_out)
 			p = vod_copy(p, FIXED_WEBVTT_STRIKE_THRU_STR, FIXED_WEBVTT_STRIKE_THRU_WIDTH);
+
 		// insert font-family
 		p = vod_copy(p, FIXED_WEBVTT_FONT_FAM_STR, FIXED_WEBVTT_FONT_FAM_WIDTH);
-		{
-			if (style->right_to_left_language)
-				p = vod_copy(p, FIXED_WEBVTT_ARABIC_FONT_STR, FIXED_WEBVTT_ARABIC_FONT_WIDTH);
-			else if ( !ass_strncasecmp(track->language, "Русский", 9) )
-				p = vod_copy(p, FIXED_WEBVTT_RUSSIAN_FONT_STR, FIXED_WEBVTT_RUSSIAN_FONT_WIDTH);
-			else if ( !ass_strncasecmp(cur_style->font_name, "Times New Roman", 15) )
-				p = vod_copy(p, FIXED_WEBVTT_TIMES_FONT_STR, FIXED_WEBVTT_TIMES_FONT_WIDTH);
-			else if ( !ass_strncasecmp(cur_style->font_name, "Trebuchet MS", 12) )
-				p = vod_copy(p, FIXED_WEBVTT_TREBUCHET_FONT_STR, FIXED_WEBVTT_TREBUCHET_FONT_WIDTH);
-			else if ( !ass_strncasecmp(cur_style->font_name, "Comic Sans MS", 13) )
-				p = vod_copy(p, FIXED_WEBVTT_COMIC_FONT_STR, FIXED_WEBVTT_COMIC_FONT_WIDTH);
-			else if ( !ass_strncasecmp(cur_style->font_name, "Lucida Console", 14) )
-				p = vod_copy(p, FIXED_WEBVTT_LUCIDA_FONT_STR, FIXED_WEBVTT_LUCIDA_FONT_WIDTH);
-			else if ( !ass_strncasecmp(cur_style->font_name, "Courier New", 11) )
-				p = vod_copy(p, FIXED_WEBVTT_COURIER_FONT_STR, FIXED_WEBVTT_COURIER_FONT_WIDTH);
-			else if ( !ass_strncasecmp(cur_style->font_name, "Times New Roman", 15) )
-				p = vod_copy(p, FIXED_WEBVTT_TIMES_FONT_STR, FIXED_WEBVTT_TIMES_FONT_WIDTH);
-			else
-				p = vod_copy(p, FIXED_WEBVTT_ARIAL_FONT_STR, FIXED_WEBVTT_ARIAL_FONT_WIDTH);
-		}
+
+		if (cur_style->right_to_left_language)
+			p = vod_copy(p, FIXED_WEBVTT_ARABIC_FONT_STR, FIXED_WEBVTT_ARABIC_FONT_WIDTH);
+		else if ( !vod_strncmp(ass_track->title,	"Русский", TITLE_BYTES_CONSIDERED) ||
+				  !vod_strncmp(ass_track->language,	"Русский", TITLE_BYTES_CONSIDERED) )
+			p = vod_copy(p, FIXED_WEBVTT_RUSSIAN_FONT_STR, FIXED_WEBVTT_RUSSIAN_FONT_WIDTH);
+		else if ( !vod_strncmp(cur_style->font_name, "Times New Roman", 15) )
+			p = vod_copy(p, FIXED_WEBVTT_TIMES_FONT_STR, FIXED_WEBVTT_TIMES_FONT_WIDTH);
+		else if ( !vod_strncmp(cur_style->font_name, "Trebuchet MS", 12) )
+			p = vod_copy(p, FIXED_WEBVTT_TREBUCHET_FONT_STR, FIXED_WEBVTT_TREBUCHET_FONT_WIDTH);
+		else if ( !vod_strncmp(cur_style->font_name, "Comic Sans MS", 13) )
+			p = vod_copy(p, FIXED_WEBVTT_COMIC_FONT_STR, FIXED_WEBVTT_COMIC_FONT_WIDTH);
+		else if ( !vod_strncmp(cur_style->font_name, "Lucida Console", 14) )
+			p = vod_copy(p, FIXED_WEBVTT_LUCIDA_FONT_STR, FIXED_WEBVTT_LUCIDA_FONT_WIDTH);
+		else if ( !vod_strncmp(cur_style->font_name, "Courier New", 11) )
+			p = vod_copy(p, FIXED_WEBVTT_COURIER_FONT_STR, FIXED_WEBVTT_COURIER_FONT_WIDTH);
+		else if ( !vod_strncmp(cur_style->font_name, "Times New Roman", 15) )
+			p = vod_copy(p, FIXED_WEBVTT_TIMES_FONT_STR, FIXED_WEBVTT_TIMES_FONT_WIDTH);
+		else
+			p = vod_copy(p, FIXED_WEBVTT_ARIAL_FONT_STR, FIXED_WEBVTT_ARIAL_FONT_WIDTH);
+
+				vod_log_error(VOD_LOG_ERR, request_context->log, 0,
+        			"title=%s, language=%s", ass_track->title, ass_track->language);
 		// insert font-size
 		p = vod_copy(p, FIXED_WEBVTT_FONT_SIZE_STR, FIXED_WEBVTT_FONT_SIZE_WIDTH);
 		if (cur_style->font_size < 16)
-			p = vod_snprintf((u_char*)p, 2, "%d", 16);
+			p = vod_snprintf(p, 2, "%d", 16);
 		else if (cur_style->font_size > 45)
-			p = vod_snprintf((u_char*)p, 2, "%d", 45);
+			p = vod_snprintf(p, 2, "%d", 45);
 		else
-			p = vod_snprintf((u_char*)p, 2, "%d", cur_style->font_size);
+			p = vod_snprintf(p, 2, "%d", cur_style->font_size);
 
 		p = vod_copy(p, FIXED_WEBVTT_CLASSOPEN_END_STR, FIXED_WEBVTT_CLASSOPEN_END_WIDTH);
 #endif
@@ -951,10 +982,10 @@ ass_parse_frames(
 		// - duration = start time of next event - start time of current event
 		// - pts_delay = end time - start time = duration this subtitle event is on screen
 
-		cur_frame->offset	= (uintptr_t)pfixed;
-		cur_frame->size	  = (uint32_t)(p - pfixed);
-		cur_frame->key_frame = FIXED_WEBVTT_CUE_NAME_WIDTH + 2; // cue name + \r\n
-		cur_frame->pts_delay = cur_event->end - cur_event->start;
+		cur_frame->offset		= (uintptr_t)pfixed;
+		cur_frame->size			= (uint32_t)(p - pfixed);
+		cur_frame->key_frame	= FIXED_WEBVTT_CUE_NAME_WIDTH + 2; // cue name + \r\n
+		cur_frame->pts_delay	= cur_event->end - cur_event->start;
 
 		vtt_track->total_frames_size += cur_frame->size;
 		cur_style->output_in_cur_segment = TRUE; // output this style as part of this segment

--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -29,7 +29,7 @@ PAIROF(HEADER,	NEWLINES,	10,	WEBVTT_HEADER_NEWLINES)
 
 
 // STYLE_SUPPORT will insert dynamic styles with the names used in the ASS/SSA file
-// CSS_SUPPORT will use static style classes defined in crstyles.css
+// CSS_SUPPORT will use static style classes defined in ./css/crstyles.css
 // They are mutually exclusive
 #ifdef ASSUME_STYLE_SUPPORT
 PAIROF(STYLE, 	START, 		22,	"STYLE\r\n::cue(v[voice=\"")

--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -14,6 +14,10 @@
 #define NUM_OF_TAGS_ALLOWED_PER_LINE 1
 
 //#define ASSUME_STYLE_SUPPORT
+#define ASSUME_CSS_SUPPORT
+#ifdef ASSUME_STYLE_SUPPORT
+#undef ASSUME_CSS_SUPPORT
+#endif
 
 #define PAIROF(type, name, w, str)											\
 static const int      FIXED_WEBVTT_ ## type ## _ ## name ## _WIDTH = w;		\
@@ -23,6 +27,10 @@ PAIROF(CUE, 	NAME, 		8,	"c%07d");
 PAIROF(ESCAPE,	FOR_RTL,	5,	"&lrm;")
 PAIROF(HEADER,	NEWLINES,	10,	WEBVTT_HEADER_NEWLINES)
 
+
+// STYLE_SUPPORT will insert dynamic styles with the names used in the ASS/SSA file
+// CSS_SUPPORT will use static style classes defined in crstyles.css
+// They are mutually exclusive
 #ifdef ASSUME_STYLE_SUPPORT
 PAIROF(STYLE, 	START, 		22,	"STYLE\r\n::cue(v[voice=\"")
 PAIROF(STYLE, 	END,		4,	"\"]) ")
@@ -30,9 +38,29 @@ PAIROF(BRACES,	START,		3,	"{\r\n")
 PAIROF(BRACES,	END,		3,	"}\r\n")
 PAIROF(VOICE,	START,		3,	"<v ")
 PAIROF(VOICE,	END,		1,	">")
-// ignore this set for now, later we will use <v.strike StyleName>  for lines that are strikethrough
-//PAIROF(CLASS,	STRIKE, 	68,	"STYLE\r\n::cue(.strike) {\r\ntext-decoration: solid line-through;\r\n}\r\n\r\n")
 #endif
+#ifdef ASSUME_CSS_SUPPORT
+PAIROF(CLASSOPEN,	START,	2,	"<c")
+PAIROF(CLASSOPEN,	END,	1,	">")
+PAIROF(CLASSCLOSE,	FULL,	4,	"</c>")
+PAIROF(COLOR,		FULL,	7,	".color_")
+PAIROF(BACKGROUND,	FULL,	9,	".bkcolor_")
+PAIROF(OUTLINE,		FULL,	8,	".outline")
+PAIROF(STRIKE,		THRU,	14,	".strikethrough")
+PAIROF(FONT,		FAM,	8,	".fontfam")
+PAIROF(FONT,		SIZE,	9,	".fontsize")
+PAIROF(ALPHA,		FULL,	5,	"_full")
+PAIROF(ALPHA,		HALF,	5,	"_half")
+PAIROF(TIMES,		FONT,	5,	"times")
+PAIROF(ARIAL,		FONT,	5,	"arial")
+PAIROF(COMIC,		FONT,	5,	"comic")
+PAIROF(LUCIDA,		FONT,	6,	"lucida")
+PAIROF(COURIER,		FONT,	7,	"courier")
+PAIROF(ARABIC,		FONT,	6,	"arabic")
+PAIROF(RUSSIAN,		FONT,	7,	"russian")
+PAIROF(TREBUCHET,	FONT,	9,	"trebuchet")
+#endif
+
 
 typedef enum
 {
@@ -120,6 +148,55 @@ static const char* tag_replacement_strings[TAG_TYPE_NONE] =
 	""
 };
 
+#ifdef ASSUME_CSS_SUPPORT
+static const char*  palette[/*Red*/ 5][/*Green*/ 5][/*Blue*/ 5] =
+{
+	{
+		{"black",			"stratos",			"navy",				"mediumblue",		"blue"			},
+		{"deepfir",			"cyprus",			"congressblue",		"cobalt",			"blueribbon"	},
+		{"japlaurel",		"fungreen",			"teal",				"lochmara",			"azure"			},
+		{"forest",			"malachite",		"caribbean",		"eggblue",			"cerulean"		},
+		{"green",			"lime",				"springgreen",		"brightturq",		"cyan"			}
+	},
+	{
+		{"temptress",		"blackberry",		"indigo",			"purpleblue",		"redblue"		},
+		{"verdun",			"tundora",			"eastbay",			"governor",			"royalblue"		},
+		{"limeade",			"goblin",			"fadedjade",		"steelblue",		"dodger"		},
+		{"harlequin",		"emerald",			"shamrock",			"pelorous",			"dodgerblue"	},
+		{"brightgreen",		"pastelgreen",		"screaminggreen",	"aquamarine",		"aqua"			}
+	},
+	{
+		{"maroon",			"siren",			"eggplant",			"purple",			"electric"		},
+		{"cinnamon",		"lotus",			"cannonpink",		"fuchsiablue",		"heliotrope"	},
+		{"olive",			"yellowmetal",		"gray",				"yonder",			"malibu"		},
+		{"pistachio",		"wasabi",			"deyork",			"neptune",			"anakiwa"		},
+		{"chartreuse",		"greenyellow",		"mintgreen",		"magicmint",		"turquoise"		}
+	},
+	{
+		{"guardsman",		"monza",			"flirt",			"cerise",			"purpleheart"	},
+		{"sharonrose",		"crail",			"mulberry",			"amethyst",			"violet"		},
+		{"pirategold",		"tussock",			"voldrose",			"viola",			"orchid"		},
+		{"buddhagold",		"turmeric",			"pineglade",		"silver",			"melrose"		},
+		{"laspalmas",		"starship",			"reef",				"snowymint",		"onahau"		}
+	},
+	{
+		{"red",				"torchred",			"rose",				"pizzazz",			"magenta"		},
+		{"vermilion",		"coral",			"strawberry",		"razzledazzle",		"flamingo"		},
+		{"flushorange",		"crusta",			"vividtangerine",	"hotpink",			"blushpink"		},
+		{"amber",			"yelloworange",		"macncheese",		"yourpink",			"pinklace"		},
+		{"yellow",			"goldenfizz",		"dolly",			"shalimar",			"white"			}
+	}
+}
+
+/* color_name() returns a string with the name of the color corresponding to these RGB u8 values */
+static char* color_name(uint8_t red, uint8_t green, uint8_t blue)
+{
+	red		= ((red		+ 25) / 51);
+	green	= ((green	+ 25) / 51);
+	blue	= ((blue	+ 25) / 51);
+	return palette[red][green][blue];
+}
+#endif
 void swap_events(ass_event_t* nxt, ass_event_t* cur)
 {
 	ass_event_t tmp;
@@ -770,11 +847,99 @@ ass_parse_frames(
 		p = vod_copy(p, FIXED_WEBVTT_VOICE_END_STR, FIXED_WEBVTT_VOICE_END_WIDTH);
 #endif //ASSUME_STYLE_SUPPORT
 
+#ifdef ASSUME_CSS_SUPPORT
+		p = vod_copy(p, FIXED_WEBVTT_CLASSOPEN_START_STR, FIXED_WEBVTT_CLASSOPEN_START_WIDTH);
+		// insert primary color class
+		{
+			uint8_t alpha, red, green, blue;
+			alpha	= uint8_t(cur_style->primary_colour >> 24);
+			blue	= uint8_t(cur_style->primary_colour >> 16) && 0xFF;
+			green	= uint8_t(cur_style->primary_colour >>  8) && 0xFF;
+			red		= uint8_t(cur_style->primary_colour      ) && 0xFF;
+			p = vod_copy(p, FIXED_WEBVTT_COLOR_FULL_STR, FIXED_WEBVTT_COLOR_FULL_WIDTH);
+			p = vod_sprintf((u_char*)p, color_name(red, green, blue), vod_strlen(color_name(red, green, blue));
+			if (alpha <= 64)
+				p = vod_copy(p, FIXED_WEBVTT_ALPHA_FULL_STR, FIXED_WEBVTT_ALPHA_FULL_WIDTH);
+			else
+				p = vod_copy(p, FIXED_WEBVTT_ALPHA_HALF_STR, FIXED_WEBVTT_ALPHA_HALF_WIDTH);
+		}
+		// insert outline or background color
+		if (cur_style->border_style == 3)
+		{
+			// Opaque box with background color
+			uint8_t alpha, red, green, blue;
+			alpha	= uint8_t(cur_style->back_colour >> 24);
+			blue	= uint8_t(cur_style->back_colour >> 16) && 0xFF;
+			green	= uint8_t(cur_style->back_colour >>  8) && 0xFF;
+			red		= uint8_t(cur_style->back_colour      ) && 0xFF;
+			p = vod_copy(p, FIXED_WEBVTT_BACKGROUND_FULL_STR, FIXED_WEBVTT_BACKGROUND_FULL_WIDTH);
+			p = vod_sprintf((u_char*)p, color_name(red, green, blue), vod_strlen(color_name(red, green, blue));
+			if (alpha <= 64)
+				p = vod_copy(p, FIXED_WEBVTT_ALPHA_FULL_STR, FIXED_WEBVTT_ALPHA_FULL_WIDTH);
+			else
+				p = vod_copy(p, FIXED_WEBVTT_ALPHA_HALF_STR, FIXED_WEBVTT_ALPHA_HALF_WIDTH);
+		}
+		else if (cur_style->outline > 0 && cur_style->outline <= 4)
+		{
+			// Outline color as dictated, with size in pixels as dictated
+			uint8_t alpha, red, green, blue;
+			alpha	= uint8_t(cur_style->outline_colour >> 24);
+			blue	= uint8_t(cur_style->outline_colour >> 16) && 0xFF;
+			green	= uint8_t(cur_style->outline_colour >>  8) && 0xFF;
+			red		= uint8_t(cur_style->outline_colour      ) && 0xFF;
+			p = vod_copy(p, FIXED_WEBVTT_OUTLINE_FULL_STR, FIXED_WEBVTT_OUTLINE_FULL_WIDTH);
+			if (cur_style->outline == 1)
+				p 	= vod_copy(p, "1", 1);
+			else if (cur_style->outline == 2)
+				p 	= vod_copy(p, "2", 1);
+			else
+				p 	= vod_copy(p, "3", 1);
+			p = vod_sprintf((u_char*)p, color_name(red, green, blue), vod_strlen(color_name(red, green, blue));
+		}
+		// insert strikethrough
+		if (cur_style->strike_out)
+			p = vod_copy(p, FIXED_WEBVTT_STRIKE_THRU_STR, FIXED_WEBVTT_STRIKE_THRU_WIDTH);
+		// insert font-family
+		p = vod_copy(p, FIXED_WEBVTT_FONT_FAM_STR, FIXED_WEBVTT_FONT_FAM_WIDTH);
+		{
+			if (style->right_to_left_language)
+				p = vod_copy(p, FIXED_WEBVTT_ARABIC_FONT_STR, FIXED_WEBVTT_ARABIC_FONT_WIDTH);
+			else if ( !ass_strncasecmp(track->language, "Русский", 9) )
+				p = vod_copy(p, FIXED_WEBVTT_RUSSIAN_FONT_STR, FIXED_WEBVTT_RUSSIAN_FONT_WIDTH);
+			else if ( !ass_strncasecmp(cur_style->font_name, "Times New Roman", 15) )
+				p = vod_copy(p, FIXED_WEBVTT_TIMES_FONT_STR, FIXED_WEBVTT_TIMES_FONT_WIDTH);
+			else if ( !ass_strncasecmp(cur_style->font_name, "Trebuchet MS", 12) )
+				p = vod_copy(p, FIXED_WEBVTT_TREBUCHET_FONT_STR, FIXED_WEBVTT_TREBUCHET_FONT_WIDTH);
+			else if ( !ass_strncasecmp(cur_style->font_name, "Comic Sans MS", 13) )
+				p = vod_copy(p, FIXED_WEBVTT_COMIC_FONT_STR, FIXED_WEBVTT_COMIC_FONT_WIDTH);
+			else if ( !ass_strncasecmp(cur_style->font_name, "Lucida Console", 14) )
+				p = vod_copy(p, FIXED_WEBVTT_LUCIDA_FONT_STR, FIXED_WEBVTT_LUCIDA_FONT_WIDTH);
+			else if ( !ass_strncasecmp(cur_style->font_name, "Courier New", 11) )
+				p = vod_copy(p, FIXED_WEBVTT_COURIER_FONT_STR, FIXED_WEBVTT_COURIER_FONT_WIDTH);
+			else if ( !ass_strncasecmp(cur_style->font_name, "Times New Roman", 15) )
+				p = vod_copy(p, FIXED_WEBVTT_TIMES_FONT_STR, FIXED_WEBVTT_TIMES_FONT_WIDTH);
+			else
+				p = vod_copy(p, FIXED_WEBVTT_ARIAL_FONT_STR, FIXED_WEBVTT_ARIAL_FONT_WIDTH);
+		}
+		// insert font-size
+		p = vod_copy(p, FIXED_WEBVTT_FONT_SIZE_STR, FIXED_WEBVTT_FONT_SIZE_WIDTH);
+		if (cur_style->font_size < 16)
+			p = vod_snprintf((u_char*)p, 2, "%d", 16);
+		else if (cur_style->font_size > 45)
+			p = vod_snprintf((u_char*)p, 2, "%d", 45);
+		else
+			p = vod_snprintf((u_char*)p, 2, "%d", cur_style->font_size);
+
+		p = vod_copy(p, FIXED_WEBVTT_CLASSOPEN_END_STR, FIXED_WEBVTT_CLASSOPEN_END_WIDTH);
+#endif
+
 		for (chunkcounter = 0; chunkcounter < num_chunks_in_text; chunkcounter++)
 		{
 			 p = vod_copy(p, event_textp[chunkcounter], event_len[chunkcounter]);
 		}
-
+#ifdef ASSUME_CSS_SUPPORT
+		p = vod_copy(p, FIXED_WEBVTT_CLASSCLOSE_FULL_STR, FIXED_WEBVTT_CLASSCLOSE_FULL_WIDTH);
+#endif
 		p = vod_copy(p, "\r\n", 2);
 		// we still need an empty line after each event/cue
 		p = vod_copy(p, "\r\n", 2);

--- a/vod/subtitle/ass_format.h
+++ b/vod/subtitle/ass_format.h
@@ -12,6 +12,8 @@
 #define FFMIN(a,b) ((a) > (b) ? (b) : (a))
 #define FFMINMAX(c,a,b) FFMIN(FFMAX(c, a), b)
 
+#define TITLE_BYTES_CONSIDERED 14
+
 typedef enum
 {
 	PST_UNKNOWN = 0,

--- a/vod/subtitle/ass_parse.c
+++ b/vod/subtitle/ass_parse.c
@@ -51,7 +51,6 @@ static const unsigned char lowertab[] =
 	0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc,
 	0xfd, 0xfe, 0xff
 };
-
 static int ass_strcasecmp(const char *s1, const char *s2)
 {
 	unsigned char a, b;
@@ -64,8 +63,6 @@ static int ass_strcasecmp(const char *s1, const char *s2)
 
 	return a - b;
 }
-
-
 static int ass_strncasecmp(const char *s1, const char *s2, size_t n)
 {
 	unsigned char a, b;
@@ -94,16 +91,6 @@ void rskip_spaces(char **str, char *limit)
 	while ((p > limit) && ((p[-1] == ' ') || (p[-1] == '\t')))
 		--p;
 	*str = p;
-}
-
-static inline uint32_t ass_bswap32(uint32_t x)
-{
-#ifdef _MSC_VER
-	return _byteswap_ulong(x);
-#else
-	return	(x & 0x000000FF) << 24 | (x & 0x0000FF00) <<  8 |
-			(x & 0x00FF0000) >>  8 | (x & 0xFF000000) >> 24;
-#endif
 }
 
 static inline int ass_isspace(int c)
@@ -484,136 +471,21 @@ done:
 	return fraction;
 }
 
-int mystrtoi(char **p, int *res)
+void mystrtoi32(char **p, uint32_t *res)
 {
-	char *start = *p;
-	double temp_res = ass_strtod(*p, p);
-	*res = (int) (temp_res + (temp_res > 0 ? 0.5 : -0.5));
-	return *p != start;
-}
-
-int mystrtoll(char **p, long long *res)
-{
-	char *start = *p;
-	double temp_res = ass_strtod(*p, p);
-	*res = (long long) (temp_res + (temp_res > 0 ? 0.5 : -0.5));
-	return *p != start;
-}
-
-int mystrtod(char **p, double *res)
-{
-	char *start = *p;
-	*res = ass_strtod(*p, p);
-	return *p != start;
-}
-
-int mystrtoi32(char **p, int base, int32_t *res)
-{
-	char *start = *p;
-	long long temp_res = strtoll(*p, p, base);
-	*res = FFMINMAX(temp_res, INT32_MIN, INT32_MAX);
-	return *p != start;
-}
-
-static int read_digits(char **str, int base, uint32_t *res)
-{
-	char *p = *str;
-	char *start = p;
-	uint32_t val = 0;
-
-	while (1) {
-		int digit;
-		if (*p >= '0' && *p < FFMIN(base, 10) + '0')
-			digit = *p - '0';
-		else if (*p >= 'a' && *p < base - 10 + 'a')
-			digit = *p - 'a' + 10;
-		else if (*p >= 'A' && *p < base - 10 + 'A')
-			digit = *p - 'A' + 10;
-		else
-			break;
-		val = val * base + digit;
-		++p;
-	}
-
-	*res = val;
-	*str = p;
-	return p != start;
-}
-
-/*
- * \brief Convert a string to an integer reduced modulo 2**32
- * Follows the rules for strtoul but reduces the number modulo 2**32
- * instead of saturating it to 2**32 - 1.
- */
-static int mystrtou32_modulo(char **p, int base, uint32_t *res)
-{
-	// This emulates scanf with %d or %x format as it works on
-	// Windows, because that's what is used by VSFilter. In practice,
-	// scanf works the same way on other platforms too, but
-	// the standard leaves its behavior on overflow undefined.
-
-	// Unlike scanf and like strtoul, produce 0 for invalid inputs.
-
-	char *start = *p;
-	int sign = 1;
-
-	skip_spaces(p);
-
-	if (**p == '+')
-		++*p;
-	else if (**p == '-')
-		sign = -1, ++*p;
-
-	if (base == 16 && !ass_strncasecmp(*p, "0x", 2))
-		*p += 2;
-
-	if (read_digits(p, base, res)) {
-		*res *= sign;
-		return 1;
-	}
-	else
-	{
-		*p = start;
-		return 0;
-	}
-}
-int32_t parse_alpha_tag(char *str)
-{
-	int32_t alpha = 0;
-
-	while (*str == '&' || *str == 'H')
-		++str;
-
-	mystrtoi32(&str, 16, &alpha);
-	return alpha;
+	unsigned long temp_res = strtoul(*p, p, 16);
+	*res = FFMINMAX(temp_res, 0, 0xFFFFFFFF);
 }
 
 uint32_t parse_color_tag(char *str)
 {
-	int32_t color = 0;
+	uint32_t color = 0;
 
-	while (*str == '&' || *str == 'H')
+	while (*str == '&' || *str == 'H' || *str == 'h')
 		++str;
 
-	mystrtoi32(&str, 16, &color);
-	return ass_bswap32((uint32_t) color);
-}
-
-uint32_t parse_color_header(char *str)
-{
-	uint32_t color = 0;
-	int base;
-
-	if (!ass_strncasecmp(str, "&h", 2) || !ass_strncasecmp(str, "0x", 2))
-	{
-		str += 2;
-		base = 16;
-	}
-	else
-		base = 10;
-
-	mystrtou32_modulo(&str, base, &color);
-	return ass_bswap32(color);
+	mystrtoi32(&str, &color);
+	return color;
 }
 
 // Return a boolean value for a string
@@ -631,6 +503,8 @@ ass_track_t * ass_alloc_track(request_context_t *request_context)
 
 	track->play_res_x = 1920;
 	track->play_res_y = 1080;
+	track->language = strdup("English (US)");
+	track->title = strdup("English (US)");
 
 	return track;
 }
@@ -778,7 +652,7 @@ int lookup_style(ass_track_t *track, char *name)
 		++name;
 	// VSFilter then normalizes the case of "Default"
 	// (only in contexts where this function is called)
-	if (ass_strcasecmp(name, "Default") == 0)
+	if (!ass_strncasecmp(name, "Default", 7))
 		name = "Default";
 	for (i = track->n_styles - 1; i >= 0; --i)
 	{
@@ -792,49 +666,6 @@ int lookup_style(ass_track_t *track, char *name)
 #define NEXT(str,token) \
 	token = next_token(&str); \
 	if (!token) break;
-
-
-#define ALIAS(alias,name) \
-		if (ass_strcasecmp(tname, #alias) == 0) {tname = #name;}
-
-/* One section started with PARSE_START and PARSE_END parses a single token
- * (contained in the variable named token) for the header indicated by the
- * variable tname. It does so by chaining a number of else-if statements, each
- * of which checks if the tname variable indicates that this header should be
- * parsed. The first parameter of the macro gives the name of the header.
- *
- * The string that is passed is in str. str is advanced to the next token if
- * a header could be parsed. The parsed results are stored in the variable
- * target, which has the type ass_style_t* or ass_event_t*.
- */
-#define PARSE_START	if (0) {
-#define PARSE_END	}
-
-#define ANYVAL(name,func) \
-	} else if (ass_strcasecmp(tname, #name) == 0) { \
-		target->name = func(token);
-
-#define STRVAL(name) \
-	} else if (ass_strcasecmp(tname, #name) == 0) { \
-		if (target->name != NULL) free(target->name); \
-		target->name = strdup(token);
-
-#define STARREDSTRVAL(name) \
-	} else if (ass_strcasecmp(tname, #name) == 0) { \
-		if (target->name != NULL) free(target->name); \
-		while (*token == '*') ++token; \
-		target->name = strdup(token);
-
-#define COLORVAL(name) ANYVAL(name,parse_color_header)
-#define INTVAL(name) ANYVAL(name,atoi)
-#define FPVAL(name) ANYVAL(name,ass_atof)
-#define TIMEVAL(name) \
-	} else if (ass_strcasecmp(tname, #name) == 0) { \
-		target->name = string2timecode(token);
-
-#define STYLEVAL(name) \
-	} else if (ass_strcasecmp(tname, #name) == 0) { \
-		target->name = lookup_style(track, token);
 
 static char *next_token(char **str)
 {
@@ -889,7 +720,7 @@ static int process_event_tail(ass_track_t *track, ass_event_t *event, char *str)
 	while (1)
 	{
 		NEXT(q, tname);
-		if (ass_strcasecmp(tname, "Text") == 0)
+		if (!ass_strcasecmp(tname, "Text"))
 		{
 			char *last;
 			event->text = strdup(p);
@@ -908,17 +739,19 @@ static int process_event_tail(ass_track_t *track, ass_event_t *event, char *str)
 		}
 		NEXT(p, token);
 
-		PARSE_START
-			INTVAL(layer)
-			STYLEVAL(style)
-			STRVAL(name)
-			STRVAL(effect)
-			INTVAL(margin_l)
-			INTVAL(margin_r)
-			INTVAL(margin_v)
-			TIMEVAL(start)
-			TIMEVAL(end)
-		PARSE_END
+		if (!ass_strcasecmp(tname, "Start")) {
+			target->start = string2timecode(token);
+		} else if (!ass_strcasecmp(tname, "End")) {
+			target->end = string2timecode(token);
+		} else if (!ass_strcasecmp(tname, "MarginL")) {
+			target->margin_l	= atoi(token);
+		} else if (!ass_strcasecmp(tname, "MarginR")) {
+			target->margin_r	= atoi(token);
+		} else if (!ass_strcasecmp(tname, "MarginV")) {
+			target->margin_v	= atoi(token);
+		} else if (!ass_strcasecmp(tname, "Style")) {
+			target->style		= lookup_style(track, token);
+		}
 	}
 	free(format);
 	return 1;
@@ -970,16 +803,11 @@ static int process_style(ass_track_t *track, char *str, request_context_t* reque
 		if (track->track_type == TRACK_TYPE_SSA)
 			track->style_format =
 				strdup
-				("Name, Fontname, Fontsize, PrimaryColour, SecondaryColour,"
-				 "TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline,"
-				 "Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding");
+				("Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding");
 		else
 			track->style_format =
 				strdup
-				("Name, Fontname, Fontsize, PrimaryColour, SecondaryColour,"
-				 "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut,"
-				 "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow,"
-				 "Alignment, MarginL, MarginR, MarginV, Encoding");
+				("Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding");
 	}
 
 	q = format = strdup(track->style_format);
@@ -1005,47 +833,74 @@ static int process_style(ass_track_t *track, char *str, request_context_t* reque
 		NEXT(q, tname);
 		NEXT(p, token);
 
-		PARSE_START
-			STARREDSTRVAL(name)
-			if (strcmp(target->name, "Default") == 0)
-				track->default_style = sid;
-			STRVAL(font_name)
-			COLORVAL(primary_colour)
-			COLORVAL(secondary_colour)
-			COLORVAL(outline_colour) // TertiaryColor
-			COLORVAL(back_colour)
-			// SSA uses BackColour for both outline and shadow
-			// this will destroy SSA's TertiaryColour, but i'm not going to use it anyway
-			if (track->track_type == TRACK_TYPE_SSA)
-				target->outline_colour = target->back_colour;
-			INTVAL(font_size)
-			INTVAL(bold)
-			INTVAL(italic)
-			INTVAL(underline)
-			INTVAL(strike_out)
-			FPVAL(spacing)
-			FPVAL(angle)
-			INTVAL(border_style)
-			INTVAL(alignment)
-			if (track->track_type == TRACK_TYPE_ASS)
-			{
-				target->alignment = numpad2align(target->alignment);
-			}
-			// VSFilter compatibility
-			else if (target->alignment == 8)
-				target->alignment = 3;
-			else if (target->alignment == 4)
-				target->alignment = 11;
-			INTVAL(margin_l)
-			INTVAL(margin_r)
-			INTVAL(margin_v)
-			INTVAL(encoding)
-			FPVAL(scale_x)
-			FPVAL(scale_y)
-			INTVAL(outline)
-			INTVAL(shadow)
-		PARSE_END
+		if (!ass_strcasecmp(tname, "Name")) {
+			if (target->name != NULL) free(target->name);
+			target->name = strdup(token);
+		} else if (!ass_strcasecmp(tname, "Fontname")) {
+			if (target->font_name != NULL) free(target->font_name);
+			target->font_name = strdup(token);
+		} else if (!ass_strcasecmp(tname, "Fontsize")) {
+			target->font_size			= atoi(token);
+		} else if (!ass_strcasecmp(tname, "PrimaryColour")) {
+			target->primary_colour		= parse_color_tag(token);
+		} else if (!ass_strcasecmp(tname, "OutlineColour")) {
+			target->outline_colour 		= parse_color_tag(token);
+		} else if (!ass_strcasecmp(tname, "BackColour")) {
+			target->back_colour			= parse_color_tag(token);
+
+		} else if (!ass_strcasecmp(tname, "Bold")) {
+			target->bold				= atoi(token);
+		} else if (!ass_strcasecmp(tname, "Italic")) {
+			target->italic				= atoi(token);
+		} else if (!ass_strcasecmp(tname, "Underline")) {
+			target->underline			= atoi(token);
+		} else if (!ass_strcasecmp(tname, "StrikeOut")) {
+			target->strike_out			= atoi(token);
+		} else if (!ass_strcasecmp(tname, "BorderStyle")) {
+			target->border_style		= atoi(token);
+		} else if (!ass_strcasecmp(tname, "Alignment")) {
+			target->alignment			= atoi(token);
+		} else if (!ass_strcasecmp(tname, "MarginL")) {
+			target->margin_l			= atoi(token);
+		} else if (!ass_strcasecmp(tname, "MarginR")) {
+			target->margin_r			= atoi(token);
+		} else if (!ass_strcasecmp(tname, "MarginV")) {
+			target->margin_v			= atoi(token);
+		} else if (!ass_strcasecmp(tname, "Outline")) {
+			target->outline				= atoi(token);
+
+		/*
+		} else if (!ass_strcasecmp(tname, "SecondaryColour")) {
+			target->secondary_colour	= parse_color_tag(token);
+		} else if (!ass_strcasecmp(tname, "Shadow")) {
+			target->shadow				= atoi(token);
+		} else if (!ass_strcasecmp(tname, "Spacing")) {
+				target->spacing			= ass_atof(token);
+		} else if (!ass_strcasecmp(tname, "Angle")) {
+				target->angle			= ass_atof(token);
+		} else if (!ass_strcasecmp(tname, "ScaleX")) {
+				target->scale_x			= ass_atof(token);
+		} else if (!ass_strcasecmp(tname, "ScaleY")) {
+				target->scale_y			= ass_atof(token);
+		*/
+		}
 	}
+	if (strcmp(style->name, "Default") == 0)
+		track->default_style = sid;
+	// SSA uses BackColour for both outline and shadow
+	// this will destroy SSA's TertiaryColour, but i'm not going to use it anyway
+	if (track->track_type == TRACK_TYPE_SSA)
+		style->outline_colour = style->back_colour;
+	if (track->track_type == TRACK_TYPE_ASS)
+	{
+		style->alignment = numpad2align(style->alignment);
+	}
+	// VSFilter compatibility
+	else if (style->alignment == 8)
+		style->alignment = 3;
+	else if (style->alignment == 4)
+		style->alignment = 11;
+
 	style->scale_x		= FFMAX(style->scale_x, 0.) / 100.;
 	style->scale_y		= FFMAX(style->scale_y, 0.) / 100.;
 	style->spacing		= FFMAX(style->spacing, 0.);
@@ -1060,6 +915,7 @@ static int process_style(ass_track_t *track, char *str, request_context_t* reque
 		style->name		= strdup("Default");
 	if (!style->font_name)
 		style->font_name = strdup("Arial");
+
 
 	// For now, right_to_left_language is TRUE only for Arabic language. In future, it will be enabled for many others.
 	if ( !ass_strncasecmp(style->font_name, "Adobe Arabic", 12) )
@@ -1083,7 +939,8 @@ static int process_styles_line(ass_track_t *track, char *str, request_context_t*
 		skip_spaces(&p);
 		free(track->style_format);
 		track->style_format = strdup(p);
-	} else if (!strncmp(str, "Style:", 6))
+	}
+	else if (!strncmp(str, "Style:", 6))
 	{
 		char *p = str + 6;
 		skip_spaces(&p);
@@ -1126,23 +983,25 @@ static int process_info_line(ass_track_t *track, char *str, request_context_t* r
 	{
 		// This field is not part of the ASS/SSA specs
 		char *p = str + 9;
+		char *strt, *end;
 		while (*p && ass_isspace(*p)) p++;
+		strt = p;
+		while (*p && !ass_isspace(*p)) p++;
+		end = p;
 		free(track->language);
-		track->language = strndup(p, 2);
+		track->language = strndup(strt, FFMAX(TITLE_BYTES_CONSIDERED, (size_t)(end-strt)));
 	} else if (!strncmp(str, "Title:", 6))
 	{
 		char *p = str + 6;
 		char *strt, *end;
-		while (*p && ass_isspace(*p))
-			p++;
+		while (*p && ass_isspace(*p)) p++;
 		strt = p;
-		while (*p && !ass_isspace(*p))
-			p++;
+		while (*p && !ass_isspace(*p)) p++;
 		end = p;
 		free(track->title);
+		track->title = strndup(strt, FFMAX(TITLE_BYTES_CONSIDERED, (size_t)(end-strt)));
 		// Title: ﺎﻠﻋﺮﺒﻳﺓ
-		track->title = strndup(p, FFMAX(14, (size_t)(end-strt)));
-		track->right_to_left_language = ((14 == (end-strt)) && (strt[0] == (char)0xD8) && (strt[13] == (char)0xA9));
+		track->right_to_left_language = ((TITLE_BYTES_CONSIDERED == (end-strt)) && (strt[0] == (char)0xD8) && (strt[13] == (char)0xA9));
 	}
 	return 0;
 }
@@ -1151,11 +1010,9 @@ static void event_format_fallback(ass_track_t *track)
 {
 	track->state = PST_EVENTS;
 	if (track->track_type == TRACK_TYPE_SSA)
-		track->event_format = strdup("Marked, Start, End, Style, "
-			"Name, MarginL, MarginR, MarginV, Effect, Text");
+		track->event_format = strdup("Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text");
 	else
-		track->event_format = strdup("Layer, Start, End, Style, "
-			"Actor, MarginL, MarginR, MarginV, Effect, Text");
+		track->event_format = strdup("Layer, Start, End, Style, Actor, MarginL, MarginR, MarginV, Effect, Text");
 }
 
 static int process_events_line(ass_track_t *track, char *str, request_context_t* request_context)

--- a/vod/subtitle/ass_parse.c
+++ b/vod/subtitle/ass_parse.c
@@ -726,10 +726,10 @@ static void set_default_style(ass_style_t *style, bool_t alloc_names)
 		style->font_name		= strdup("Arial");
 	}
 	style->font_size			= 18;
-	style->primary_colour		= 0xffffff00;
+	style->primary_colour		= 0x00ffffff;
 	style->secondary_colour		= 0x00ffff00;
 	style->outline_colour		= 0x00000000;
-	style->back_colour			= 0x00000080;
+	style->back_colour			= 0x80000000;
 	style->bold					= FALSE;
 	style->italic				= FALSE;
 	style->underline			= FALSE;

--- a/vod/subtitle/ass_parse.c
+++ b/vod/subtitle/ass_parse.c
@@ -885,6 +885,7 @@ static int process_style(ass_track_t *track, char *str, request_context_t* reque
 		*/
 		}
 	}
+
 	if (strcmp(style->name, "Default") == 0)
 		track->default_style = sid;
 	// SSA uses BackColour for both outline and shadow

--- a/vod/subtitle/css/crstyles.css
+++ b/vod/subtitle/css/crstyles.css
@@ -1,0 +1,2194 @@
+/* https://www.w3schools.com/css/css_colors.asp */
+/* https://www.w3schools.com/colors/color_tryit.asp?hex=EE82EE */
+/* http://chir.ag/projects/name-that-color/#404000 */
+
+/* COLORS */
+/* ====== */
+::cue(.color_black_full)         {color: rgba(0, 0, 0, 1);}
+::cue(.color_stratos_full)       {color: rgba(0, 0, 64, 1);}
+::cue(.color_navy_full)          {color: rgba(0, 0, 128, 1);}
+::cue(.color_mediumblue_full)    {color: rgba(0, 0, 192, 1);}
+::cue(.color_blue_full)          {color: rgba(0, 0, 255, 1);}
+::cue(.color_deepfir_full)       {color: rgba(0, 64, 0, 1);}
+::cue(.color_cyprus_full)        {color: rgba(0, 64, 64, 1);}
+::cue(.color_congressblue_full)  {color: rgba(0, 64, 128, 1);}
+::cue(.color_cobalt_full)        {color: rgba(0, 64, 192, 1);}
+::cue(.color_blueribbon_full)    {color: rgba(0, 64, 255, 1);}
+::cue(.color_japlaurel_full)     {color: rgba(0, 128, 0, 1);}
+::cue(.color_fungreen_full)      {color: rgba(0, 128, 64, 1);}
+::cue(.color_teal_full)          {color: rgba(0, 128, 128, 1);}
+::cue(.color_lochmara_full)      {color: rgba(0, 128, 192, 1);}
+::cue(.color_azure_full)         {color: rgba(0, 128, 255, 1);}
+::cue(.color_forest_full)        {color: rgba(0, 192, 0, 1);}
+::cue(.color_malachite_full)     {color: rgba(0, 192, 64, 1);}
+::cue(.color_caribbean_full)     {color: rgba(0, 192, 128, 1);}
+::cue(.color_eggblue_full)       {color: rgba(0, 192, 192, 1);}
+::cue(.color_cerulean_full)      {color: rgba(0, 192, 255, 1);}
+::cue(.color_green_full)         {color: rgba(0, 255, 0, 1);}
+::cue(.color_lime_full)          {color: rgba(0, 255, 64, 1);}
+::cue(.color_springgreen_full)   {color: rgba(0, 255, 128, 1);}
+::cue(.color_brightturq_full)    {color: rgba(0, 255, 64, 1);}
+::cue(.color_cyan_full)          {color: rgba(0, 255, 255, 1);}
+::cue(.color_temptress_full)     {color: rgba(64, 0, 0, 1);}
+::cue(.color_blackberry_full)    {color: rgba(64, 0, 64, 1);}
+::cue(.color_indigo_full)        {color: rgba(64, 0, 128, 1);}
+::cue(.color_purpleblue_full)    {color: rgba(64, 0, 192, 1);}
+::cue(.color_redblue_full)       {color: rgba(64, 0, 255, 1);}
+::cue(.color_verdun_full)        {color: rgba(64, 64, 0, 1);}
+::cue(.color_tundora_full)       {color: rgba(64, 64, 64, 1);}
+::cue(.color_eastbay_full)       {color: rgba(64, 64, 128, 1);}
+::cue(.color_governor_full)      {color: rgba(64, 64, 192, 1);}
+::cue(.color_royalblue_full)     {color: rgba(64, 64, 255, 1);}
+::cue(.color_limeade_full)       {color: rgba(64, 128, 0, 1);}
+::cue(.color_goblin_full)        {color: rgba(64, 128, 64, 1);}
+::cue(.color_fadedjade_full)     {color: rgba(64, 128, 128, 1);}
+::cue(.color_steelblue_full)     {color: rgba(64, 128, 192, 1);}
+::cue(.color_dodger_full)        {color: rgba(64, 128, 255, 1);}
+::cue(.color_harlequin_full)     {color: rgba(64, 192, 0, 1);}
+::cue(.color_emerald_full)       {color: rgba(64, 192, 64, 1);}
+::cue(.color_shamrock_full)      {color: rgba(64, 192, 128, 1);}
+::cue(.color_pelorous_full)      {color: rgba(64, 192, 192, 1);}
+::cue(.color_dodgerblue_full)    {color: rgba(64, 192, 255, 1);}
+::cue(.color_brightgreen_full)   {color: rgba(64, 255, 0, 1);}
+::cue(.color_pastelgreen_full)   {color: rgba(64, 255, 64, 1);}
+::cue(.color_screamingreen_full) {color: rgba(64, 255, 128, 1);}
+::cue(.color_aquamarine_full)    {color: rgba(64, 255, 64, 1);}
+::cue(.color_aqua_full)          {color: rgba(64, 255, 255, 1);}
+::cue(.color_maroon_full)        {color: rgba(128, 0, 0, 1);}
+::cue(.color_siren_full)         {color: rgba(128, 0, 64, 1);}
+::cue(.color_eggplant_full)      {color: rgba(128, 0, 128, 1);}
+::cue(.color_purple_full)        {color: rgba(128, 0, 192, 1);}
+::cue(.color_electric_full)      {color: rgba(128, 0, 255, 1);}
+::cue(.color_cinnamon_full)      {color: rgba(128, 64, 0, 1);}
+::cue(.color_lotus_full)         {color: rgba(128, 64, 64, 1);}
+::cue(.color_cannonpink_full)    {color: rgba(128, 64, 128, 1);}
+::cue(.color_fuchsiablue_full)   {color: rgba(128, 64, 192, 1);}
+::cue(.color_heliotrope_full)    {color: rgba(128, 64, 255, 1);}
+::cue(.color_olive_full)         {color: rgba(128, 128, 0, 1);}
+::cue(.color_yellowmetal_full)   {color: rgba(128, 128, 64, 1);}
+::cue(.color_gray_full)          {color: rgba(128, 128, 128, 1);}
+::cue(.color_yonder_full)        {color: rgba(128, 128, 192, 1);}
+::cue(.color_malibu_full)        {color: rgba(128, 128, 255, 1);}
+::cue(.color_pistachio_full)     {color: rgba(128, 192, 0, 1);}
+::cue(.color_wasabi_full)        {color: rgba(128, 192, 64, 1);}
+::cue(.color_deyork_full)        {color: rgba(128, 192, 128, 1);}
+::cue(.color_neptune_full)       {color: rgba(128, 192, 192, 1);}
+::cue(.color_anakiwa_full)       {color: rgba(128, 192, 255, 1);}
+::cue(.color_chartreuse_full)    {color: rgba(128, 255, 0, 1);}
+::cue(.color_greenyellow_full)   {color: rgba(128, 255, 64, 1);}
+::cue(.color_mintgreen_full)     {color: rgba(128, 255, 128, 1);}
+::cue(.color_magicmint_full)     {color: rgba(128, 255, 192, 1);}
+::cue(.color_turquoise_full)     {color: rgba(128, 255, 255, 1);}
+::cue(.color_guardsman_full)     {color: rgba(192, 0, 0, 1);}
+::cue(.color_monza_full)         {color: rgba(192, 0, 64, 1);}
+::cue(.color_flirt_full)         {color: rgba(192, 0, 128, 1);}
+::cue(.color_cerise_full)        {color: rgba(192, 0, 192, 1);}
+::cue(.color_purpleheart_full)   {color: rgba(192, 0, 255, 1);}
+::cue(.color_sharonrose_full)    {color: rgba(192, 64, 0, 1);}
+::cue(.color_crail_full)         {color: rgba(192, 64, 64, 1);}
+::cue(.color_mulberry_full)      {color: rgba(192, 64, 128, 1);}
+::cue(.color_amethyst_full)      {color: rgba(192, 64, 192, 1);}
+::cue(.color_violet_full)        {color: rgba(192, 64, 255, 1);}
+::cue(.color_pirategold_full)    {color: rgba(192, 128, 0, 1);}
+::cue(.color_tussock_full)       {color: rgba(192, 128, 64, 1);}
+::cue(.color_oldrose_full)       {color: rgba(192, 128, 128, 1);}
+::cue(.color_viola_full)         {color: rgba(192, 128, 192, 1);}
+::cue(.color_orchid_full)        {color: rgba(192, 128, 255, 1);}
+::cue(.color_buddhagold_full)    {color: rgba(192, 192, 0, 1);}
+::cue(.color_turmeric_full)      {color: rgba(192, 192, 64, 1);}
+::cue(.color_pineglade_full)     {color: rgba(192, 192, 128, 1);}
+::cue(.color_silver_full)        {color: rgba(192, 192, 192, 1);}
+::cue(.color_melrose_full)       {color: rgba(192, 192, 255, 1);}
+::cue(.color_laspalmas_full)     {color: rgba(192, 255, 0, 1);}
+::cue(.color_starship_full)      {color: rgba(192, 255, 64, 1);}
+::cue(.color_reef_full)          {color: rgba(192, 255, 128, 1);}
+::cue(.color_snowymint_full)     {color: rgba(192, 255, 192, 1);}
+::cue(.color_onahau_full)        {color: rgba(192, 255, 255, 1);}
+::cue(.color_red_full)           {color: rgba(255, 0, 0, 1);}
+::cue(.color_torchred_full)      {color: rgba(255, 0, 64, 1);}
+::cue(.color_rose_full)          {color: rgba(255, 0, 128, 1);}
+::cue(.color_pizzazz_full)       {color: rgba(255, 0, 192, 1);}
+::cue(.color_magenta_full)       {color: rgba(255, 0, 255, 1);}
+::cue(.color_vermilion_full)     {color: rgba(255, 64, 0, 1);}
+::cue(.color_coral_full)         {color: rgba(255, 64, 64, 1);}
+::cue(.color_strawberry_full)    {color: rgba(255, 64, 128, 1);}
+::cue(.color_razzledazzle_full)  {color: rgba(255, 64, 192, 1);}
+::cue(.color_flamingo_full)      {color: rgba(255, 64, 255, 1);}
+::cue(.color_flushorange_full)   {color: rgba(255, 128, 0, 1);}
+::cue(.color_crusta_full)        {color: rgba(255, 128, 64, 1);}
+::cue(.color_vividtangerine_full){color: rgba(255, 128, 128, 1);}
+::cue(.color_hotpink_full)       {color: rgba(255, 128, 192, 1);}
+::cue(.color_blushpink_full)     {color: rgba(255, 128, 255, 1);}
+::cue(.color_amber_full)         {color: rgba(255, 192, 0, 1);}
+::cue(.color_yelloworange_full)  {color: rgba(255, 192, 64, 1);}
+::cue(.color_macncheese_full)    {color: rgba(255, 192, 128, 1);}
+::cue(.color_yourpink_full)      {color: rgba(255, 192, 192, 1);}
+::cue(.color_pinklace_full)      {color: rgba(255, 192, 255, 1);}
+::cue(.color_yellow_full)        {color: rgba(255, 255, 0, 1);}
+::cue(.color_goldenfizz_full)    {color: rgba(255, 255, 64, 1);}
+::cue(.color_dolly_full)         {color: rgba(255, 255, 128, 1);}
+::cue(.color_shalimar_full)      {color: rgba(255, 255, 192, 1);}
+::cue(.color_white_full)         {color: rgba(255, 255, 255, 1);}
+
+::cue(.color_black_half)         {color: rgba(0, 0, 0, 0.5);}
+::cue(.color_stratos_half)       {color: rgba(0, 0, 64, 0.5);}
+::cue(.color_navy_half)          {color: rgba(0, 0, 128, 0.5);}
+::cue(.color_mediumblue_half)    {color: rgba(0, 0, 192, 0.5);}
+::cue(.color_blue_half)          {color: rgba(0, 0, 255, 0.5);}
+::cue(.color_deepfir_half)       {color: rgba(0, 64, 0, 0.5);}
+::cue(.color_cyprus_half)        {color: rgba(0, 64, 64, 0.5);}
+::cue(.color_congressblue_half)  {color: rgba(0, 64, 128, 0.5);}
+::cue(.color_cobalt_half)        {color: rgba(0, 64, 192, 0.5);}
+::cue(.color_blueribbon_half)    {color: rgba(0, 64, 255, 0.5);}
+::cue(.color_japlaurel_half)     {color: rgba(0, 128, 0, 0.5);}
+::cue(.color_fungreen_half)      {color: rgba(0, 128, 64, 0.5);}
+::cue(.color_teal_half)          {color: rgba(0, 128, 128, 0.5);}
+::cue(.color_lochmara_half)      {color: rgba(0, 128, 192, 0.5);}
+::cue(.color_azure_half)         {color: rgba(0, 128, 255, 0.5);}
+::cue(.color_forest_half)        {color: rgba(0, 192, 0, 0.5);}
+::cue(.color_malachite_half)     {color: rgba(0, 192, 64, 0.5);}
+::cue(.color_caribbean_half)     {color: rgba(0, 192, 128, 0.5);}
+::cue(.color_eggblue_half)       {color: rgba(0, 192, 192, 0.5);}
+::cue(.color_cerulean_half)      {color: rgba(0, 192, 255, 0.5);}
+::cue(.color_green_half)         {color: rgba(0, 255, 0, 0.5);}
+::cue(.color_lime_half)          {color: rgba(0, 255, 64, 0.5);}
+::cue(.color_springgreen_half)   {color: rgba(0, 255, 128, 0.5);}
+::cue(.color_brightturq_half)    {color: rgba(0, 255, 64, 0.5);}
+::cue(.color_cyan_half)          {color: rgba(0, 255, 255, 0.5);}
+::cue(.color_temptress_half)     {color: rgba(64, 0, 0, 0.5);}
+::cue(.color_blackberry_half)    {color: rgba(64, 0, 64, 0.5);}
+::cue(.color_indigo_half)        {color: rgba(64, 0, 128, 0.5);}
+::cue(.color_purpleblue_half)    {color: rgba(64, 0, 192, 0.5);}
+::cue(.color_redblue_half)       {color: rgba(64, 0, 255, 0.5);}
+::cue(.color_verdun_half)        {color: rgba(64, 64, 0, 0.5);}
+::cue(.color_tundora_half)       {color: rgba(64, 64, 64, 0.5);}
+::cue(.color_eastbay_half)       {color: rgba(64, 64, 128, 0.5);}
+::cue(.color_governor_half)      {color: rgba(64, 64, 192, 0.5);}
+::cue(.color_royalblue_half)     {color: rgba(64, 64, 255, 0.5);}
+::cue(.color_limeade_half)       {color: rgba(64, 128, 0, 0.5);}
+::cue(.color_goblin_half)        {color: rgba(64, 128, 64, 0.5);}
+::cue(.color_fadedjade_half)     {color: rgba(64, 128, 128, 0.5);}
+::cue(.color_steelblue_half)     {color: rgba(64, 128, 192, 0.5);}
+::cue(.color_dodger_half)        {color: rgba(64, 128, 255, 0.5);}
+::cue(.color_harlequin_half)     {color: rgba(64, 192, 0, 0.5);}
+::cue(.color_emerald_half)       {color: rgba(64, 192, 64, 0.5);}
+::cue(.color_shamrock_half)      {color: rgba(64, 192, 128, 0.5);}
+::cue(.color_pelorous_half)      {color: rgba(64, 192, 192, 0.5);}
+::cue(.color_dodgerblue_half)    {color: rgba(64, 192, 255, 0.5);}
+::cue(.color_brightgreen_half)   {color: rgba(64, 255, 0, 0.5);}
+::cue(.color_pastelgreen_half)   {color: rgba(64, 255, 64, 0.5);}
+::cue(.color_screamingreen_half) {color: rgba(64, 255, 128, 0.5);}
+::cue(.color_aquamarine_half)    {color: rgba(64, 255, 64, 0.5);}
+::cue(.color_aqua_half)          {color: rgba(64, 255, 255, 0.5);}
+::cue(.color_maroon_half)        {color: rgba(128, 0, 0, 0.5);}
+::cue(.color_siren_half)         {color: rgba(128, 0, 64, 0.5);}
+::cue(.color_eggplant_half)      {color: rgba(128, 0, 128, 0.5);}
+::cue(.color_purple_half)        {color: rgba(128, 0, 192, 0.5);}
+::cue(.color_electric_half)      {color: rgba(128, 0, 255, 0.5);}
+::cue(.color_cinnamon_half)      {color: rgba(128, 64, 0, 0.5);}
+::cue(.color_lotus_half)         {color: rgba(128, 64, 64, 0.5);}
+::cue(.color_cannonpink_half)    {color: rgba(128, 64, 128, 0.5);}
+::cue(.color_fuchsiablue_half)   {color: rgba(128, 64, 192, 0.5);}
+::cue(.color_heliotrope_half)    {color: rgba(128, 64, 255, 0.5);}
+::cue(.color_olive_half)         {color: rgba(128, 128, 0, 0.5);}
+::cue(.color_yellowmetal_half)   {color: rgba(128, 128, 64, 0.5);}
+::cue(.color_gray_half)          {color: rgba(128, 128, 128, 0.5);}
+::cue(.color_yonder_half)        {color: rgba(128, 128, 192, 0.5);}
+::cue(.color_malibu_half)        {color: rgba(128, 128, 255, 0.5);}
+::cue(.color_pistachio_half)     {color: rgba(128, 192, 0, 0.5);}
+::cue(.color_wasabi_half)        {color: rgba(128, 192, 64, 0.5);}
+::cue(.color_deyork_half)        {color: rgba(128, 192, 128, 0.5);}
+::cue(.color_neptune_half)       {color: rgba(128, 192, 192, 0.5);}
+::cue(.color_anakiwa_half)       {color: rgba(128, 192, 255, 0.5);}
+::cue(.color_chartreuse_half)    {color: rgba(128, 255, 0, 0.5);}
+::cue(.color_greenyellow_half)   {color: rgba(128, 255, 64, 0.5);}
+::cue(.color_mintgreen_half)     {color: rgba(128, 255, 128, 0.5);}
+::cue(.color_magicmint_half)     {color: rgba(128, 255, 192, 0.5);}
+::cue(.color_turquoise_half)     {color: rgba(128, 255, 255, 0.5);}
+::cue(.color_guardsman_half)     {color: rgba(192, 0, 0, 0.5);}
+::cue(.color_monza_half)         {color: rgba(192, 0, 64, 0.5);}
+::cue(.color_flirt_half)         {color: rgba(192, 0, 128, 0.5);}
+::cue(.color_cerise_half)        {color: rgba(192, 0, 192, 0.5);}
+::cue(.color_purpleheart_half)   {color: rgba(192, 0, 255, 0.5);}
+::cue(.color_sharonrose_half)    {color: rgba(192, 64, 0, 0.5);}
+::cue(.color_crail_half)         {color: rgba(192, 64, 64, 0.5);}
+::cue(.color_mulberry_half)      {color: rgba(192, 64, 128, 0.5);}
+::cue(.color_amethyst_half)      {color: rgba(192, 64, 192, 0.5);}
+::cue(.color_violet_half)        {color: rgba(192, 64, 255, 0.5);}
+::cue(.color_pirategold_half)    {color: rgba(192, 128, 0, 0.5);}
+::cue(.color_tussock_half)       {color: rgba(192, 128, 64, 0.5);}
+::cue(.color_oldrose_half)       {color: rgba(192, 128, 128, 0.5);}
+::cue(.color_viola_half)         {color: rgba(192, 128, 192, 0.5);}
+::cue(.color_orchid_half)        {color: rgba(192, 128, 255, 0.5);}
+::cue(.color_buddhagold_half)    {color: rgba(192, 192, 0, 0.5);}
+::cue(.color_turmeric_half)      {color: rgba(192, 192, 64, 0.5);}
+::cue(.color_pineglade_half)     {color: rgba(192, 192, 128, 0.5);}
+::cue(.color_silver_half)        {color: rgba(192, 192, 192, 0.5);}
+::cue(.color_melrose_half)       {color: rgba(192, 192, 255, 0.5);}
+::cue(.color_laspalmas_half)     {color: rgba(192, 255, 0, 0.5);}
+::cue(.color_starship_half)      {color: rgba(192, 255, 64, 0.5);}
+::cue(.color_reef_half)          {color: rgba(192, 255, 128, 0.5);}
+::cue(.color_snowymint_half)     {color: rgba(192, 255, 192, 0.5);}
+::cue(.color_onahau_half)        {color: rgba(192, 255, 255, 0.5);}
+::cue(.color_red_half)           {color: rgba(255, 0, 0, 0.5);}
+::cue(.color_torchred_half)      {color: rgba(255, 0, 64, 0.5);}
+::cue(.color_rose_half)          {color: rgba(255, 0, 128, 0.5);}
+::cue(.color_pizzazz_half)       {color: rgba(255, 0, 192, 0.5);}
+::cue(.color_magenta_half)       {color: rgba(255, 0, 255, 0.5);}
+::cue(.color_vermilion_half)     {color: rgba(255, 64, 0, 0.5);}
+::cue(.color_coral_half)         {color: rgba(255, 64, 64, 0.5);}
+::cue(.color_strawberry_half)    {color: rgba(255, 64, 128, 0.5);}
+::cue(.color_razzledazzle_half)  {color: rgba(255, 64, 192, 0.5);}
+::cue(.color_flamingo_half)      {color: rgba(255, 64, 255, 0.5);}
+::cue(.color_flushorange_half)   {color: rgba(255, 128, 0, 0.5);}
+::cue(.color_crusta_half)        {color: rgba(255, 128, 64, 0.5);}
+::cue(.color_vividtangerine_half){color: rgba(255, 128, 128, 0.5);}
+::cue(.color_hotpink_half)       {color: rgba(255, 128, 192, 0.5);}
+::cue(.color_blushpink_half)     {color: rgba(255, 128, 255, 0.5);}
+::cue(.color_amber_half)         {color: rgba(255, 192, 0, 0.5);}
+::cue(.color_yelloworange_half)  {color: rgba(255, 192, 64, 0.5);}
+::cue(.color_macncheese_half)    {color: rgba(255, 192, 128, 0.5);}
+::cue(.color_yourpink_half)      {color: rgba(255, 192, 192, 0.5);}
+::cue(.color_pinklace_half)      {color: rgba(255, 192, 255, 0.5);}
+::cue(.color_yellow_half)        {color: rgba(255, 255, 0, 0.5);}
+::cue(.color_goldenfizz_half)    {color: rgba(255, 255, 64, 0.5);}
+::cue(.color_dolly_half)         {color: rgba(255, 255, 128, 0.5);}
+::cue(.color_shalimar_half)      {color: rgba(255, 255, 192, 0.5);}
+::cue(.color_white_half)         {color: rgba(255, 255, 255, 0.5);}
+
+/* BACKGROUND COLORS */
+/* ================= */
+::cue(.bkcolor_black_full)         {background-color: rgba(0, 0, 0, 1);}
+::cue(.bkcolor_stratos_full)       {background-color: rgba(0, 0, 64, 1);}
+::cue(.bkcolor_navy_full)          {background-color: rgba(0, 0, 128, 1);}
+::cue(.bkcolor_mediumblue_full)    {background-color: rgba(0, 0, 192, 1);}
+::cue(.bkcolor_blue_full)          {background-color: rgba(0, 0, 255, 1);}
+::cue(.bkcolor_deepfir_full)       {background-color: rgba(0, 64, 0, 1);}
+::cue(.bkcolor_cyprus_full)        {background-color: rgba(0, 64, 64, 1);}
+::cue(.bkcolor_congressblue_full)  {background-color: rgba(0, 64, 128, 1);}
+::cue(.bkcolor_cobalt_full)        {background-color: rgba(0, 64, 192, 1);}
+::cue(.bkcolor_blueribbon_full)    {background-color: rgba(0, 64, 255, 1);}
+::cue(.bkcolor_japlaurel_full)     {background-color: rgba(0, 128, 0, 1);}
+::cue(.bkcolor_fungreen_full)      {background-color: rgba(0, 128, 64, 1);}
+::cue(.bkcolor_teal_full)          {background-color: rgba(0, 128, 128, 1);}
+::cue(.bkcolor_lochmara_full)      {background-color: rgba(0, 128, 192, 1);}
+::cue(.bkcolor_azure_full)         {background-color: rgba(0, 128, 255, 1);}
+::cue(.bkcolor_forest_full)        {background-color: rgba(0, 192, 0, 1);}
+::cue(.bkcolor_malachite_full)     {background-color: rgba(0, 192, 64, 1);}
+::cue(.bkcolor_caribbean_full)     {background-color: rgba(0, 192, 128, 1);}
+::cue(.bkcolor_eggblue_full)       {background-color: rgba(0, 192, 192, 1);}
+::cue(.bkcolor_cerulean_full)      {background-color: rgba(0, 192, 255, 1);}
+::cue(.bkcolor_green_full)         {background-color: rgba(0, 255, 0, 1);}
+::cue(.bkcolor_lime_full)          {background-color: rgba(0, 255, 64, 1);}
+::cue(.bkcolor_springgreen_full)   {background-color: rgba(0, 255, 128, 1);}
+::cue(.bkcolor_brightturq_full)    {background-color: rgba(0, 255, 64, 1);}
+::cue(.bkcolor_cyan_full)          {background-color: rgba(0, 255, 255, 1);}
+::cue(.bkcolor_temptress_full)     {background-color: rgba(64, 0, 0, 1);}
+::cue(.bkcolor_blackberry_full)    {background-color: rgba(64, 0, 64, 1);}
+::cue(.bkcolor_indigo_full)        {background-color: rgba(64, 0, 128, 1);}
+::cue(.bkcolor_purpleblue_full)    {background-color: rgba(64, 0, 192, 1);}
+::cue(.bkcolor_redblue_full)       {background-color: rgba(64, 0, 255, 1);}
+::cue(.bkcolor_verdun_full)        {background-color: rgba(64, 64, 0, 1);}
+::cue(.bkcolor_tundora_full)       {background-color: rgba(64, 64, 64, 1);}
+::cue(.bkcolor_eastbay_full)       {background-color: rgba(64, 64, 128, 1);}
+::cue(.bkcolor_governor_full)      {background-color: rgba(64, 64, 192, 1);}
+::cue(.bkcolor_royalblue_full)     {background-color: rgba(64, 64, 255, 1);}
+::cue(.bkcolor_limeade_full)       {background-color: rgba(64, 128, 0, 1);}
+::cue(.bkcolor_goblin_full)        {background-color: rgba(64, 128, 64, 1);}
+::cue(.bkcolor_fadedjade_full)     {background-color: rgba(64, 128, 128, 1);}
+::cue(.bkcolor_steelblue_full)     {background-color: rgba(64, 128, 192, 1);}
+::cue(.bkcolor_dodger_full)        {background-color: rgba(64, 128, 255, 1);}
+::cue(.bkcolor_harlequin_full)     {background-color: rgba(64, 192, 0, 1);}
+::cue(.bkcolor_emerald_full)       {background-color: rgba(64, 192, 64, 1);}
+::cue(.bkcolor_shamrock_full)      {background-color: rgba(64, 192, 128, 1);}
+::cue(.bkcolor_pelorous_full)      {background-color: rgba(64, 192, 192, 1);}
+::cue(.bkcolor_dodgerblue_full)    {background-color: rgba(64, 192, 255, 1);}
+::cue(.bkcolor_brightgreen_full)   {background-color: rgba(64, 255, 0, 1);}
+::cue(.bkcolor_pastelgreen_full)   {background-color: rgba(64, 255, 64, 1);}
+::cue(.bkcolor_screamingreen_full) {background-color: rgba(64, 255, 128, 1);}
+::cue(.bkcolor_aquamarine_full)    {background-color: rgba(64, 255, 64, 1);}
+::cue(.bkcolor_aqua_full)          {background-color: rgba(64, 255, 255, 1);}
+::cue(.bkcolor_maroon_full)        {background-color: rgba(128, 0, 0, 1);}
+::cue(.bkcolor_siren_full)         {background-color: rgba(128, 0, 64, 1);}
+::cue(.bkcolor_eggplant_full)      {background-color: rgba(128, 0, 128, 1);}
+::cue(.bkcolor_purple_full)        {background-color: rgba(128, 0, 192, 1);}
+::cue(.bkcolor_electric_full)      {background-color: rgba(128, 0, 255, 1);}
+::cue(.bkcolor_cinnamon_full)      {background-color: rgba(128, 64, 0, 1);}
+::cue(.bkcolor_lotus_full)         {background-color: rgba(128, 64, 64, 1);}
+::cue(.bkcolor_cannonpink_full)    {background-color: rgba(128, 64, 128, 1);}
+::cue(.bkcolor_fuchsiablue_full)   {background-color: rgba(128, 64, 192, 1);}
+::cue(.bkcolor_heliotrope_full)    {background-color: rgba(128, 64, 255, 1);}
+::cue(.bkcolor_olive_full)         {background-color: rgba(128, 128, 0, 1);}
+::cue(.bkcolor_yellowmetal_full)   {background-color: rgba(128, 128, 64, 1);}
+::cue(.bkcolor_gray_full)          {background-color: rgba(128, 128, 128, 1);}
+::cue(.bkcolor_yonder_full)        {background-color: rgba(128, 128, 192, 1);}
+::cue(.bkcolor_malibu_full)        {background-color: rgba(128, 128, 255, 1);}
+::cue(.bkcolor_pistachio_full)     {background-color: rgba(128, 192, 0, 1);}
+::cue(.bkcolor_wasabi_full)        {background-color: rgba(128, 192, 64, 1);}
+::cue(.bkcolor_deyork_full)        {background-color: rgba(128, 192, 128, 1);}
+::cue(.bkcolor_neptune_full)       {background-color: rgba(128, 192, 192, 1);}
+::cue(.bkcolor_anakiwa_full)       {background-color: rgba(128, 192, 255, 1);}
+::cue(.bkcolor_chartreuse_full)    {background-color: rgba(128, 255, 0, 1);}
+::cue(.bkcolor_greenyellow_full)   {background-color: rgba(128, 255, 64, 1);}
+::cue(.bkcolor_mintgreen_full)     {background-color: rgba(128, 255, 128, 1);}
+::cue(.bkcolor_magicmint_full)     {background-color: rgba(128, 255, 192, 1);}
+::cue(.bkcolor_turquoise_full)     {background-color: rgba(128, 255, 255, 1);}
+::cue(.bkcolor_guardsman_full)     {background-color: rgba(192, 0, 0, 1);}
+::cue(.bkcolor_monza_full)         {background-color: rgba(192, 0, 64, 1);}
+::cue(.bkcolor_flirt_full)         {background-color: rgba(192, 0, 128, 1);}
+::cue(.bkcolor_cerise_full)        {background-color: rgba(192, 0, 192, 1);}
+::cue(.bkcolor_purpleheart_full)   {background-color: rgba(192, 0, 255, 1);}
+::cue(.bkcolor_sharonrose_full)    {background-color: rgba(192, 64, 0, 1);}
+::cue(.bkcolor_crail_full)         {background-color: rgba(192, 64, 64, 1);}
+::cue(.bkcolor_mulberry_full)      {background-color: rgba(192, 64, 128, 1);}
+::cue(.bkcolor_amethyst_full)      {background-color: rgba(192, 64, 192, 1);}
+::cue(.bkcolor_violet_full)        {background-color: rgba(192, 64, 255, 1);}
+::cue(.bkcolor_pirategold_full)    {background-color: rgba(192, 128, 0, 1);}
+::cue(.bkcolor_tussock_full)       {background-color: rgba(192, 128, 64, 1);}
+::cue(.bkcolor_oldrose_full)       {background-color: rgba(192, 128, 128, 1);}
+::cue(.bkcolor_viola_full)         {background-color: rgba(192, 128, 192, 1);}
+::cue(.bkcolor_orchid_full)        {background-color: rgba(192, 128, 255, 1);}
+::cue(.bkcolor_buddhagold_full)    {background-color: rgba(192, 192, 0, 1);}
+::cue(.bkcolor_turmeric_full)      {background-color: rgba(192, 192, 64, 1);}
+::cue(.bkcolor_pineglade_full)     {background-color: rgba(192, 192, 128, 1);}
+::cue(.bkcolor_silver_full)        {background-color: rgba(192, 192, 192, 1);}
+::cue(.bkcolor_melrose_full)       {background-color: rgba(192, 192, 255, 1);}
+::cue(.bkcolor_laspalmas_full)     {background-color: rgba(192, 255, 0, 1);}
+::cue(.bkcolor_starship_full)      {background-color: rgba(192, 255, 64, 1);}
+::cue(.bkcolor_reef_full)          {background-color: rgba(192, 255, 128, 1);}
+::cue(.bkcolor_snowymint_full)     {background-color: rgba(192, 255, 192, 1);}
+::cue(.bkcolor_onahau_full)        {background-color: rgba(192, 255, 255, 1);}
+::cue(.bkcolor_red_full)           {background-color: rgba(255, 0, 0, 1);}
+::cue(.bkcolor_torchred_full)      {background-color: rgba(255, 0, 64, 1);}
+::cue(.bkcolor_rose_full)          {background-color: rgba(255, 0, 128, 1);}
+::cue(.bkcolor_pizzazz_full)       {background-color: rgba(255, 0, 192, 1);}
+::cue(.bkcolor_magenta_full)       {background-color: rgba(255, 0, 255, 1);}
+::cue(.bkcolor_vermilion_full)     {background-color: rgba(255, 64, 0, 1);}
+::cue(.bkcolor_coral_full)         {background-color: rgba(255, 64, 64, 1);}
+::cue(.bkcolor_strawberry_full)    {background-color: rgba(255, 64, 128, 1);}
+::cue(.bkcolor_razzledazzle_full)  {background-color: rgba(255, 64, 192, 1);}
+::cue(.bkcolor_flamingo_full)      {background-color: rgba(255, 64, 255, 1);}
+::cue(.bkcolor_flushorange_full)   {background-color: rgba(255, 128, 0, 1);}
+::cue(.bkcolor_crusta_full)        {background-color: rgba(255, 128, 64, 1);}
+::cue(.bkcolor_vividtangerine_full){background-color: rgba(255, 128, 128, 1);}
+::cue(.bkcolor_hotpink_full)       {background-color: rgba(255, 128, 192, 1);}
+::cue(.bkcolor_blushpink_full)     {background-color: rgba(255, 128, 255, 1);}
+::cue(.bkcolor_amber_full)         {background-color: rgba(255, 192, 0, 1);}
+::cue(.bkcolor_yelloworange_full)  {background-color: rgba(255, 192, 64, 1);}
+::cue(.bkcolor_macncheese_full)    {background-color: rgba(255, 192, 128, 1);}
+::cue(.bkcolor_yourpink_full)      {background-color: rgba(255, 192, 192, 1);}
+::cue(.bkcolor_pinklace_full)      {background-color: rgba(255, 192, 255, 1);}
+::cue(.bkcolor_yellow_full)        {background-color: rgba(255, 255, 0, 1);}
+::cue(.bkcolor_goldenfizz_full)    {background-color: rgba(255, 255, 64, 1);}
+::cue(.bkcolor_dolly_full)         {background-color: rgba(255, 255, 128, 1);}
+::cue(.bkcolor_shalimar_full)      {background-color: rgba(255, 255, 192, 1);}
+::cue(.bkcolor_white_full)         {background-color: rgba(255, 255, 255, 1);}
+
+::cue(.bkcolor_black_half)         {background-color: rgba(0, 0, 0, 0.5);}
+::cue(.bkcolor_stratos_half)       {background-color: rgba(0, 0, 64, 0.5);}
+::cue(.bkcolor_navy_half)          {background-color: rgba(0, 0, 128, 0.5);}
+::cue(.bkcolor_mediumblue_half)    {background-color: rgba(0, 0, 192, 0.5);}
+::cue(.bkcolor_blue_half)          {background-color: rgba(0, 0, 255, 0.5);}
+::cue(.bkcolor_deepfir_half)       {background-color: rgba(0, 64, 0, 0.5);}
+::cue(.bkcolor_cyprus_half)        {background-color: rgba(0, 64, 64, 0.5);}
+::cue(.bkcolor_congressblue_half)  {background-color: rgba(0, 64, 128, 0.5);}
+::cue(.bkcolor_cobalt_half)        {background-color: rgba(0, 64, 192, 0.5);}
+::cue(.bkcolor_blueribbon_half)    {background-color: rgba(0, 64, 255, 0.5);}
+::cue(.bkcolor_japlaurel_half)     {background-color: rgba(0, 128, 0, 0.5);}
+::cue(.bkcolor_fungreen_half)      {background-color: rgba(0, 128, 64, 0.5);}
+::cue(.bkcolor_teal_half)          {background-color: rgba(0, 128, 128, 0.5);}
+::cue(.bkcolor_lochmara_half)      {background-color: rgba(0, 128, 192, 0.5);}
+::cue(.bkcolor_azure_half)         {background-color: rgba(0, 128, 255, 0.5);}
+::cue(.bkcolor_forest_half)        {background-color: rgba(0, 192, 0, 0.5);}
+::cue(.bkcolor_malachite_half)     {background-color: rgba(0, 192, 64, 0.5);}
+::cue(.bkcolor_caribbean_half)     {background-color: rgba(0, 192, 128, 0.5);}
+::cue(.bkcolor_eggblue_half)       {background-color: rgba(0, 192, 192, 0.5);}
+::cue(.bkcolor_cerulean_half)      {background-color: rgba(0, 192, 255, 0.5);}
+::cue(.bkcolor_green_half)         {background-color: rgba(0, 255, 0, 0.5);}
+::cue(.bkcolor_lime_half)          {background-color: rgba(0, 255, 64, 0.5);}
+::cue(.bkcolor_springgreen_half)   {background-color: rgba(0, 255, 128, 0.5);}
+::cue(.bkcolor_brightturq_half)    {background-color: rgba(0, 255, 64, 0.5);}
+::cue(.bkcolor_cyan_half)          {background-color: rgba(0, 255, 255, 0.5);}
+::cue(.bkcolor_temptress_half)     {background-color: rgba(64, 0, 0, 0.5);}
+::cue(.bkcolor_blackberry_half)    {background-color: rgba(64, 0, 64, 0.5);}
+::cue(.bkcolor_indigo_half)        {background-color: rgba(64, 0, 128, 0.5);}
+::cue(.bkcolor_purpleblue_half)    {background-color: rgba(64, 0, 192, 0.5);}
+::cue(.bkcolor_redblue_half)       {background-color: rgba(64, 0, 255, 0.5);}
+::cue(.bkcolor_verdun_half)        {background-color: rgba(64, 64, 0, 0.5);}
+::cue(.bkcolor_tundora_half)       {background-color: rgba(64, 64, 64, 0.5);}
+::cue(.bkcolor_eastbay_half)       {background-color: rgba(64, 64, 128, 0.5);}
+::cue(.bkcolor_governor_half)      {background-color: rgba(64, 64, 192, 0.5);}
+::cue(.bkcolor_royalblue_half)     {background-color: rgba(64, 64, 255, 0.5);}
+::cue(.bkcolor_limeade_half)       {background-color: rgba(64, 128, 0, 0.5);}
+::cue(.bkcolor_goblin_half)        {background-color: rgba(64, 128, 64, 0.5);}
+::cue(.bkcolor_fadedjade_half)     {background-color: rgba(64, 128, 128, 0.5);}
+::cue(.bkcolor_steelblue_half)     {background-color: rgba(64, 128, 192, 0.5);}
+::cue(.bkcolor_dodger_half)        {background-color: rgba(64, 128, 255, 0.5);}
+::cue(.bkcolor_harlequin_half)     {background-color: rgba(64, 192, 0, 0.5);}
+::cue(.bkcolor_emerald_half)       {background-color: rgba(64, 192, 64, 0.5);}
+::cue(.bkcolor_shamrock_half)      {background-color: rgba(64, 192, 128, 0.5);}
+::cue(.bkcolor_pelorous_half)      {background-color: rgba(64, 192, 192, 0.5);}
+::cue(.bkcolor_dodgerblue_half)    {background-color: rgba(64, 192, 255, 0.5);}
+::cue(.bkcolor_brightgreen_half)   {background-color: rgba(64, 255, 0, 0.5);}
+::cue(.bkcolor_pastelgreen_half)   {background-color: rgba(64, 255, 64, 0.5);}
+::cue(.bkcolor_screamingreen_half) {background-color: rgba(64, 255, 128, 0.5);}
+::cue(.bkcolor_aquamarine_half)    {background-color: rgba(64, 255, 64, 0.5);}
+::cue(.bkcolor_aqua_half)          {background-color: rgba(64, 255, 255, 0.5);}
+::cue(.bkcolor_maroon_half)        {background-color: rgba(128, 0, 0, 0.5);}
+::cue(.bkcolor_siren_half)         {background-color: rgba(128, 0, 64, 0.5);}
+::cue(.bkcolor_eggplant_half)      {background-color: rgba(128, 0, 128, 0.5);}
+::cue(.bkcolor_purple_half)        {background-color: rgba(128, 0, 192, 0.5);}
+::cue(.bkcolor_electric_half)      {background-color: rgba(128, 0, 255, 0.5);}
+::cue(.bkcolor_cinnamon_half)      {background-color: rgba(128, 64, 0, 0.5);}
+::cue(.bkcolor_lotus_half)         {background-color: rgba(128, 64, 64, 0.5);}
+::cue(.bkcolor_cannonpink_half)    {background-color: rgba(128, 64, 128, 0.5);}
+::cue(.bkcolor_fuchsiablue_half)   {background-color: rgba(128, 64, 192, 0.5);}
+::cue(.bkcolor_heliotrope_half)    {background-color: rgba(128, 64, 255, 0.5);}
+::cue(.bkcolor_olive_half)         {background-color: rgba(128, 128, 0, 0.5);}
+::cue(.bkcolor_yellowmetal_half)   {background-color: rgba(128, 128, 64, 0.5);}
+::cue(.bkcolor_gray_half)          {background-color: rgba(128, 128, 128, 0.5);}
+::cue(.bkcolor_yonder_half)        {background-color: rgba(128, 128, 192, 0.5);}
+::cue(.bkcolor_malibu_half)        {background-color: rgba(128, 128, 255, 0.5);}
+::cue(.bkcolor_pistachio_half)     {background-color: rgba(128, 192, 0, 0.5);}
+::cue(.bkcolor_wasabi_half)        {background-color: rgba(128, 192, 64, 0.5);}
+::cue(.bkcolor_deyork_half)        {background-color: rgba(128, 192, 128, 0.5);}
+::cue(.bkcolor_neptune_half)       {background-color: rgba(128, 192, 192, 0.5);}
+::cue(.bkcolor_anakiwa_half)       {background-color: rgba(128, 192, 255, 0.5);}
+::cue(.bkcolor_chartreuse_half)    {background-color: rgba(128, 255, 0, 0.5);}
+::cue(.bkcolor_greenyellow_half)   {background-color: rgba(128, 255, 64, 0.5);}
+::cue(.bkcolor_mintgreen_half)     {background-color: rgba(128, 255, 128, 0.5);}
+::cue(.bkcolor_magicmint_half)     {background-color: rgba(128, 255, 192, 0.5);}
+::cue(.bkcolor_turquoise_half)     {background-color: rgba(128, 255, 255, 0.5);}
+::cue(.bkcolor_guardsman_half)     {background-color: rgba(192, 0, 0, 0.5);}
+::cue(.bkcolor_monza_half)         {background-color: rgba(192, 0, 64, 0.5);}
+::cue(.bkcolor_flirt_half)         {background-color: rgba(192, 0, 128, 0.5);}
+::cue(.bkcolor_cerise_half)        {background-color: rgba(192, 0, 192, 0.5);}
+::cue(.bkcolor_purpleheart_half)   {background-color: rgba(192, 0, 255, 0.5);}
+::cue(.bkcolor_sharonrose_half)    {background-color: rgba(192, 64, 0, 0.5);}
+::cue(.bkcolor_crail_half)         {background-color: rgba(192, 64, 64, 0.5);}
+::cue(.bkcolor_mulberry_half)      {background-color: rgba(192, 64, 128, 0.5);}
+::cue(.bkcolor_amethyst_half)      {background-color: rgba(192, 64, 192, 0.5);}
+::cue(.bkcolor_violet_half)        {background-color: rgba(192, 64, 255, 0.5);}
+::cue(.bkcolor_pirategold_half)    {background-color: rgba(192, 128, 0, 0.5);}
+::cue(.bkcolor_tussock_half)       {background-color: rgba(192, 128, 64, 0.5);}
+::cue(.bkcolor_oldrose_half)       {background-color: rgba(192, 128, 128, 0.5);}
+::cue(.bkcolor_viola_half)         {background-color: rgba(192, 128, 192, 0.5);}
+::cue(.bkcolor_orchid_half)        {background-color: rgba(192, 128, 255, 0.5);}
+::cue(.bkcolor_buddhagold_half)    {background-color: rgba(192, 192, 0, 0.5);}
+::cue(.bkcolor_turmeric_half)      {background-color: rgba(192, 192, 64, 0.5);}
+::cue(.bkcolor_pineglade_half)     {background-color: rgba(192, 192, 128, 0.5);}
+::cue(.bkcolor_silver_half)        {background-color: rgba(192, 192, 192, 0.5);}
+::cue(.bkcolor_melrose_half)       {background-color: rgba(192, 192, 255, 0.5);}
+::cue(.bkcolor_laspalmas_half)     {background-color: rgba(192, 255, 0, 0.5);}
+::cue(.bkcolor_starship_half)      {background-color: rgba(192, 255, 64, 0.5);}
+::cue(.bkcolor_reef_half)          {background-color: rgba(192, 255, 128, 0.5);}
+::cue(.bkcolor_snowymint_half)     {background-color: rgba(192, 255, 192, 0.5);}
+::cue(.bkcolor_onahau_half)        {background-color: rgba(192, 255, 255, 0.5);}
+::cue(.bkcolor_red_half)           {background-color: rgba(255, 0, 0, 0.5);}
+::cue(.bkcolor_torchred_half)      {background-color: rgba(255, 0, 64, 0.5);}
+::cue(.bkcolor_rose_half)          {background-color: rgba(255, 0, 128, 0.5);}
+::cue(.bkcolor_pizzazz_half)       {background-color: rgba(255, 0, 192, 0.5);}
+::cue(.bkcolor_magenta_half)       {background-color: rgba(255, 0, 255, 0.5);}
+::cue(.bkcolor_vermilion_half)     {background-color: rgba(255, 64, 0, 0.5);}
+::cue(.bkcolor_coral_half)         {background-color: rgba(255, 64, 64, 0.5);}
+::cue(.bkcolor_strawberry_half)    {background-color: rgba(255, 64, 128, 0.5);}
+::cue(.bkcolor_razzledazzle_half)  {background-color: rgba(255, 64, 192, 0.5);}
+::cue(.bkcolor_flamingo_half)      {background-color: rgba(255, 64, 255, 0.5);}
+::cue(.bkcolor_flushorange_half)   {background-color: rgba(255, 128, 0, 0.5);}
+::cue(.bkcolor_crusta_half)        {background-color: rgba(255, 128, 64, 0.5);}
+::cue(.bkcolor_vividtangerine_half){background-color: rgba(255, 128, 128, 0.5);}
+::cue(.bkcolor_hotpink_half)       {background-color: rgba(255, 128, 192, 0.5);}
+::cue(.bkcolor_blushpink_half)     {background-color: rgba(255, 128, 255, 0.5);}
+::cue(.bkcolor_amber_half)         {background-color: rgba(255, 192, 0, 0.5);}
+::cue(.bkcolor_yelloworange_half)  {background-color: rgba(255, 192, 64, 0.5);}
+::cue(.bkcolor_macncheese_half)    {background-color: rgba(255, 192, 128, 0.5);}
+::cue(.bkcolor_yourpink_half)      {background-color: rgba(255, 192, 192, 0.5);}
+::cue(.bkcolor_pinklace_half)      {background-color: rgba(255, 192, 255, 0.5);}
+::cue(.bkcolor_yellow_half)        {background-color: rgba(255, 255, 0, 0.5);}
+::cue(.bkcolor_goldenfizz_half)    {background-color: rgba(255, 255, 64, 0.5);}
+::cue(.bkcolor_dolly_half)         {background-color: rgba(255, 255, 128, 0.5);}
+::cue(.bkcolor_shalimar_half)      {background-color: rgba(255, 255, 192, 0.5);}
+::cue(.bkcolor_white_half)         {background-color: rgba(255, 255, 255, 0.5);}
+
+/* STRIKETHROUGH */
+/* ============= */
+::cue(.strikethrough)            {text-decoration: solid line-through;}
+
+/* Font Families */
+/* ============= */
+/* https://www.w3schools.com/cssref/css_websafe_fonts.asp */
+::cue(.fontfamtimes)             {font-family: "Times New Roman", Times, serif;}
+::cue(.fontfamarial)             {font-family: Arial, Helvetica, sans-serif;}
+::cue(.fontfamcomic)             {font-family: "Comic Sans MS", cursive, sans-serif;}
+::cue(.fontfamtrebuchet)         {font-family: "Trebuchet MS", Helvetica, sans-serif;}
+::cue(.fontfamlucida)            {font-family: "Lucida Console", Monaco, monospace;}
+::cue(.fontfamcourier)           {font-family: "Courier New", Courier, monospace;}
+::cue(.fontfamarabic)            {font-family: "Lateef", “Droid Arabic Naskh”, Arial, san-serif;}
+::cue(.fontfamrussian)           {font-family: "Trebuchet MS", Helvetica, sans-serif;}
+
+/* Font Size */
+/* ========= */
+/* anything less than 16px is quantized to 16px, larger than 45 quantized to 45 */
+::cue(.fontsize16)               {font-size: 0.8em;}
+::cue(.fontsize17)               {font-size: 0.85em;}
+::cue(.fontsize18)               {font-size: 0.9em;}
+::cue(.fontsize19)               {font-size: 0.95em;}
+::cue(.fontsize20)               {font-size: 1.0em;}
+::cue(.fontsize21)               {font-size: 1.05em;}
+::cue(.fontsize22)               {font-size: 1.1em;}
+::cue(.fontsize23)               {font-size: 1.15em;}
+::cue(.fontsize24)               {font-size: 1.2em;}
+::cue(.fontsize25)               {font-size: 1.25em;}
+::cue(.fontsize26)               {font-size: 1.3em;}
+::cue(.fontsize27)               {font-size: 1.35em;}
+::cue(.fontsize28)               {font-size: 1.4em;}
+::cue(.fontsize29)               {font-size: 1.45em;}
+::cue(.fontsize30)               {font-size: 1.5em;}
+::cue(.fontsize31)               {font-size: 1.55em;}
+::cue(.fontsize32)               {font-size: 1.6em;}
+::cue(.fontsize33)               {font-size: 1.65em;}
+::cue(.fontsize34)               {font-size: 1.7em;}
+::cue(.fontsize35)               {font-size: 1.75em;}
+::cue(.fontsize36)               {font-size: 1.8em;}
+::cue(.fontsize37)               {font-size: 1.85em;}
+::cue(.fontsize38)               {font-size: 1.9em;}
+::cue(.fontsize39)               {font-size: 1.95em;}
+::cue(.fontsize40)               {font-size: 2.0em;}
+::cue(.fontsize41)               {font-size: 2.05em;}
+::cue(.fontsize42)               {font-size: 2.1em;}
+::cue(.fontsize43)               {font-size: 2.15em;}
+::cue(.fontsize44)               {font-size: 2.2em;}
+::cue(.fontsize45)               {font-size: 2.25em;}
+
+
+/* OUTLINES */
+/* ======== */
+::cue(.outline3black)             {text-shadow:
+  -1px -1px #000000, -1px  0px #000000, -1px  1px #000000,  0px -1px #000000,  0px  1px #000000,  1px -1px #000000,  1px  0px #000000,  1px  1px #000000,
+  -2px -2px #000000, -2px -1px #000000, -2px  0px #000000, -2px  1px #000000, -2px  2px #000000, -1px -2px #000000, -1px  2px #000000,  0px -2px #000000,
+   0px  2px #000000,  1px -2px #000000,  1px  2px #000000,  2px -2px #000000,  2px -1px #000000,  2px  0px #000000,  2px  1px #000000,  2px  2px #000000,
+  -3px -3px #000000, -3px -2px #000000, -3px -1px #000000, -3px  0px #000000, -3px  1px #000000, -3px  2px #000000, -3px  3px #000000, -2px -3px #000000,
+  -2px  3px #000000, -1px -3px #000000, -1px  3px #000000,  0px -3px #000000,  0px  3px #000000,  1px -3px #000000,  1px  3px #000000,  2px -3px #000000,
+   2px  3px #000000,  3px -3px #000000,  3px -2px #000000,  3px -1px #000000,  3px  0px #000000,  3px  1px #000000,  3px  2px #000000,  3px  3px #000000;}
+::cue(.outline2black)             {text-shadow:
+  -1px -1px #000000, -1px  0px #000000, -1px  1px #000000,  0px -1px #000000,  0px  1px #000000,  1px -1px #000000,  1px  0px #000000,  1px  1px #000000,
+  -2px -2px #000000, -2px -1px #000000, -2px  0px #000000, -2px  1px #000000, -2px  2px #000000, -1px -2px #000000, -1px  2px #000000,  0px -2px #000000,
+   0px  2px #000000,  1px -2px #000000,  1px  2px #000000,  2px -2px #000000,  2px -1px #000000,  2px  0px #000000,  2px  1px #000000,  2px  2px #000000;}
+::cue(.outline1black)             {text-shadow:
+  -1px -1px #000000, -1px  0px #000000, -1px  1px #000000,  0px -1px #000000,  0px  1px #000000,  1px -1px #000000,  1px  0px #000000,  1px  1px #000000;}
+::cue(.outline3stratos)           {text-shadow:
+  -1px -1px #000040, -1px  0px #000040, -1px  1px #000040,  0px -1px #000040,  0px  1px #000040,  1px -1px #000040,  1px  0px #000040,  1px  1px #000040,
+  -2px -2px #000040, -2px -1px #000040, -2px  0px #000040, -2px  1px #000040, -2px  2px #000040, -1px -2px #000040, -1px  2px #000040,  0px -2px #000040,
+   0px  2px #000040,  1px -2px #000040,  1px  2px #000040,  2px -2px #000040,  2px -1px #000040,  2px  0px #000040,  2px  1px #000040,  2px  2px #000040,
+  -3px -3px #000040, -3px -2px #000040, -3px -1px #000040, -3px  0px #000040, -3px  1px #000040, -3px  2px #000040, -3px  3px #000040, -2px -3px #000040,
+  -2px  3px #000040, -1px -3px #000040, -1px  3px #000040,  0px -3px #000040,  0px  3px #000040,  1px -3px #000040,  1px  3px #000040,  2px -3px #000040,
+   2px  3px #000040,  3px -3px #000040,  3px -2px #000040,  3px -1px #000040,  3px  0px #000040,  3px  1px #000040,  3px  2px #000040,  3px  3px #000040;}
+::cue(.outline2stratos)           {text-shadow:
+  -1px -1px #000040, -1px  0px #000040, -1px  1px #000040,  0px -1px #000040,  0px  1px #000040,  1px -1px #000040,  1px  0px #000040,  1px  1px #000040,
+  -2px -2px #000040, -2px -1px #000040, -2px  0px #000040, -2px  1px #000040, -2px  2px #000040, -1px -2px #000040, -1px  2px #000040,  0px -2px #000040,
+   0px  2px #000040,  1px -2px #000040,  1px  2px #000040,  2px -2px #000040,  2px -1px #000040,  2px  0px #000040,  2px  1px #000040,  2px  2px #000040;}
+::cue(.outline1stratos)           {text-shadow:
+  -1px -1px #000040, -1px  0px #000040, -1px  1px #000040,  0px -1px #000040,  0px  1px #000040,  1px -1px #000040,  1px  0px #000040,  1px  1px #000040;}
+::cue(.outline3navy)              {text-shadow:
+  -1px -1px #000080, -1px  0px #000080, -1px  1px #000080,  0px -1px #000080,  0px  1px #000080,  1px -1px #000080,  1px  0px #000080,  1px  1px #000080,
+  -2px -2px #000080, -2px -1px #000080, -2px  0px #000080, -2px  1px #000080, -2px  2px #000080, -1px -2px #000080, -1px  2px #000080,  0px -2px #000080,
+   0px  2px #000080,  1px -2px #000080,  1px  2px #000080,  2px -2px #000080,  2px -1px #000080,  2px  0px #000080,  2px  1px #000080,  2px  2px #000080,
+  -3px -3px #000080, -3px -2px #000080, -3px -1px #000080, -3px  0px #000080, -3px  1px #000080, -3px  2px #000080, -3px  3px #000080, -2px -3px #000080,
+  -2px  3px #000080, -1px -3px #000080, -1px  3px #000080,  0px -3px #000080,  0px  3px #000080,  1px -3px #000080,  1px  3px #000080,  2px -3px #000080,
+   2px  3px #000080,  3px -3px #000080,  3px -2px #000080,  3px -1px #000080,  3px  0px #000080,  3px  1px #000080,  3px  2px #000080,  3px  3px #000080;}
+::cue(.outline2navy)              {text-shadow:
+  -1px -1px #000080, -1px  0px #000080, -1px  1px #000080,  0px -1px #000080,  0px  1px #000080,  1px -1px #000080,  1px  0px #000080,  1px  1px #000080,
+  -2px -2px #000080, -2px -1px #000080, -2px  0px #000080, -2px  1px #000080, -2px  2px #000080, -1px -2px #000080, -1px  2px #000080,  0px -2px #000080,
+   0px  2px #000080,  1px -2px #000080,  1px  2px #000080,  2px -2px #000080,  2px -1px #000080,  2px  0px #000080,  2px  1px #000080,  2px  2px #000080;}
+::cue(.outline1navy)              {text-shadow:
+  -1px -1px #000080, -1px  0px #000080, -1px  1px #000080,  0px -1px #000080,  0px  1px #000080,  1px -1px #000080,  1px  0px #000080,  1px  1px #000080;}
+::cue(.outline3mediumblue)        {text-shadow:
+  -1px -1px #0000C0, -1px  0px #0000C0, -1px  1px #0000C0,  0px -1px #0000C0,  0px  1px #0000C0,  1px -1px #0000C0,  1px  0px #0000C0,  1px  1px #0000C0,
+  -2px -2px #0000C0, -2px -1px #0000C0, -2px  0px #0000C0, -2px  1px #0000C0, -2px  2px #0000C0, -1px -2px #0000C0, -1px  2px #0000C0,  0px -2px #0000C0,
+   0px  2px #0000C0,  1px -2px #0000C0,  1px  2px #0000C0,  2px -2px #0000C0,  2px -1px #0000C0,  2px  0px #0000C0,  2px  1px #0000C0,  2px  2px #0000C0,
+  -3px -3px #0000C0, -3px -2px #0000C0, -3px -1px #0000C0, -3px  0px #0000C0, -3px  1px #0000C0, -3px  2px #0000C0, -3px  3px #0000C0, -2px -3px #0000C0,
+  -2px  3px #0000C0, -1px -3px #0000C0, -1px  3px #0000C0,  0px -3px #0000C0,  0px  3px #0000C0,  1px -3px #0000C0,  1px  3px #0000C0,  2px -3px #0000C0,
+   2px  3px #0000C0,  3px -3px #0000C0,  3px -2px #0000C0,  3px -1px #0000C0,  3px  0px #0000C0,  3px  1px #0000C0,  3px  2px #0000C0,  3px  3px #0000C0;}
+::cue(.outline2mediumblue)        {text-shadow:
+  -1px -1px #0000C0, -1px  0px #0000C0, -1px  1px #0000C0,  0px -1px #0000C0,  0px  1px #0000C0,  1px -1px #0000C0,  1px  0px #0000C0,  1px  1px #0000C0,
+  -2px -2px #0000C0, -2px -1px #0000C0, -2px  0px #0000C0, -2px  1px #0000C0, -2px  2px #0000C0, -1px -2px #0000C0, -1px  2px #0000C0,  0px -2px #0000C0,
+   0px  2px #0000C0,  1px -2px #0000C0,  1px  2px #0000C0,  2px -2px #0000C0,  2px -1px #0000C0,  2px  0px #0000C0,  2px  1px #0000C0,  2px  2px #0000C0;}
+::cue(.outline1mediumblue)        {text-shadow:
+  -1px -1px #0000C0, -1px  0px #0000C0, -1px  1px #0000C0,  0px -1px #0000C0,  0px  1px #0000C0,  1px -1px #0000C0,  1px  0px #0000C0,  1px  1px #0000C0;}
+::cue(.outline3blue)              {text-shadow:
+  -1px -1px #0000FF, -1px  0px #0000FF, -1px  1px #0000FF,  0px -1px #0000FF,  0px  1px #0000FF,  1px -1px #0000FF,  1px  0px #0000FF,  1px  1px #0000FF,
+  -2px -2px #0000FF, -2px -1px #0000FF, -2px  0px #0000FF, -2px  1px #0000FF, -2px  2px #0000FF, -1px -2px #0000FF, -1px  2px #0000FF,  0px -2px #0000FF,
+   0px  2px #0000FF,  1px -2px #0000FF,  1px  2px #0000FF,  2px -2px #0000FF,  2px -1px #0000FF,  2px  0px #0000FF,  2px  1px #0000FF,  2px  2px #0000FF,
+  -3px -3px #0000FF, -3px -2px #0000FF, -3px -1px #0000FF, -3px  0px #0000FF, -3px  1px #0000FF, -3px  2px #0000FF, -3px  3px #0000FF, -2px -3px #0000FF,
+  -2px  3px #0000FF, -1px -3px #0000FF, -1px  3px #0000FF,  0px -3px #0000FF,  0px  3px #0000FF,  1px -3px #0000FF,  1px  3px #0000FF,  2px -3px #0000FF,
+   2px  3px #0000FF,  3px -3px #0000FF,  3px -2px #0000FF,  3px -1px #0000FF,  3px  0px #0000FF,  3px  1px #0000FF,  3px  2px #0000FF,  3px  3px #0000FF;}
+::cue(.outline2blue)              {text-shadow:
+  -1px -1px #0000FF, -1px  0px #0000FF, -1px  1px #0000FF,  0px -1px #0000FF,  0px  1px #0000FF,  1px -1px #0000FF,  1px  0px #0000FF,  1px  1px #0000FF,
+  -2px -2px #0000FF, -2px -1px #0000FF, -2px  0px #0000FF, -2px  1px #0000FF, -2px  2px #0000FF, -1px -2px #0000FF, -1px  2px #0000FF,  0px -2px #0000FF,
+   0px  2px #0000FF,  1px -2px #0000FF,  1px  2px #0000FF,  2px -2px #0000FF,  2px -1px #0000FF,  2px  0px #0000FF,  2px  1px #0000FF,  2px  2px #0000FF;}
+::cue(.outline1blue)              {text-shadow:
+  -1px -1px #0000FF, -1px  0px #0000FF, -1px  1px #0000FF,  0px -1px #0000FF,  0px  1px #0000FF,  1px -1px #0000FF,  1px  0px #0000FF,  1px  1px #0000FF;}
+::cue(.outline3deepfir)        {text-shadow:
+  -1px -1px #004000, -1px  0px #004000, -1px  1px #004000,  0px -1px #004000,  0px  1px #004000,  1px -1px #004000,  1px  0px #004000,  1px  1px #004000,
+  -2px -2px #004000, -2px -1px #004000, -2px  0px #004000, -2px  1px #004000, -2px  2px #004000, -1px -2px #004000, -1px  2px #004000,  0px -2px #004000,
+   0px  2px #004000,  1px -2px #004000,  1px  2px #004000,  2px -2px #004000,  2px -1px #004000,  2px  0px #004000,  2px  1px #004000,  2px  2px #004000,
+  -3px -3px #004000, -3px -2px #004000, -3px -1px #004000, -3px  0px #004000, -3px  1px #004000, -3px  2px #004000, -3px  3px #004000, -2px -3px #004000,
+  -2px  3px #004000, -1px -3px #004000, -1px  3px #004000,  0px -3px #004000,  0px  3px #004000,  1px -3px #004000,  1px  3px #004000,  2px -3px #004000,
+   2px  3px #004000,  3px -3px #004000,  3px -2px #004000,  3px -1px #004000,  3px  0px #004000,  3px  1px #004000,  3px  2px #004000,  3px  3px #004000;}
+::cue(.outline2deepfir)        {text-shadow:
+  -1px -1px #004000, -1px  0px #004000, -1px  1px #004000,  0px -1px #004000,  0px  1px #004000,  1px -1px #004000,  1px  0px #004000,  1px  1px #004000,
+  -2px -2px #004000, -2px -1px #004000, -2px  0px #004000, -2px  1px #004000, -2px  2px #004000, -1px -2px #004000, -1px  2px #004000,  0px -2px #004000,
+   0px  2px #004000,  1px -2px #004000,  1px  2px #004000,  2px -2px #004000,  2px -1px #004000,  2px  0px #004000,  2px  1px #004000,  2px  2px #004000;}
+::cue(.outline1deepfir)        {text-shadow:
+  -1px -1px #004000, -1px  0px #004000, -1px  1px #004000,  0px -1px #004000,  0px  1px #004000,  1px -1px #004000,  1px  0px #004000,  1px  1px #004000;}
+::cue(.outline3cyprus)        {text-shadow:
+  -1px -1px #004040, -1px  0px #004040, -1px  1px #004040,  0px -1px #004040,  0px  1px #004040,  1px -1px #004040,  1px  0px #004040,  1px  1px #004040,
+  -2px -2px #004040, -2px -1px #004040, -2px  0px #004040, -2px  1px #004040, -2px  2px #004040, -1px -2px #004040, -1px  2px #004040,  0px -2px #004040,
+   0px  2px #004040,  1px -2px #004040,  1px  2px #004040,  2px -2px #004040,  2px -1px #004040,  2px  0px #004040,  2px  1px #004040,  2px  2px #004040,
+  -3px -3px #004040, -3px -2px #004040, -3px -1px #004040, -3px  0px #004040, -3px  1px #004040, -3px  2px #004040, -3px  3px #004040, -2px -3px #004040,
+  -2px  3px #004040, -1px -3px #004040, -1px  3px #004040,  0px -3px #004040,  0px  3px #004040,  1px -3px #004040,  1px  3px #004040,  2px -3px #004040,
+   2px  3px #004040,  3px -3px #004040,  3px -2px #004040,  3px -1px #004040,  3px  0px #004040,  3px  1px #004040,  3px  2px #004040,  3px  3px #004040;}
+::cue(.outline2cyprus)        {text-shadow:
+  -1px -1px #004040, -1px  0px #004040, -1px  1px #004040,  0px -1px #004040,  0px  1px #004040,  1px -1px #004040,  1px  0px #004040,  1px  1px #004040,
+  -2px -2px #004040, -2px -1px #004040, -2px  0px #004040, -2px  1px #004040, -2px  2px #004040, -1px -2px #004040, -1px  2px #004040,  0px -2px #004040,
+   0px  2px #004040,  1px -2px #004040,  1px  2px #004040,  2px -2px #004040,  2px -1px #004040,  2px  0px #004040,  2px  1px #004040,  2px  2px #004040;}
+::cue(.outline1cyprus)        {text-shadow:
+  -1px -1px #004040, -1px  0px #004040, -1px  1px #004040,  0px -1px #004040,  0px  1px #004040,  1px -1px #004040,  1px  0px #004040,  1px  1px #004040;}
+::cue(.outline3congressblue)        {text-shadow:
+  -1px -1px #004080, -1px  0px #004080, -1px  1px #004080,  0px -1px #004080,  0px  1px #004080,  1px -1px #004080,  1px  0px #004080,  1px  1px #004080,
+  -2px -2px #004080, -2px -1px #004080, -2px  0px #004080, -2px  1px #004080, -2px  2px #004080, -1px -2px #004080, -1px  2px #004080,  0px -2px #004080,
+   0px  2px #004080,  1px -2px #004080,  1px  2px #004080,  2px -2px #004080,  2px -1px #004080,  2px  0px #004080,  2px  1px #004080,  2px  2px #004080,
+  -3px -3px #004080, -3px -2px #004080, -3px -1px #004080, -3px  0px #004080, -3px  1px #004080, -3px  2px #004080, -3px  3px #004080, -2px -3px #004080,
+  -2px  3px #004080, -1px -3px #004080, -1px  3px #004080,  0px -3px #004080,  0px  3px #004080,  1px -3px #004080,  1px  3px #004080,  2px -3px #004080,
+   2px  3px #004080,  3px -3px #004080,  3px -2px #004080,  3px -1px #004080,  3px  0px #004080,  3px  1px #004080,  3px  2px #004080,  3px  3px #004080;}
+::cue(.outline2congressblue)        {text-shadow:
+  -1px -1px #004080, -1px  0px #004080, -1px  1px #004080,  0px -1px #004080,  0px  1px #004080,  1px -1px #004080,  1px  0px #004080,  1px  1px #004080,
+  -2px -2px #004080, -2px -1px #004080, -2px  0px #004080, -2px  1px #004080, -2px  2px #004080, -1px -2px #004080, -1px  2px #004080,  0px -2px #004080,
+   0px  2px #004080,  1px -2px #004080,  1px  2px #004080,  2px -2px #004080,  2px -1px #004080,  2px  0px #004080,  2px  1px #004080,  2px  2px #004080;}
+::cue(.outline1congressblue)        {text-shadow:
+  -1px -1px #004080, -1px  0px #004080, -1px  1px #004080,  0px -1px #004080,  0px  1px #004080,  1px -1px #004080,  1px  0px #004080,  1px  1px #004080;}
+::cue(.outline3cobalt)        {text-shadow:
+  -1px -1px #0040C0, -1px  0px #0040C0, -1px  1px #0040C0,  0px -1px #0040C0,  0px  1px #0040C0,  1px -1px #0040C0,  1px  0px #0040C0,  1px  1px #0040C0,
+  -2px -2px #0040C0, -2px -1px #0040C0, -2px  0px #0040C0, -2px  1px #0040C0, -2px  2px #0040C0, -1px -2px #0040C0, -1px  2px #0040C0,  0px -2px #0040C0,
+   0px  2px #0040C0,  1px -2px #0040C0,  1px  2px #0040C0,  2px -2px #0040C0,  2px -1px #0040C0,  2px  0px #0040C0,  2px  1px #0040C0,  2px  2px #0040C0,
+  -3px -3px #0040C0, -3px -2px #0040C0, -3px -1px #0040C0, -3px  0px #0040C0, -3px  1px #0040C0, -3px  2px #0040C0, -3px  3px #0040C0, -2px -3px #0040C0,
+  -2px  3px #0040C0, -1px -3px #0040C0, -1px  3px #0040C0,  0px -3px #0040C0,  0px  3px #0040C0,  1px -3px #0040C0,  1px  3px #0040C0,  2px -3px #0040C0,
+   2px  3px #0040C0,  3px -3px #0040C0,  3px -2px #0040C0,  3px -1px #0040C0,  3px  0px #0040C0,  3px  1px #0040C0,  3px  2px #0040C0,  3px  3px #0040C0;}
+::cue(.outline2cobalt)        {text-shadow:
+  -1px -1px #0040C0, -1px  0px #0040C0, -1px  1px #0040C0,  0px -1px #0040C0,  0px  1px #0040C0,  1px -1px #0040C0,  1px  0px #0040C0,  1px  1px #0040C0,
+  -2px -2px #0040C0, -2px -1px #0040C0, -2px  0px #0040C0, -2px  1px #0040C0, -2px  2px #0040C0, -1px -2px #0040C0, -1px  2px #0040C0,  0px -2px #0040C0,
+   0px  2px #0040C0,  1px -2px #0040C0,  1px  2px #0040C0,  2px -2px #0040C0,  2px -1px #0040C0,  2px  0px #0040C0,  2px  1px #0040C0,  2px  2px #0040C0;}
+::cue(.outline1cobalt)        {text-shadow:
+  -1px -1px #0040C0, -1px  0px #0040C0, -1px  1px #0040C0,  0px -1px #0040C0,  0px  1px #0040C0,  1px -1px #0040C0,  1px  0px #0040C0,  1px  1px #0040C0;}
+::cue(.outline3blueribbon)        {text-shadow:
+  -1px -1px #0040FF, -1px  0px #0040FF, -1px  1px #0040FF,  0px -1px #0040FF,  0px  1px #0040FF,  1px -1px #0040FF,  1px  0px #0040FF,  1px  1px #0040FF,
+  -2px -2px #0040FF, -2px -1px #0040FF, -2px  0px #0040FF, -2px  1px #0040FF, -2px  2px #0040FF, -1px -2px #0040FF, -1px  2px #0040FF,  0px -2px #0040FF,
+   0px  2px #0040FF,  1px -2px #0040FF,  1px  2px #0040FF,  2px -2px #0040FF,  2px -1px #0040FF,  2px  0px #0040FF,  2px  1px #0040FF,  2px  2px #0040FF,
+  -3px -3px #0040FF, -3px -2px #0040FF, -3px -1px #0040FF, -3px  0px #0040FF, -3px  1px #0040FF, -3px  2px #0040FF, -3px  3px #0040FF, -2px -3px #0040FF,
+  -2px  3px #0040FF, -1px -3px #0040FF, -1px  3px #0040FF,  0px -3px #0040FF,  0px  3px #0040FF,  1px -3px #0040FF,  1px  3px #0040FF,  2px -3px #0040FF,
+   2px  3px #0040FF,  3px -3px #0040FF,  3px -2px #0040FF,  3px -1px #0040FF,  3px  0px #0040FF,  3px  1px #0040FF,  3px  2px #0040FF,  3px  3px #0040FF;}
+::cue(.outline2blueribbon)        {text-shadow:
+  -1px -1px #0040FF, -1px  0px #0040FF, -1px  1px #0040FF,  0px -1px #0040FF,  0px  1px #0040FF,  1px -1px #0040FF,  1px  0px #0040FF,  1px  1px #0040FF,
+  -2px -2px #0040FF, -2px -1px #0040FF, -2px  0px #0040FF, -2px  1px #0040FF, -2px  2px #0040FF, -1px -2px #0040FF, -1px  2px #0040FF,  0px -2px #0040FF,
+   0px  2px #0040FF,  1px -2px #0040FF,  1px  2px #0040FF,  2px -2px #0040FF,  2px -1px #0040FF,  2px  0px #0040FF,  2px  1px #0040FF,  2px  2px #0040FF;}
+::cue(.outline1blueribbon)        {text-shadow:
+  -1px -1px #0040FF, -1px  0px #0040FF, -1px  1px #0040FF,  0px -1px #0040FF,  0px  1px #0040FF,  1px -1px #0040FF,  1px  0px #0040FF,  1px  1px #0040FF;}
+::cue(.outline3japlaurel)        {text-shadow:
+  -1px -1px #008000, -1px  0px #008000, -1px  1px #008000,  0px -1px #008000,  0px  1px #008000,  1px -1px #008000,  1px  0px #008000,  1px  1px #008000,
+  -2px -2px #008000, -2px -1px #008000, -2px  0px #008000, -2px  1px #008000, -2px  2px #008000, -1px -2px #008000, -1px  2px #008000,  0px -2px #008000,
+   0px  2px #008000,  1px -2px #008000,  1px  2px #008000,  2px -2px #008000,  2px -1px #008000,  2px  0px #008000,  2px  1px #008000,  2px  2px #008000,
+  -3px -3px #008000, -3px -2px #008000, -3px -1px #008000, -3px  0px #008000, -3px  1px #008000, -3px  2px #008000, -3px  3px #008000, -2px -3px #008000,
+  -2px  3px #008000, -1px -3px #008000, -1px  3px #008000,  0px -3px #008000,  0px  3px #008000,  1px -3px #008000,  1px  3px #008000,  2px -3px #008000,
+   2px  3px #008000,  3px -3px #008000,  3px -2px #008000,  3px -1px #008000,  3px  0px #008000,  3px  1px #008000,  3px  2px #008000,  3px  3px #008000;}
+::cue(.outline2japlaurel)        {text-shadow:
+  -1px -1px #008000, -1px  0px #008000, -1px  1px #008000,  0px -1px #008000,  0px  1px #008000,  1px -1px #008000,  1px  0px #008000,  1px  1px #008000,
+  -2px -2px #008000, -2px -1px #008000, -2px  0px #008000, -2px  1px #008000, -2px  2px #008000, -1px -2px #008000, -1px  2px #008000,  0px -2px #008000,
+   0px  2px #008000,  1px -2px #008000,  1px  2px #008000,  2px -2px #008000,  2px -1px #008000,  2px  0px #008000,  2px  1px #008000,  2px  2px #008000;}
+::cue(.outline1japlaurel)        {text-shadow:
+  -1px -1px #008000, -1px  0px #008000, -1px  1px #008000,  0px -1px #008000,  0px  1px #008000,  1px -1px #008000,  1px  0px #008000,  1px  1px #008000;}
+::cue(.outline3fungreen)        {text-shadow:
+  -1px -1px #008040, -1px  0px #008040, -1px  1px #008040,  0px -1px #008040,  0px  1px #008040,  1px -1px #008040,  1px  0px #008040,  1px  1px #008040,
+  -2px -2px #008040, -2px -1px #008040, -2px  0px #008040, -2px  1px #008040, -2px  2px #008040, -1px -2px #008040, -1px  2px #008040,  0px -2px #008040,
+   0px  2px #008040,  1px -2px #008040,  1px  2px #008040,  2px -2px #008040,  2px -1px #008040,  2px  0px #008040,  2px  1px #008040,  2px  2px #008040,
+  -3px -3px #008040, -3px -2px #008040, -3px -1px #008040, -3px  0px #008040, -3px  1px #008040, -3px  2px #008040, -3px  3px #008040, -2px -3px #008040,
+  -2px  3px #008040, -1px -3px #008040, -1px  3px #008040,  0px -3px #008040,  0px  3px #008040,  1px -3px #008040,  1px  3px #008040,  2px -3px #008040,
+   2px  3px #008040,  3px -3px #008040,  3px -2px #008040,  3px -1px #008040,  3px  0px #008040,  3px  1px #008040,  3px  2px #008040,  3px  3px #008040;}
+::cue(.outline2fungreen)        {text-shadow:
+  -1px -1px #008040, -1px  0px #008040, -1px  1px #008040,  0px -1px #008040,  0px  1px #008040,  1px -1px #008040,  1px  0px #008040,  1px  1px #008040,
+  -2px -2px #008040, -2px -1px #008040, -2px  0px #008040, -2px  1px #008040, -2px  2px #008040, -1px -2px #008040, -1px  2px #008040,  0px -2px #008040,
+   0px  2px #008040,  1px -2px #008040,  1px  2px #008040,  2px -2px #008040,  2px -1px #008040,  2px  0px #008040,  2px  1px #008040,  2px  2px #008040;}
+::cue(.outline1fungreen)        {text-shadow:
+  -1px -1px #008080, -1px  0px #008080, -1px  1px #008080,  0px -1px #008080,  0px  1px #008080,  1px -1px #008080,  1px  0px #008080,  1px  1px #008080;}
+::cue(.outline3teal)        {text-shadow:
+  -1px -1px #008080, -1px  0px #008080, -1px  1px #008080,  0px -1px #008080,  0px  1px #008080,  1px -1px #008080,  1px  0px #008080,  1px  1px #008080,
+  -2px -2px #008080, -2px -1px #008080, -2px  0px #008080, -2px  1px #008080, -2px  2px #008080, -1px -2px #008080, -1px  2px #008080,  0px -2px #008080,
+   0px  2px #008080,  1px -2px #008080,  1px  2px #008080,  2px -2px #008080,  2px -1px #008080,  2px  0px #008080,  2px  1px #008080,  2px  2px #008080,
+  -3px -3px #008080, -3px -2px #008080, -3px -1px #008080, -3px  0px #008080, -3px  1px #008080, -3px  2px #008080, -3px  3px #008080, -2px -3px #008080,
+  -2px  3px #008080, -1px -3px #008080, -1px  3px #008080,  0px -3px #008080,  0px  3px #008080,  1px -3px #008080,  1px  3px #008080,  2px -3px #008080,
+   2px  3px #008080,  3px -3px #008080,  3px -2px #008080,  3px -1px #008080,  3px  0px #008080,  3px  1px #008080,  3px  2px #008080,  3px  3px #008080;}
+::cue(.outline2teal)        {text-shadow:
+  -1px -1px #008080, -1px  0px #008080, -1px  1px #008080,  0px -1px #008080,  0px  1px #008080,  1px -1px #008080,  1px  0px #008080,  1px  1px #008080,
+  -2px -2px #008080, -2px -1px #008080, -2px  0px #008080, -2px  1px #008080, -2px  2px #008080, -1px -2px #008080, -1px  2px #008080,  0px -2px #008080,
+   0px  2px #008080,  1px -2px #008080,  1px  2px #008080,  2px -2px #008080,  2px -1px #008080,  2px  0px #008080,  2px  1px #008080,  2px  2px #008080;}
+::cue(.outline1teal)        {text-shadow:
+  -1px -1px #008080, -1px  0px #008080, -1px  1px #008080,  0px -1px #008080,  0px  1px #008080,  1px -1px #008080,  1px  0px #008080,  1px  1px #008080;}
+::cue(.outline3lochmara)        {text-shadow:
+  -1px -1px #0080C0, -1px  0px #0080C0, -1px  1px #0080C0,  0px -1px #0080C0,  0px  1px #0080C0,  1px -1px #0080C0,  1px  0px #0080C0,  1px  1px #0080C0,
+  -2px -2px #0080C0, -2px -1px #0080C0, -2px  0px #0080C0, -2px  1px #0080C0, -2px  2px #0080C0, -1px -2px #0080C0, -1px  2px #0080C0,  0px -2px #0080C0,
+   0px  2px #0080C0,  1px -2px #0080C0,  1px  2px #0080C0,  2px -2px #0080C0,  2px -1px #0080C0,  2px  0px #0080C0,  2px  1px #0080C0,  2px  2px #0080C0,
+  -3px -3px #0080C0, -3px -2px #0080C0, -3px -1px #0080C0, -3px  0px #0080C0, -3px  1px #0080C0, -3px  2px #0080C0, -3px  3px #0080C0, -2px -3px #0080C0,
+  -2px  3px #0080C0, -1px -3px #0080C0, -1px  3px #0080C0,  0px -3px #0080C0,  0px  3px #0080C0,  1px -3px #0080C0,  1px  3px #0080C0,  2px -3px #0080C0,
+   2px  3px #0080C0,  3px -3px #0080C0,  3px -2px #0080C0,  3px -1px #0080C0,  3px  0px #0080C0,  3px  1px #0080C0,  3px  2px #0080C0,  3px  3px #0080C0;}
+::cue(.outline2lochmara)        {text-shadow:
+  -1px -1px #0080C0, -1px  0px #0080C0, -1px  1px #0080C0,  0px -1px #0080C0,  0px  1px #0080C0,  1px -1px #0080C0,  1px  0px #0080C0,  1px  1px #0080C0,
+  -2px -2px #0080C0, -2px -1px #0080C0, -2px  0px #0080C0, -2px  1px #0080C0, -2px  2px #0080C0, -1px -2px #0080C0, -1px  2px #0080C0,  0px -2px #0080C0,
+   0px  2px #0080C0,  1px -2px #0080C0,  1px  2px #0080C0,  2px -2px #0080C0,  2px -1px #0080C0,  2px  0px #0080C0,  2px  1px #0080C0,  2px  2px #0080C0;}
+::cue(.outline1lochmara)        {text-shadow:
+  -1px -1px #0080C0, -1px  0px #0080C0, -1px  1px #0080C0,  0px -1px #0080C0,  0px  1px #0080C0,  1px -1px #0080C0,  1px  0px #0080C0,  1px  1px #0080C0;}
+::cue(.outline3azure)        {text-shadow:
+  -1px -1px #0080FF, -1px  0px #0080FF, -1px  1px #0080FF,  0px -1px #0080FF,  0px  1px #0080FF,  1px -1px #0080FF,  1px  0px #0080FF,  1px  1px #0080FF,
+  -2px -2px #0080FF, -2px -1px #0080FF, -2px  0px #0080FF, -2px  1px #0080FF, -2px  2px #0080FF, -1px -2px #0080FF, -1px  2px #0080FF,  0px -2px #0080FF,
+   0px  2px #0080FF,  1px -2px #0080FF,  1px  2px #0080FF,  2px -2px #0080FF,  2px -1px #0080FF,  2px  0px #0080FF,  2px  1px #0080FF,  2px  2px #0080FF,
+  -3px -3px #0080FF, -3px -2px #0080FF, -3px -1px #0080FF, -3px  0px #0080FF, -3px  1px #0080FF, -3px  2px #0080FF, -3px  3px #0080FF, -2px -3px #0080FF,
+  -2px  3px #0080FF, -1px -3px #0080FF, -1px  3px #0080FF,  0px -3px #0080FF,  0px  3px #0080FF,  1px -3px #0080FF,  1px  3px #0080FF,  2px -3px #0080FF,
+   2px  3px #0080FF,  3px -3px #0080FF,  3px -2px #0080FF,  3px -1px #0080FF,  3px  0px #0080FF,  3px  1px #0080FF,  3px  2px #0080FF,  3px  3px #0080FF;}
+::cue(.outline2azure)        {text-shadow:
+  -1px -1px #0080FF, -1px  0px #0080FF, -1px  1px #0080FF,  0px -1px #0080FF,  0px  1px #0080FF,  1px -1px #0080FF,  1px  0px #0080FF,  1px  1px #0080FF,
+  -2px -2px #0080FF, -2px -1px #0080FF, -2px  0px #0080FF, -2px  1px #0080FF, -2px  2px #0080FF, -1px -2px #0080FF, -1px  2px #0080FF,  0px -2px #0080FF,
+   0px  2px #0080FF,  1px -2px #0080FF,  1px  2px #0080FF,  2px -2px #0080FF,  2px -1px #0080FF,  2px  0px #0080FF,  2px  1px #0080FF,  2px  2px #0080FF;}
+::cue(.outline1azure)        {text-shadow:
+  -1px -1px #0080FF, -1px  0px #0080FF, -1px  1px #0080FF,  0px -1px #0080FF,  0px  1px #0080FF,  1px -1px #0080FF,  1px  0px #0080FF,  1px  1px #0080FF;}
+::cue(.outline3forest)        {text-shadow:
+  -1px -1px #00C000, -1px  0px #00C000, -1px  1px #00C000,  0px -1px #00C000,  0px  1px #00C000,  1px -1px #00C000,  1px  0px #00C000,  1px  1px #00C000,
+  -2px -2px #00C000, -2px -1px #00C000, -2px  0px #00C000, -2px  1px #00C000, -2px  2px #00C000, -1px -2px #00C000, -1px  2px #00C000,  0px -2px #00C000,
+   0px  2px #00C000,  1px -2px #00C000,  1px  2px #00C000,  2px -2px #00C000,  2px -1px #00C000,  2px  0px #00C000,  2px  1px #00C000,  2px  2px #00C000,
+  -3px -3px #00C000, -3px -2px #00C000, -3px -1px #00C000, -3px  0px #00C000, -3px  1px #00C000, -3px  2px #00C000, -3px  3px #00C000, -2px -3px #00C000,
+  -2px  3px #00C000, -1px -3px #00C000, -1px  3px #00C000,  0px -3px #00C000,  0px  3px #00C000,  1px -3px #00C000,  1px  3px #00C000,  2px -3px #00C000,
+   2px  3px #00C000,  3px -3px #00C000,  3px -2px #00C000,  3px -1px #00C000,  3px  0px #00C000,  3px  1px #00C000,  3px  2px #00C000,  3px  3px #00C000;}
+::cue(.outline2forest)        {text-shadow:
+  -1px -1px #00C000, -1px  0px #00C000, -1px  1px #00C000,  0px -1px #00C000,  0px  1px #00C000,  1px -1px #00C000,  1px  0px #00C000,  1px  1px #00C000,
+  -2px -2px #00C000, -2px -1px #00C000, -2px  0px #00C000, -2px  1px #00C000, -2px  2px #00C000, -1px -2px #00C000, -1px  2px #00C000,  0px -2px #00C000,
+   0px  2px #00C000,  1px -2px #00C000,  1px  2px #00C000,  2px -2px #00C000,  2px -1px #00C000,  2px  0px #00C000,  2px  1px #00C000,  2px  2px #00C000;}
+::cue(.outline1forest)        {text-shadow:
+  -1px -1px #00C000, -1px  0px #00C000, -1px  1px #00C000,  0px -1px #00C000,  0px  1px #00C000,  1px -1px #00C000,  1px  0px #00C000,  1px  1px #00C000;}
+::cue(.outline3malachite)        {text-shadow:
+  -1px -1px #00C040, -1px  0px #00C040, -1px  1px #00C040,  0px -1px #00C040,  0px  1px #00C040,  1px -1px #00C040,  1px  0px #00C040,  1px  1px #00C040,
+  -2px -2px #00C040, -2px -1px #00C040, -2px  0px #00C040, -2px  1px #00C040, -2px  2px #00C040, -1px -2px #00C040, -1px  2px #00C040,  0px -2px #00C040,
+   0px  2px #00C040,  1px -2px #00C040,  1px  2px #00C040,  2px -2px #00C040,  2px -1px #00C040,  2px  0px #00C040,  2px  1px #00C040,  2px  2px #00C040,
+  -3px -3px #00C040, -3px -2px #00C040, -3px -1px #00C040, -3px  0px #00C040, -3px  1px #00C040, -3px  2px #00C040, -3px  3px #00C040, -2px -3px #00C040,
+  -2px  3px #00C040, -1px -3px #00C040, -1px  3px #00C040,  0px -3px #00C040,  0px  3px #00C040,  1px -3px #00C040,  1px  3px #00C040,  2px -3px #00C040,
+   2px  3px #00C040,  3px -3px #00C040,  3px -2px #00C040,  3px -1px #00C040,  3px  0px #00C040,  3px  1px #00C040,  3px  2px #00C040,  3px  3px #00C040;}
+::cue(.outline2malachite)        {text-shadow:
+  -1px -1px #00C040, -1px  0px #00C040, -1px  1px #00C040,  0px -1px #00C040,  0px  1px #00C040,  1px -1px #00C040,  1px  0px #00C040,  1px  1px #00C040,
+  -2px -2px #00C040, -2px -1px #00C040, -2px  0px #00C040, -2px  1px #00C040, -2px  2px #00C040, -1px -2px #00C040, -1px  2px #00C040,  0px -2px #00C040,
+   0px  2px #00C040,  1px -2px #00C040,  1px  2px #00C040,  2px -2px #00C040,  2px -1px #00C040,  2px  0px #00C040,  2px  1px #00C040,  2px  2px #00C040;}
+::cue(.outline1malachite)        {text-shadow:
+  -1px -1px #00C040, -1px  0px #00C040, -1px  1px #00C040,  0px -1px #00C040,  0px  1px #00C040,  1px -1px #00C040,  1px  0px #00C040,  1px  1px #00C040;}
+::cue(.outline3caribbean)        {text-shadow:
+  -1px -1px #00C080, -1px  0px #00C080, -1px  1px #00C080,  0px -1px #00C080,  0px  1px #00C080,  1px -1px #00C080,  1px  0px #00C080,  1px  1px #00C080,
+  -2px -2px #00C080, -2px -1px #00C080, -2px  0px #00C080, -2px  1px #00C080, -2px  2px #00C080, -1px -2px #00C080, -1px  2px #00C080,  0px -2px #00C080,
+   0px  2px #00C080,  1px -2px #00C080,  1px  2px #00C080,  2px -2px #00C080,  2px -1px #00C080,  2px  0px #00C080,  2px  1px #00C080,  2px  2px #00C080,
+  -3px -3px #00C080, -3px -2px #00C080, -3px -1px #00C080, -3px  0px #00C080, -3px  1px #00C080, -3px  2px #00C080, -3px  3px #00C080, -2px -3px #00C080,
+  -2px  3px #00C080, -1px -3px #00C080, -1px  3px #00C080,  0px -3px #00C080,  0px  3px #00C080,  1px -3px #00C080,  1px  3px #00C080,  2px -3px #00C080,
+   2px  3px #00C080,  3px -3px #00C080,  3px -2px #00C080,  3px -1px #00C080,  3px  0px #00C080,  3px  1px #00C080,  3px  2px #00C080,  3px  3px #00C080;}
+::cue(.outline2caribbean)        {text-shadow:
+  -1px -1px #00C080, -1px  0px #00C080, -1px  1px #00C080,  0px -1px #00C080,  0px  1px #00C080,  1px -1px #00C080,  1px  0px #00C080,  1px  1px #00C080,
+  -2px -2px #00C080, -2px -1px #00C080, -2px  0px #00C080, -2px  1px #00C080, -2px  2px #00C080, -1px -2px #00C080, -1px  2px #00C080,  0px -2px #00C080,
+   0px  2px #00C080,  1px -2px #00C080,  1px  2px #00C080,  2px -2px #00C080,  2px -1px #00C080,  2px  0px #00C080,  2px  1px #00C080,  2px  2px #00C080;}
+::cue(.outline1caribbean)        {text-shadow:
+  -1px -1px #00C080, -1px  0px #00C080, -1px  1px #00C080,  0px -1px #00C080,  0px  1px #00C080,  1px -1px #00C080,  1px  0px #00C080,  1px  1px #00C080;}
+::cue(.outline3eggblue)        {text-shadow:
+  -1px -1px #00C0C0, -1px  0px #00C0C0, -1px  1px #00C0C0,  0px -1px #00C0C0,  0px  1px #00C0C0,  1px -1px #00C0C0,  1px  0px #00C0C0,  1px  1px #00C0C0,
+  -2px -2px #00C0C0, -2px -1px #00C0C0, -2px  0px #00C0C0, -2px  1px #00C0C0, -2px  2px #00C0C0, -1px -2px #00C0C0, -1px  2px #00C0C0,  0px -2px #00C0C0,
+   0px  2px #00C0C0,  1px -2px #00C0C0,  1px  2px #00C0C0,  2px -2px #00C0C0,  2px -1px #00C0C0,  2px  0px #00C0C0,  2px  1px #00C0C0,  2px  2px #00C0C0,
+  -3px -3px #00C0C0, -3px -2px #00C0C0, -3px -1px #00C0C0, -3px  0px #00C0C0, -3px  1px #00C0C0, -3px  2px #00C0C0, -3px  3px #00C0C0, -2px -3px #00C0C0,
+  -2px  3px #00C0C0, -1px -3px #00C0C0, -1px  3px #00C0C0,  0px -3px #00C0C0,  0px  3px #00C0C0,  1px -3px #00C0C0,  1px  3px #00C0C0,  2px -3px #00C0C0,
+   2px  3px #00C0C0,  3px -3px #00C0C0,  3px -2px #00C0C0,  3px -1px #00C0C0,  3px  0px #00C0C0,  3px  1px #00C0C0,  3px  2px #00C0C0,  3px  3px #00C0C0;}
+::cue(.outline2eggblue)        {text-shadow:
+  -1px -1px #00C0C0, -1px  0px #00C0C0, -1px  1px #00C0C0,  0px -1px #00C0C0,  0px  1px #00C0C0,  1px -1px #00C0C0,  1px  0px #00C0C0,  1px  1px #00C0C0,
+  -2px -2px #00C0C0, -2px -1px #00C0C0, -2px  0px #00C0C0, -2px  1px #00C0C0, -2px  2px #00C0C0, -1px -2px #00C0C0, -1px  2px #00C0C0,  0px -2px #00C0C0,
+   0px  2px #00C0C0,  1px -2px #00C0C0,  1px  2px #00C0C0,  2px -2px #00C0C0,  2px -1px #00C0C0,  2px  0px #00C0C0,  2px  1px #00C0C0,  2px  2px #00C0C0;}
+::cue(.outline1eggblue)        {text-shadow:
+  -1px -1px #00C0C0, -1px  0px #00C0C0, -1px  1px #00C0C0,  0px -1px #00C0C0,  0px  1px #00C0C0,  1px -1px #00C0C0,  1px  0px #00C0C0,  1px  1px #00C0C0;}
+::cue(.outline3cerulean)        {text-shadow:
+  -1px -1px #00C0FF, -1px  0px #00C0FF, -1px  1px #00C0FF,  0px -1px #00C0FF,  0px  1px #00C0FF,  1px -1px #00C0FF,  1px  0px #00C0FF,  1px  1px #00C0FF,
+  -2px -2px #00C0FF, -2px -1px #00C0FF, -2px  0px #00C0FF, -2px  1px #00C0FF, -2px  2px #00C0FF, -1px -2px #00C0FF, -1px  2px #00C0FF,  0px -2px #00C0FF,
+   0px  2px #00C0FF,  1px -2px #00C0FF,  1px  2px #00C0FF,  2px -2px #00C0FF,  2px -1px #00C0FF,  2px  0px #00C0FF,  2px  1px #00C0FF,  2px  2px #00C0FF,
+  -3px -3px #00C0FF, -3px -2px #00C0FF, -3px -1px #00C0FF, -3px  0px #00C0FF, -3px  1px #00C0FF, -3px  2px #00C0FF, -3px  3px #00C0FF, -2px -3px #00C0FF,
+  -2px  3px #00C0FF, -1px -3px #00C0FF, -1px  3px #00C0FF,  0px -3px #00C0FF,  0px  3px #00C0FF,  1px -3px #00C0FF,  1px  3px #00C0FF,  2px -3px #00C0FF,
+   2px  3px #00C0FF,  3px -3px #00C0FF,  3px -2px #00C0FF,  3px -1px #00C0FF,  3px  0px #00C0FF,  3px  1px #00C0FF,  3px  2px #00C0FF,  3px  3px #00C0FF;}
+::cue(.outline2cerulean)        {text-shadow:
+  -1px -1px #00C0FF, -1px  0px #00C0FF, -1px  1px #00C0FF,  0px -1px #00C0FF,  0px  1px #00C0FF,  1px -1px #00C0FF,  1px  0px #00C0FF,  1px  1px #00C0FF,
+  -2px -2px #00C0FF, -2px -1px #00C0FF, -2px  0px #00C0FF, -2px  1px #00C0FF, -2px  2px #00C0FF, -1px -2px #00C0FF, -1px  2px #00C0FF,  0px -2px #00C0FF,
+   0px  2px #00C0FF,  1px -2px #00C0FF,  1px  2px #00C0FF,  2px -2px #00C0FF,  2px -1px #00C0FF,  2px  0px #00C0FF,  2px  1px #00C0FF,  2px  2px #00C0FF;}
+::cue(.outline1cerulean)        {text-shadow:
+  -1px -1px #00C0FF, -1px  0px #00C0FF, -1px  1px #00C0FF,  0px -1px #00C0FF,  0px  1px #00C0FF,  1px -1px #00C0FF,  1px  0px #00C0FF,  1px  1px #00C0FF;}
+::cue(.outline3green)        {text-shadow:
+  -1px -1px #00FF00, -1px  0px #00FF00, -1px  1px #00FF00,  0px -1px #00FF00,  0px  1px #00FF00,  1px -1px #00FF00,  1px  0px #00FF00,  1px  1px #00FF00,
+  -2px -2px #00FF00, -2px -1px #00FF00, -2px  0px #00FF00, -2px  1px #00FF00, -2px  2px #00FF00, -1px -2px #00FF00, -1px  2px #00FF00,  0px -2px #00FF00,
+   0px  2px #00FF00,  1px -2px #00FF00,  1px  2px #00FF00,  2px -2px #00FF00,  2px -1px #00FF00,  2px  0px #00FF00,  2px  1px #00FF00,  2px  2px #00FF00,
+  -3px -3px #00FF00, -3px -2px #00FF00, -3px -1px #00FF00, -3px  0px #00FF00, -3px  1px #00FF00, -3px  2px #00FF00, -3px  3px #00FF00, -2px -3px #00FF00,
+  -2px  3px #00FF00, -1px -3px #00FF00, -1px  3px #00FF00,  0px -3px #00FF00,  0px  3px #00FF00,  1px -3px #00FF00,  1px  3px #00FF00,  2px -3px #00FF00,
+   2px  3px #00FF00,  3px -3px #00FF00,  3px -2px #00FF00,  3px -1px #00FF00,  3px  0px #00FF00,  3px  1px #00FF00,  3px  2px #00FF00,  3px  3px #00FF00;}
+::cue(.outline2green)        {text-shadow:
+  -1px -1px #00FF00, -1px  0px #00FF00, -1px  1px #00FF00,  0px -1px #00FF00,  0px  1px #00FF00,  1px -1px #00FF00,  1px  0px #00FF00,  1px  1px #00FF00,
+  -2px -2px #00FF00, -2px -1px #00FF00, -2px  0px #00FF00, -2px  1px #00FF00, -2px  2px #00FF00, -1px -2px #00FF00, -1px  2px #00FF00,  0px -2px #00FF00,
+   0px  2px #00FF00,  1px -2px #00FF00,  1px  2px #00FF00,  2px -2px #00FF00,  2px -1px #00FF00,  2px  0px #00FF00,  2px  1px #00FF00,  2px  2px #00FF00;}
+::cue(.outline1green)        {text-shadow:
+  -1px -1px #00FF00, -1px  0px #00FF00, -1px  1px #00FF00,  0px -1px #00FF00,  0px  1px #00FF00,  1px -1px #00FF00,  1px  0px #00FF00,  1px  1px #00FF00;}
+::cue(.outline3lime)        {text-shadow:
+  -1px -1px #00FF40, -1px  0px #00FF40, -1px  1px #00FF40,  0px -1px #00FF40,  0px  1px #00FF40,  1px -1px #00FF40,  1px  0px #00FF40,  1px  1px #00FF40,
+  -2px -2px #00FF40, -2px -1px #00FF40, -2px  0px #00FF40, -2px  1px #00FF40, -2px  2px #00FF40, -1px -2px #00FF40, -1px  2px #00FF40,  0px -2px #00FF40,
+   0px  2px #00FF40,  1px -2px #00FF40,  1px  2px #00FF40,  2px -2px #00FF40,  2px -1px #00FF40,  2px  0px #00FF40,  2px  1px #00FF40,  2px  2px #00FF40,
+  -3px -3px #00FF40, -3px -2px #00FF40, -3px -1px #00FF40, -3px  0px #00FF40, -3px  1px #00FF40, -3px  2px #00FF40, -3px  3px #00FF40, -2px -3px #00FF40,
+  -2px  3px #00FF40, -1px -3px #00FF40, -1px  3px #00FF40,  0px -3px #00FF40,  0px  3px #00FF40,  1px -3px #00FF40,  1px  3px #00FF40,  2px -3px #00FF40,
+   2px  3px #00FF40,  3px -3px #00FF40,  3px -2px #00FF40,  3px -1px #00FF40,  3px  0px #00FF40,  3px  1px #00FF40,  3px  2px #00FF40,  3px  3px #00FF40;}
+::cue(.outline2lime)        {text-shadow:
+  -1px -1px #00FF40, -1px  0px #00FF40, -1px  1px #00FF40,  0px -1px #00FF40,  0px  1px #00FF40,  1px -1px #00FF40,  1px  0px #00FF40,  1px  1px #00FF40,
+  -2px -2px #00FF40, -2px -1px #00FF40, -2px  0px #00FF40, -2px  1px #00FF40, -2px  2px #00FF40, -1px -2px #00FF40, -1px  2px #00FF40,  0px -2px #00FF40,
+   0px  2px #00FF40,  1px -2px #00FF40,  1px  2px #00FF40,  2px -2px #00FF40,  2px -1px #00FF40,  2px  0px #00FF40,  2px  1px #00FF40,  2px  2px #00FF40;}
+::cue(.outline1lime)        {text-shadow:
+  -1px -1px #00FF40, -1px  0px #00FF40, -1px  1px #00FF40,  0px -1px #00FF40,  0px  1px #00FF40,  1px -1px #00FF40,  1px  0px #00FF40,  1px  1px #00FF40;}
+::cue(.outline3springgreen)        {text-shadow:
+  -1px -1px #00FF80, -1px  0px #00FF80, -1px  1px #00FF80,  0px -1px #00FF80,  0px  1px #00FF80,  1px -1px #00FF80,  1px  0px #00FF80,  1px  1px #00FF80,
+  -2px -2px #00FF80, -2px -1px #00FF80, -2px  0px #00FF80, -2px  1px #00FF80, -2px  2px #00FF80, -1px -2px #00FF80, -1px  2px #00FF80,  0px -2px #00FF80,
+   0px  2px #00FF80,  1px -2px #00FF80,  1px  2px #00FF80,  2px -2px #00FF80,  2px -1px #00FF80,  2px  0px #00FF80,  2px  1px #00FF80,  2px  2px #00FF80,
+  -3px -3px #00FF80, -3px -2px #00FF80, -3px -1px #00FF80, -3px  0px #00FF80, -3px  1px #00FF80, -3px  2px #00FF80, -3px  3px #00FF80, -2px -3px #00FF80,
+  -2px  3px #00FF80, -1px -3px #00FF80, -1px  3px #00FF80,  0px -3px #00FF80,  0px  3px #00FF80,  1px -3px #00FF80,  1px  3px #00FF80,  2px -3px #00FF80,
+   2px  3px #00FF80,  3px -3px #00FF80,  3px -2px #00FF80,  3px -1px #00FF80,  3px  0px #00FF80,  3px  1px #00FF80,  3px  2px #00FF80,  3px  3px #00FF80;}
+::cue(.outline2springgreen)        {text-shadow:
+  -1px -1px #00FF80, -1px  0px #00FF80, -1px  1px #00FF80,  0px -1px #00FF80,  0px  1px #00FF80,  1px -1px #00FF80,  1px  0px #00FF80,  1px  1px #00FF80,
+  -2px -2px #00FF80, -2px -1px #00FF80, -2px  0px #00FF80, -2px  1px #00FF80, -2px  2px #00FF80, -1px -2px #00FF80, -1px  2px #00FF80,  0px -2px #00FF80,
+   0px  2px #00FF80,  1px -2px #00FF80,  1px  2px #00FF80,  2px -2px #00FF80,  2px -1px #00FF80,  2px  0px #00FF80,  2px  1px #00FF80,  2px  2px #00FF80;}
+::cue(.outline1springgreen)        {text-shadow:
+  -1px -1px #00FF80, -1px  0px #00FF80, -1px  1px #00FF80,  0px -1px #00FF80,  0px  1px #00FF80,  1px -1px #00FF80,  1px  0px #00FF80,  1px  1px #00FF80;}
+::cue(.outline3brightturq)        {text-shadow:
+  -1px -1px #00FFC0, -1px  0px #00FFC0, -1px  1px #00FFC0,  0px -1px #00FFC0,  0px  1px #00FFC0,  1px -1px #00FFC0,  1px  0px #00FFC0,  1px  1px #00FFC0,
+  -2px -2px #00FFC0, -2px -1px #00FFC0, -2px  0px #00FFC0, -2px  1px #00FFC0, -2px  2px #00FFC0, -1px -2px #00FFC0, -1px  2px #00FFC0,  0px -2px #00FFC0,
+   0px  2px #00FFC0,  1px -2px #00FFC0,  1px  2px #00FFC0,  2px -2px #00FFC0,  2px -1px #00FFC0,  2px  0px #00FFC0,  2px  1px #00FFC0,  2px  2px #00FFC0,
+  -3px -3px #00FFC0, -3px -2px #00FFC0, -3px -1px #00FFC0, -3px  0px #00FFC0, -3px  1px #00FFC0, -3px  2px #00FFC0, -3px  3px #00FFC0, -2px -3px #00FFC0,
+  -2px  3px #00FFC0, -1px -3px #00FFC0, -1px  3px #00FFC0,  0px -3px #00FFC0,  0px  3px #00FFC0,  1px -3px #00FFC0,  1px  3px #00FFC0,  2px -3px #00FFC0,
+   2px  3px #00FFC0,  3px -3px #00FFC0,  3px -2px #00FFC0,  3px -1px #00FFC0,  3px  0px #00FFC0,  3px  1px #00FFC0,  3px  2px #00FFC0,  3px  3px #00FFC0;}
+::cue(.outline2brightturq)        {text-shadow:
+  -1px -1px #00FFC0, -1px  0px #00FFC0, -1px  1px #00FFC0,  0px -1px #00FFC0,  0px  1px #00FFC0,  1px -1px #00FFC0,  1px  0px #00FFC0,  1px  1px #00FFC0,
+  -2px -2px #00FFC0, -2px -1px #00FFC0, -2px  0px #00FFC0, -2px  1px #00FFC0, -2px  2px #00FFC0, -1px -2px #00FFC0, -1px  2px #00FFC0,  0px -2px #00FFC0,
+   0px  2px #00FFC0,  1px -2px #00FFC0,  1px  2px #00FFC0,  2px -2px #00FFC0,  2px -1px #00FFC0,  2px  0px #00FFC0,  2px  1px #00FFC0,  2px  2px #00FFC0;}
+::cue(.outline1brightturq)        {text-shadow:
+  -1px -1px #00FFC0, -1px  0px #00FFC0, -1px  1px #00FFC0,  0px -1px #00FFC0,  0px  1px #00FFC0,  1px -1px #00FFC0,  1px  0px #00FFC0,  1px  1px #00FFC0;}
+::cue(.outline3cyan)        {text-shadow:
+  -1px -1px #00FFFF, -1px  0px #00FFFF, -1px  1px #00FFFF,  0px -1px #00FFFF,  0px  1px #00FFFF,  1px -1px #00FFFF,  1px  0px #00FFFF,  1px  1px #00FFFF,
+  -2px -2px #00FFFF, -2px -1px #00FFFF, -2px  0px #00FFFF, -2px  1px #00FFFF, -2px  2px #00FFFF, -1px -2px #00FFFF, -1px  2px #00FFFF,  0px -2px #00FFFF,
+   0px  2px #00FFFF,  1px -2px #00FFFF,  1px  2px #00FFFF,  2px -2px #00FFFF,  2px -1px #00FFFF,  2px  0px #00FFFF,  2px  1px #00FFFF,  2px  2px #00FFFF,
+  -3px -3px #00FFFF, -3px -2px #00FFFF, -3px -1px #00FFFF, -3px  0px #00FFFF, -3px  1px #00FFFF, -3px  2px #00FFFF, -3px  3px #00FFFF, -2px -3px #00FFFF,
+  -2px  3px #00FFFF, -1px -3px #00FFFF, -1px  3px #00FFFF,  0px -3px #00FFFF,  0px  3px #00FFFF,  1px -3px #00FFFF,  1px  3px #00FFFF,  2px -3px #00FFFF,
+   2px  3px #00FFFF,  3px -3px #00FFFF,  3px -2px #00FFFF,  3px -1px #00FFFF,  3px  0px #00FFFF,  3px  1px #00FFFF,  3px  2px #00FFFF,  3px  3px #00FFFF;}
+::cue(.outline2cyan)        {text-shadow:
+  -1px -1px #00FFFF, -1px  0px #00FFFF, -1px  1px #00FFFF,  0px -1px #00FFFF,  0px  1px #00FFFF,  1px -1px #00FFFF,  1px  0px #00FFFF,  1px  1px #00FFFF,
+  -2px -2px #00FFFF, -2px -1px #00FFFF, -2px  0px #00FFFF, -2px  1px #00FFFF, -2px  2px #00FFFF, -1px -2px #00FFFF, -1px  2px #00FFFF,  0px -2px #00FFFF,
+   0px  2px #00FFFF,  1px -2px #00FFFF,  1px  2px #00FFFF,  2px -2px #00FFFF,  2px -1px #00FFFF,  2px  0px #00FFFF,  2px  1px #00FFFF,  2px  2px #00FFFF;}
+::cue(.outline1cyan)        {text-shadow:
+  -1px -1px #00FFFF, -1px  0px #00FFFF, -1px  1px #00FFFF,  0px -1px #00FFFF,  0px  1px #00FFFF,  1px -1px #00FFFF,  1px  0px #00FFFF,  1px  1px #00FFFF;}
+
+::cue(.outline3temptress)             {text-shadow:
+  -1px -1px #400000, -1px  0px #400000, -1px  1px #400000,  0px -1px #400000,  0px  1px #400000,  1px -1px #400000,  1px  0px #400000,  1px  1px #400000,
+  -2px -2px #400000, -2px -1px #400000, -2px  0px #400000, -2px  1px #400000, -2px  2px #400000, -1px -2px #400000, -1px  2px #400000,  0px -2px #400000,
+   0px  2px #400000,  1px -2px #400000,  1px  2px #400000,  2px -2px #400000,  2px -1px #400000,  2px  0px #400000,  2px  1px #400000,  2px  2px #400000,
+  -3px -3px #400000, -3px -2px #400000, -3px -1px #400000, -3px  0px #400000, -3px  1px #400000, -3px  2px #400000, -3px  3px #400000, -2px -3px #400000,
+  -2px  3px #400000, -1px -3px #400000, -1px  3px #400000,  0px -3px #400000,  0px  3px #400000,  1px -3px #400000,  1px  3px #400000,  2px -3px #400000,
+   2px  3px #400000,  3px -3px #400000,  3px -2px #400000,  3px -1px #400000,  3px  0px #400000,  3px  1px #400000,  3px  2px #400000,  3px  3px #400000;}
+::cue(.outline2temptress)             {text-shadow:
+  -1px -1px #400000, -1px  0px #400000, -1px  1px #400000,  0px -1px #400000,  0px  1px #400000,  1px -1px #400000,  1px  0px #400000,  1px  1px #400000,
+  -2px -2px #400000, -2px -1px #400000, -2px  0px #400000, -2px  1px #400000, -2px  2px #400000, -1px -2px #400000, -1px  2px #400000,  0px -2px #400000,
+   0px  2px #400000,  1px -2px #400000,  1px  2px #400000,  2px -2px #400000,  2px -1px #400000,  2px  0px #400000,  2px  1px #400000,  2px  2px #400000;}
+::cue(.outline1temptress)             {text-shadow:
+  -1px -1px #400000, -1px  0px #400000, -1px  1px #400000,  0px -1px #400000,  0px  1px #400000,  1px -1px #400000,  1px  0px #400000,  1px  1px #400000;}
+::cue(.outline3blackberry)           {text-shadow:
+  -1px -1px #400040, -1px  0px #400040, -1px  1px #400040,  0px -1px #400040,  0px  1px #400040,  1px -1px #400040,  1px  0px #400040,  1px  1px #400040,
+  -2px -2px #400040, -2px -1px #400040, -2px  0px #400040, -2px  1px #400040, -2px  2px #400040, -1px -2px #400040, -1px  2px #400040,  0px -2px #400040,
+   0px  2px #400040,  1px -2px #400040,  1px  2px #400040,  2px -2px #400040,  2px -1px #400040,  2px  0px #400040,  2px  1px #400040,  2px  2px #400040,
+  -3px -3px #400040, -3px -2px #400040, -3px -1px #400040, -3px  0px #400040, -3px  1px #400040, -3px  2px #400040, -3px  3px #400040, -2px -3px #400040,
+  -2px  3px #400040, -1px -3px #400040, -1px  3px #400040,  0px -3px #400040,  0px  3px #400040,  1px -3px #400040,  1px  3px #400040,  2px -3px #400040,
+   2px  3px #400040,  3px -3px #400040,  3px -2px #400040,  3px -1px #400040,  3px  0px #400040,  3px  1px #400040,  3px  2px #400040,  3px  3px #400040;}
+::cue(.outline2blackberry)           {text-shadow:
+  -1px -1px #400040, -1px  0px #400040, -1px  1px #400040,  0px -1px #400040,  0px  1px #400040,  1px -1px #400040,  1px  0px #400040,  1px  1px #400040,
+  -2px -2px #400040, -2px -1px #400040, -2px  0px #400040, -2px  1px #400040, -2px  2px #400040, -1px -2px #400040, -1px  2px #400040,  0px -2px #400040,
+   0px  2px #400040,  1px -2px #400040,  1px  2px #400040,  2px -2px #400040,  2px -1px #400040,  2px  0px #400040,  2px  1px #400040,  2px  2px #400040;}
+::cue(.outline1blackberry)           {text-shadow:
+  -1px -1px #400040, -1px  0px #400040, -1px  1px #400040,  0px -1px #400040,  0px  1px #400040,  1px -1px #400040,  1px  0px #400040,  1px  1px #400040;}
+::cue(.outline3indigo)              {text-shadow:
+  -1px -1px #400080, -1px  0px #400080, -1px  1px #400080,  0px -1px #400080,  0px  1px #400080,  1px -1px #400080,  1px  0px #400080,  1px  1px #400080,
+  -2px -2px #400080, -2px -1px #400080, -2px  0px #400080, -2px  1px #400080, -2px  2px #400080, -1px -2px #400080, -1px  2px #400080,  0px -2px #400080,
+   0px  2px #400080,  1px -2px #400080,  1px  2px #400080,  2px -2px #400080,  2px -1px #400080,  2px  0px #400080,  2px  1px #400080,  2px  2px #400080,
+  -3px -3px #400080, -3px -2px #400080, -3px -1px #400080, -3px  0px #400080, -3px  1px #400080, -3px  2px #400080, -3px  3px #400080, -2px -3px #400080,
+  -2px  3px #400080, -1px -3px #400080, -1px  3px #400080,  0px -3px #400080,  0px  3px #400080,  1px -3px #400080,  1px  3px #400080,  2px -3px #400080,
+   2px  3px #400080,  3px -3px #400080,  3px -2px #400080,  3px -1px #400080,  3px  0px #400080,  3px  1px #400080,  3px  2px #400080,  3px  3px #400080;}
+::cue(.outline2indigo)              {text-shadow:
+  -1px -1px #400080, -1px  0px #400080, -1px  1px #400080,  0px -1px #400080,  0px  1px #400080,  1px -1px #400080,  1px  0px #400080,  1px  1px #400080,
+  -2px -2px #400080, -2px -1px #400080, -2px  0px #400080, -2px  1px #400080, -2px  2px #400080, -1px -2px #400080, -1px  2px #400080,  0px -2px #400080,
+   0px  2px #400080,  1px -2px #400080,  1px  2px #400080,  2px -2px #400080,  2px -1px #400080,  2px  0px #400080,  2px  1px #400080,  2px  2px #400080;}
+::cue(.outline1indigo)              {text-shadow:
+  -1px -1px #400080, -1px  0px #400080, -1px  1px #400080,  0px -1px #400080,  0px  1px #400080,  1px -1px #400080,  1px  0px #400080,  1px  1px #400080;}
+::cue(.outline3purpleblue)        {text-shadow:
+  -1px -1px #4000C0, -1px  0px #4000C0, -1px  1px #4000C0,  0px -1px #4000C0,  0px  1px #4000C0,  1px -1px #4000C0,  1px  0px #4000C0,  1px  1px #4000C0,
+  -2px -2px #4000C0, -2px -1px #4000C0, -2px  0px #4000C0, -2px  1px #4000C0, -2px  2px #4000C0, -1px -2px #4000C0, -1px  2px #4000C0,  0px -2px #4000C0,
+   0px  2px #4000C0,  1px -2px #4000C0,  1px  2px #4000C0,  2px -2px #4000C0,  2px -1px #4000C0,  2px  0px #4000C0,  2px  1px #4000C0,  2px  2px #4000C0,
+  -3px -3px #4000C0, -3px -2px #4000C0, -3px -1px #4000C0, -3px  0px #4000C0, -3px  1px #4000C0, -3px  2px #4000C0, -3px  3px #4000C0, -2px -3px #4000C0,
+  -2px  3px #4000C0, -1px -3px #4000C0, -1px  3px #4000C0,  0px -3px #4000C0,  0px  3px #4000C0,  1px -3px #4000C0,  1px  3px #4000C0,  2px -3px #4000C0,
+   2px  3px #4000C0,  3px -3px #4000C0,  3px -2px #4000C0,  3px -1px #4000C0,  3px  0px #4000C0,  3px  1px #4000C0,  3px  2px #4000C0,  3px  3px #4000C0;}
+::cue(.outline2purpleblue)        {text-shadow:
+  -1px -1px #4000C0, -1px  0px #4000C0, -1px  1px #4000C0,  0px -1px #4000C0,  0px  1px #4000C0,  1px -1px #4000C0,  1px  0px #4000C0,  1px  1px #4000C0,
+  -2px -2px #4000C0, -2px -1px #4000C0, -2px  0px #4000C0, -2px  1px #4000C0, -2px  2px #4000C0, -1px -2px #4000C0, -1px  2px #4000C0,  0px -2px #4000C0,
+   0px  2px #4000C0,  1px -2px #4000C0,  1px  2px #4000C0,  2px -2px #4000C0,  2px -1px #4000C0,  2px  0px #4000C0,  2px  1px #4000C0,  2px  2px #4000C0;}
+::cue(.outline1purpleblue)        {text-shadow:
+  -1px -1px #4000C0, -1px  0px #4000C0, -1px  1px #4000C0,  0px -1px #4000C0,  0px  1px #4000C0,  1px -1px #4000C0,  1px  0px #4000C0,  1px  1px #4000C0;}
+::cue(.outline3redblue)              {text-shadow:
+  -1px -1px #4000FF, -1px  0px #4000FF, -1px  1px #4000FF,  0px -1px #4000FF,  0px  1px #4000FF,  1px -1px #4000FF,  1px  0px #4000FF,  1px  1px #4000FF,
+  -2px -2px #4000FF, -2px -1px #4000FF, -2px  0px #4000FF, -2px  1px #4000FF, -2px  2px #4000FF, -1px -2px #4000FF, -1px  2px #4000FF,  0px -2px #4000FF,
+   0px  2px #4000FF,  1px -2px #4000FF,  1px  2px #4000FF,  2px -2px #4000FF,  2px -1px #4000FF,  2px  0px #4000FF,  2px  1px #4000FF,  2px  2px #4000FF,
+  -3px -3px #4000FF, -3px -2px #4000FF, -3px -1px #4000FF, -3px  0px #4000FF, -3px  1px #4000FF, -3px  2px #4000FF, -3px  3px #4000FF, -2px -3px #4000FF,
+  -2px  3px #4000FF, -1px -3px #4000FF, -1px  3px #4000FF,  0px -3px #4000FF,  0px  3px #4000FF,  1px -3px #4000FF,  1px  3px #4000FF,  2px -3px #4000FF,
+   2px  3px #4000FF,  3px -3px #4000FF,  3px -2px #4000FF,  3px -1px #4000FF,  3px  0px #4000FF,  3px  1px #4000FF,  3px  2px #4000FF,  3px  3px #4000FF;}
+::cue(.outline2redblue)              {text-shadow:
+  -1px -1px #4000FF, -1px  0px #4000FF, -1px  1px #4000FF,  0px -1px #4000FF,  0px  1px #4000FF,  1px -1px #4000FF,  1px  0px #4000FF,  1px  1px #4000FF,
+  -2px -2px #4000FF, -2px -1px #4000FF, -2px  0px #4000FF, -2px  1px #4000FF, -2px  2px #4000FF, -1px -2px #4000FF, -1px  2px #4000FF,  0px -2px #4000FF,
+   0px  2px #4000FF,  1px -2px #4000FF,  1px  2px #4000FF,  2px -2px #4000FF,  2px -1px #4000FF,  2px  0px #4000FF,  2px  1px #4000FF,  2px  2px #4000FF;}
+::cue(.outline1redblue)              {text-shadow:
+  -1px -1px #4000FF, -1px  0px #4000FF, -1px  1px #4000FF,  0px -1px #4000FF,  0px  1px #4000FF,  1px -1px #4000FF,  1px  0px #4000FF,  1px  1px #4000FF;}
+::cue(.outline3verdun)        {text-shadow:
+  -1px -1px #404000, -1px  0px #404000, -1px  1px #404000,  0px -1px #404000,  0px  1px #404000,  1px -1px #404000,  1px  0px #404000,  1px  1px #404000,
+  -2px -2px #404000, -2px -1px #404000, -2px  0px #404000, -2px  1px #404000, -2px  2px #404000, -1px -2px #404000, -1px  2px #404000,  0px -2px #404000,
+   0px  2px #404000,  1px -2px #404000,  1px  2px #404000,  2px -2px #404000,  2px -1px #404000,  2px  0px #404000,  2px  1px #404000,  2px  2px #404000,
+  -3px -3px #404000, -3px -2px #404000, -3px -1px #404000, -3px  0px #404000, -3px  1px #404000, -3px  2px #404000, -3px  3px #404000, -2px -3px #404000,
+  -2px  3px #404000, -1px -3px #404000, -1px  3px #404000,  0px -3px #404000,  0px  3px #404000,  1px -3px #404000,  1px  3px #404000,  2px -3px #404000,
+   2px  3px #404000,  3px -3px #404000,  3px -2px #404000,  3px -1px #404000,  3px  0px #404000,  3px  1px #404000,  3px  2px #404000,  3px  3px #404000;}
+::cue(.outline2verdun)        {text-shadow:
+  -1px -1px #404000, -1px  0px #404000, -1px  1px #404000,  0px -1px #404000,  0px  1px #404000,  1px -1px #404000,  1px  0px #404000,  1px  1px #404000,
+  -2px -2px #404000, -2px -1px #404000, -2px  0px #404000, -2px  1px #404000, -2px  2px #404000, -1px -2px #404000, -1px  2px #404000,  0px -2px #404000,
+   0px  2px #404000,  1px -2px #404000,  1px  2px #404000,  2px -2px #404000,  2px -1px #404000,  2px  0px #404000,  2px  1px #404000,  2px  2px #404000;}
+::cue(.outline1verdun)        {text-shadow:
+  -1px -1px #404000, -1px  0px #404000, -1px  1px #404000,  0px -1px #404000,  0px  1px #404000,  1px -1px #404000,  1px  0px #404000,  1px  1px #404000;}
+::cue(.outline3tundora)        {text-shadow:
+  -1px -1px #404040, -1px  0px #404040, -1px  1px #404040,  0px -1px #404040,  0px  1px #404040,  1px -1px #404040,  1px  0px #404040,  1px  1px #404040,
+  -2px -2px #404040, -2px -1px #404040, -2px  0px #404040, -2px  1px #404040, -2px  2px #404040, -1px -2px #404040, -1px  2px #404040,  0px -2px #404040,
+   0px  2px #404040,  1px -2px #404040,  1px  2px #404040,  2px -2px #404040,  2px -1px #404040,  2px  0px #404040,  2px  1px #404040,  2px  2px #404040,
+  -3px -3px #404040, -3px -2px #404040, -3px -1px #404040, -3px  0px #404040, -3px  1px #404040, -3px  2px #404040, -3px  3px #404040, -2px -3px #404040,
+  -2px  3px #404040, -1px -3px #404040, -1px  3px #404040,  0px -3px #404040,  0px  3px #404040,  1px -3px #404040,  1px  3px #404040,  2px -3px #404040,
+   2px  3px #404040,  3px -3px #404040,  3px -2px #404040,  3px -1px #404040,  3px  0px #404040,  3px  1px #404040,  3px  2px #404040,  3px  3px #404040;}
+::cue(.outline2tundora)        {text-shadow:
+  -1px -1px #404040, -1px  0px #404040, -1px  1px #404040,  0px -1px #404040,  0px  1px #404040,  1px -1px #404040,  1px  0px #404040,  1px  1px #404040,
+  -2px -2px #404040, -2px -1px #404040, -2px  0px #404040, -2px  1px #404040, -2px  2px #404040, -1px -2px #404040, -1px  2px #404040,  0px -2px #404040,
+   0px  2px #404040,  1px -2px #404040,  1px  2px #404040,  2px -2px #404040,  2px -1px #404040,  2px  0px #404040,  2px  1px #404040,  2px  2px #404040;}
+::cue(.outline1tundora)        {text-shadow:
+  -1px -1px #404040, -1px  0px #404040, -1px  1px #404040,  0px -1px #404040,  0px  1px #404040,  1px -1px #404040,  1px  0px #404040,  1px  1px #404040;}
+::cue(.outline3eastbay)        {text-shadow:
+  -1px -1px #404080, -1px  0px #404080, -1px  1px #404080,  0px -1px #404080,  0px  1px #404080,  1px -1px #404080,  1px  0px #404080,  1px  1px #404080,
+  -2px -2px #404080, -2px -1px #404080, -2px  0px #404080, -2px  1px #404080, -2px  2px #404080, -1px -2px #404080, -1px  2px #404080,  0px -2px #404080,
+   0px  2px #404080,  1px -2px #404080,  1px  2px #404080,  2px -2px #404080,  2px -1px #404080,  2px  0px #404080,  2px  1px #404080,  2px  2px #404080,
+  -3px -3px #404080, -3px -2px #404080, -3px -1px #404080, -3px  0px #404080, -3px  1px #404080, -3px  2px #404080, -3px  3px #404080, -2px -3px #404080,
+  -2px  3px #404080, -1px -3px #404080, -1px  3px #404080,  0px -3px #404080,  0px  3px #404080,  1px -3px #404080,  1px  3px #404080,  2px -3px #404080,
+   2px  3px #404080,  3px -3px #404080,  3px -2px #404080,  3px -1px #404080,  3px  0px #404080,  3px  1px #404080,  3px  2px #404080,  3px  3px #404080;}
+::cue(.outline2eastbay)        {text-shadow:
+  -1px -1px #404080, -1px  0px #404080, -1px  1px #404080,  0px -1px #404080,  0px  1px #404080,  1px -1px #404080,  1px  0px #404080,  1px  1px #404080,
+  -2px -2px #404080, -2px -1px #404080, -2px  0px #404080, -2px  1px #404080, -2px  2px #404080, -1px -2px #404080, -1px  2px #404080,  0px -2px #404080,
+   0px  2px #404080,  1px -2px #404080,  1px  2px #404080,  2px -2px #404080,  2px -1px #404080,  2px  0px #404080,  2px  1px #404080,  2px  2px #404080;}
+::cue(.outline1eastbay)        {text-shadow:
+  -1px -1px #404080, -1px  0px #404080, -1px  1px #404080,  0px -1px #404080,  0px  1px #404080,  1px -1px #404080,  1px  0px #404080,  1px  1px #404080;}
+::cue(.outline3governor)        {text-shadow:
+  -1px -1px #4040C0, -1px  0px #4040C0, -1px  1px #4040C0,  0px -1px #4040C0,  0px  1px #4040C0,  1px -1px #4040C0,  1px  0px #4040C0,  1px  1px #4040C0,
+  -2px -2px #4040C0, -2px -1px #4040C0, -2px  0px #4040C0, -2px  1px #4040C0, -2px  2px #4040C0, -1px -2px #4040C0, -1px  2px #4040C0,  0px -2px #4040C0,
+   0px  2px #4040C0,  1px -2px #4040C0,  1px  2px #4040C0,  2px -2px #4040C0,  2px -1px #4040C0,  2px  0px #4040C0,  2px  1px #4040C0,  2px  2px #4040C0,
+  -3px -3px #4040C0, -3px -2px #4040C0, -3px -1px #4040C0, -3px  0px #4040C0, -3px  1px #4040C0, -3px  2px #4040C0, -3px  3px #4040C0, -2px -3px #4040C0,
+  -2px  3px #4040C0, -1px -3px #4040C0, -1px  3px #4040C0,  0px -3px #4040C0,  0px  3px #4040C0,  1px -3px #4040C0,  1px  3px #4040C0,  2px -3px #4040C0,
+   2px  3px #4040C0,  3px -3px #4040C0,  3px -2px #4040C0,  3px -1px #4040C0,  3px  0px #4040C0,  3px  1px #4040C0,  3px  2px #4040C0,  3px  3px #4040C0;}
+::cue(.outline2governor)        {text-shadow:
+  -1px -1px #4040C0, -1px  0px #4040C0, -1px  1px #4040C0,  0px -1px #4040C0,  0px  1px #4040C0,  1px -1px #4040C0,  1px  0px #4040C0,  1px  1px #4040C0,
+  -2px -2px #4040C0, -2px -1px #4040C0, -2px  0px #4040C0, -2px  1px #4040C0, -2px  2px #4040C0, -1px -2px #4040C0, -1px  2px #4040C0,  0px -2px #4040C0,
+   0px  2px #4040C0,  1px -2px #4040C0,  1px  2px #4040C0,  2px -2px #4040C0,  2px -1px #4040C0,  2px  0px #4040C0,  2px  1px #4040C0,  2px  2px #4040C0;}
+::cue(.outline1governor)        {text-shadow:
+  -1px -1px #4040C0, -1px  0px #4040C0, -1px  1px #4040C0,  0px -1px #4040C0,  0px  1px #4040C0,  1px -1px #4040C0,  1px  0px #4040C0,  1px  1px #4040C0;}
+::cue(.outline3royalblue)        {text-shadow:
+  -1px -1px #4040FF, -1px  0px #4040FF, -1px  1px #4040FF,  0px -1px #4040FF,  0px  1px #4040FF,  1px -1px #4040FF,  1px  0px #4040FF,  1px  1px #4040FF,
+  -2px -2px #4040FF, -2px -1px #4040FF, -2px  0px #4040FF, -2px  1px #4040FF, -2px  2px #4040FF, -1px -2px #4040FF, -1px  2px #4040FF,  0px -2px #4040FF,
+   0px  2px #4040FF,  1px -2px #4040FF,  1px  2px #4040FF,  2px -2px #4040FF,  2px -1px #4040FF,  2px  0px #4040FF,  2px  1px #4040FF,  2px  2px #4040FF,
+  -3px -3px #4040FF, -3px -2px #4040FF, -3px -1px #4040FF, -3px  0px #4040FF, -3px  1px #4040FF, -3px  2px #4040FF, -3px  3px #4040FF, -2px -3px #4040FF,
+  -2px  3px #4040FF, -1px -3px #4040FF, -1px  3px #4040FF,  0px -3px #4040FF,  0px  3px #4040FF,  1px -3px #4040FF,  1px  3px #4040FF,  2px -3px #4040FF,
+   2px  3px #4040FF,  3px -3px #4040FF,  3px -2px #4040FF,  3px -1px #4040FF,  3px  0px #4040FF,  3px  1px #4040FF,  3px  2px #4040FF,  3px  3px #4040FF;}
+::cue(.outline2royalblue)        {text-shadow:
+  -1px -1px #4040FF, -1px  0px #4040FF, -1px  1px #4040FF,  0px -1px #4040FF,  0px  1px #4040FF,  1px -1px #4040FF,  1px  0px #4040FF,  1px  1px #4040FF,
+  -2px -2px #4040FF, -2px -1px #4040FF, -2px  0px #4040FF, -2px  1px #4040FF, -2px  2px #4040FF, -1px -2px #4040FF, -1px  2px #4040FF,  0px -2px #4040FF,
+   0px  2px #4040FF,  1px -2px #4040FF,  1px  2px #4040FF,  2px -2px #4040FF,  2px -1px #4040FF,  2px  0px #4040FF,  2px  1px #4040FF,  2px  2px #4040FF;}
+::cue(.outline1royalblue)        {text-shadow:
+  -1px -1px #4040FF, -1px  0px #4040FF, -1px  1px #4040FF,  0px -1px #4040FF,  0px  1px #4040FF,  1px -1px #4040FF,  1px  0px #4040FF,  1px  1px #4040FF;}
+::cue(.outline3limeade)        {text-shadow:
+  -1px -1px #408000, -1px  0px #408000, -1px  1px #408000,  0px -1px #408000,  0px  1px #408000,  1px -1px #408000,  1px  0px #408000,  1px  1px #408000,
+  -2px -2px #408000, -2px -1px #408000, -2px  0px #408000, -2px  1px #408000, -2px  2px #408000, -1px -2px #408000, -1px  2px #408000,  0px -2px #408000,
+   0px  2px #408000,  1px -2px #408000,  1px  2px #408000,  2px -2px #408000,  2px -1px #408000,  2px  0px #408000,  2px  1px #408000,  2px  2px #408000,
+  -3px -3px #408000, -3px -2px #408000, -3px -1px #408000, -3px  0px #408000, -3px  1px #408000, -3px  2px #408000, -3px  3px #408000, -2px -3px #408000,
+  -2px  3px #408000, -1px -3px #408000, -1px  3px #408000,  0px -3px #408000,  0px  3px #408000,  1px -3px #408000,  1px  3px #408000,  2px -3px #408000,
+   2px  3px #408000,  3px -3px #408000,  3px -2px #408000,  3px -1px #408000,  3px  0px #408000,  3px  1px #408000,  3px  2px #408000,  3px  3px #408000;}
+::cue(.outline2limeade)        {text-shadow:
+  -1px -1px #408000, -1px  0px #408000, -1px  1px #408000,  0px -1px #408000,  0px  1px #408000,  1px -1px #408000,  1px  0px #408000,  1px  1px #408000,
+  -2px -2px #408000, -2px -1px #408000, -2px  0px #408000, -2px  1px #408000, -2px  2px #408000, -1px -2px #408000, -1px  2px #408000,  0px -2px #408000,
+   0px  2px #408000,  1px -2px #408000,  1px  2px #408000,  2px -2px #408000,  2px -1px #408000,  2px  0px #408000,  2px  1px #408000,  2px  2px #408000;}
+::cue(.outline1limeade)        {text-shadow:
+  -1px -1px #408000, -1px  0px #408000, -1px  1px #408000,  0px -1px #408000,  0px  1px #408000,  1px -1px #408000,  1px  0px #408000,  1px  1px #408000;}
+::cue(.outline3goblin)        {text-shadow:
+  -1px -1px #408040, -1px  0px #408040, -1px  1px #408040,  0px -1px #408040,  0px  1px #408040,  1px -1px #408040,  1px  0px #408040,  1px  1px #408040,
+  -2px -2px #408040, -2px -1px #408040, -2px  0px #408040, -2px  1px #408040, -2px  2px #408040, -1px -2px #408040, -1px  2px #408040,  0px -2px #408040,
+   0px  2px #408040,  1px -2px #408040,  1px  2px #408040,  2px -2px #408040,  2px -1px #408040,  2px  0px #408040,  2px  1px #408040,  2px  2px #408040,
+  -3px -3px #408040, -3px -2px #408040, -3px -1px #408040, -3px  0px #408040, -3px  1px #408040, -3px  2px #408040, -3px  3px #408040, -2px -3px #408040,
+  -2px  3px #408040, -1px -3px #408040, -1px  3px #408040,  0px -3px #408040,  0px  3px #408040,  1px -3px #408040,  1px  3px #408040,  2px -3px #408040,
+   2px  3px #408040,  3px -3px #408040,  3px -2px #408040,  3px -1px #408040,  3px  0px #408040,  3px  1px #408040,  3px  2px #408040,  3px  3px #408040;}
+::cue(.outline2goblin)        {text-shadow:
+  -1px -1px #408040, -1px  0px #408040, -1px  1px #408040,  0px -1px #408040,  0px  1px #408040,  1px -1px #408040,  1px  0px #408040,  1px  1px #408040,
+  -2px -2px #408040, -2px -1px #408040, -2px  0px #408040, -2px  1px #408040, -2px  2px #408040, -1px -2px #408040, -1px  2px #408040,  0px -2px #408040,
+   0px  2px #408040,  1px -2px #408040,  1px  2px #408040,  2px -2px #408040,  2px -1px #408040,  2px  0px #408040,  2px  1px #408040,  2px  2px #408040;}
+::cue(.outline1goblin)        {text-shadow:
+  -1px -1px #408080, -1px  0px #408080, -1px  1px #408080,  0px -1px #408080,  0px  1px #408080,  1px -1px #408080,  1px  0px #408080,  1px  1px #408080;}
+::cue(.outline3fadedjade)        {text-shadow:
+  -1px -1px #408080, -1px  0px #408080, -1px  1px #408080,  0px -1px #408080,  0px  1px #408080,  1px -1px #408080,  1px  0px #408080,  1px  1px #408080,
+  -2px -2px #408080, -2px -1px #408080, -2px  0px #408080, -2px  1px #408080, -2px  2px #408080, -1px -2px #408080, -1px  2px #408080,  0px -2px #408080,
+   0px  2px #408080,  1px -2px #408080,  1px  2px #408080,  2px -2px #408080,  2px -1px #408080,  2px  0px #408080,  2px  1px #408080,  2px  2px #408080,
+  -3px -3px #408080, -3px -2px #408080, -3px -1px #408080, -3px  0px #408080, -3px  1px #408080, -3px  2px #408080, -3px  3px #408080, -2px -3px #408080,
+  -2px  3px #408080, -1px -3px #408080, -1px  3px #408080,  0px -3px #408080,  0px  3px #408080,  1px -3px #408080,  1px  3px #408080,  2px -3px #408080,
+   2px  3px #408080,  3px -3px #408080,  3px -2px #408080,  3px -1px #408080,  3px  0px #408080,  3px  1px #408080,  3px  2px #408080,  3px  3px #408080;}
+::cue(.outline2fadedjade)        {text-shadow:
+  -1px -1px #408080, -1px  0px #408080, -1px  1px #408080,  0px -1px #408080,  0px  1px #408080,  1px -1px #408080,  1px  0px #408080,  1px  1px #408080,
+  -2px -2px #408080, -2px -1px #408080, -2px  0px #408080, -2px  1px #408080, -2px  2px #408080, -1px -2px #408080, -1px  2px #408080,  0px -2px #408080,
+   0px  2px #408080,  1px -2px #408080,  1px  2px #408080,  2px -2px #408080,  2px -1px #408080,  2px  0px #408080,  2px  1px #408080,  2px  2px #408080;}
+::cue(.outline1fadedjade)        {text-shadow:
+  -1px -1px #408080, -1px  0px #408080, -1px  1px #408080,  0px -1px #408080,  0px  1px #408080,  1px -1px #408080,  1px  0px #408080,  1px  1px #408080;}
+::cue(.outline3steelblue)        {text-shadow:
+  -1px -1px #4080C0, -1px  0px #4080C0, -1px  1px #4080C0,  0px -1px #4080C0,  0px  1px #4080C0,  1px -1px #4080C0,  1px  0px #4080C0,  1px  1px #4080C0,
+  -2px -2px #4080C0, -2px -1px #4080C0, -2px  0px #4080C0, -2px  1px #4080C0, -2px  2px #4080C0, -1px -2px #4080C0, -1px  2px #4080C0,  0px -2px #4080C0,
+   0px  2px #4080C0,  1px -2px #4080C0,  1px  2px #4080C0,  2px -2px #4080C0,  2px -1px #4080C0,  2px  0px #4080C0,  2px  1px #4080C0,  2px  2px #4080C0,
+  -3px -3px #4080C0, -3px -2px #4080C0, -3px -1px #4080C0, -3px  0px #4080C0, -3px  1px #4080C0, -3px  2px #4080C0, -3px  3px #4080C0, -2px -3px #4080C0,
+  -2px  3px #4080C0, -1px -3px #4080C0, -1px  3px #4080C0,  0px -3px #4080C0,  0px  3px #4080C0,  1px -3px #4080C0,  1px  3px #4080C0,  2px -3px #4080C0,
+   2px  3px #4080C0,  3px -3px #4080C0,  3px -2px #4080C0,  3px -1px #4080C0,  3px  0px #4080C0,  3px  1px #4080C0,  3px  2px #4080C0,  3px  3px #4080C0;}
+::cue(.outline2steelblue)        {text-shadow:
+  -1px -1px #4080C0, -1px  0px #4080C0, -1px  1px #4080C0,  0px -1px #4080C0,  0px  1px #4080C0,  1px -1px #4080C0,  1px  0px #4080C0,  1px  1px #4080C0,
+  -2px -2px #4080C0, -2px -1px #4080C0, -2px  0px #4080C0, -2px  1px #4080C0, -2px  2px #4080C0, -1px -2px #4080C0, -1px  2px #4080C0,  0px -2px #4080C0,
+   0px  2px #4080C0,  1px -2px #4080C0,  1px  2px #4080C0,  2px -2px #4080C0,  2px -1px #4080C0,  2px  0px #4080C0,  2px  1px #4080C0,  2px  2px #4080C0;}
+::cue(.outline1steelblue)        {text-shadow:
+  -1px -1px #4080C0, -1px  0px #4080C0, -1px  1px #4080C0,  0px -1px #4080C0,  0px  1px #4080C0,  1px -1px #4080C0,  1px  0px #4080C0,  1px  1px #4080C0;}
+::cue(.outline3dodger)        {text-shadow:
+  -1px -1px #4080FF, -1px  0px #4080FF, -1px  1px #4080FF,  0px -1px #4080FF,  0px  1px #4080FF,  1px -1px #4080FF,  1px  0px #4080FF,  1px  1px #4080FF,
+  -2px -2px #4080FF, -2px -1px #4080FF, -2px  0px #4080FF, -2px  1px #4080FF, -2px  2px #4080FF, -1px -2px #4080FF, -1px  2px #4080FF,  0px -2px #4080FF,
+   0px  2px #4080FF,  1px -2px #4080FF,  1px  2px #4080FF,  2px -2px #4080FF,  2px -1px #4080FF,  2px  0px #4080FF,  2px  1px #4080FF,  2px  2px #4080FF,
+  -3px -3px #4080FF, -3px -2px #4080FF, -3px -1px #4080FF, -3px  0px #4080FF, -3px  1px #4080FF, -3px  2px #4080FF, -3px  3px #4080FF, -2px -3px #4080FF,
+  -2px  3px #4080FF, -1px -3px #4080FF, -1px  3px #4080FF,  0px -3px #4080FF,  0px  3px #4080FF,  1px -3px #4080FF,  1px  3px #4080FF,  2px -3px #4080FF,
+   2px  3px #4080FF,  3px -3px #4080FF,  3px -2px #4080FF,  3px -1px #4080FF,  3px  0px #4080FF,  3px  1px #4080FF,  3px  2px #4080FF,  3px  3px #4080FF;}
+::cue(.outline2dodger)        {text-shadow:
+  -1px -1px #4080FF, -1px  0px #4080FF, -1px  1px #4080FF,  0px -1px #4080FF,  0px  1px #4080FF,  1px -1px #4080FF,  1px  0px #4080FF,  1px  1px #4080FF,
+  -2px -2px #4080FF, -2px -1px #4080FF, -2px  0px #4080FF, -2px  1px #4080FF, -2px  2px #4080FF, -1px -2px #4080FF, -1px  2px #4080FF,  0px -2px #4080FF,
+   0px  2px #4080FF,  1px -2px #4080FF,  1px  2px #4080FF,  2px -2px #4080FF,  2px -1px #4080FF,  2px  0px #4080FF,  2px  1px #4080FF,  2px  2px #4080FF;}
+::cue(.outline1dodger)        {text-shadow:
+  -1px -1px #4080FF, -1px  0px #4080FF, -1px  1px #4080FF,  0px -1px #4080FF,  0px  1px #4080FF,  1px -1px #4080FF,  1px  0px #4080FF,  1px  1px #4080FF;}
+::cue(.outline3harlequin)        {text-shadow:
+  -1px -1px #40C000, -1px  0px #40C000, -1px  1px #40C000,  0px -1px #40C000,  0px  1px #40C000,  1px -1px #40C000,  1px  0px #40C000,  1px  1px #40C000,
+  -2px -2px #40C000, -2px -1px #40C000, -2px  0px #40C000, -2px  1px #40C000, -2px  2px #40C000, -1px -2px #40C000, -1px  2px #40C000,  0px -2px #40C000,
+   0px  2px #40C000,  1px -2px #40C000,  1px  2px #40C000,  2px -2px #40C000,  2px -1px #40C000,  2px  0px #40C000,  2px  1px #40C000,  2px  2px #40C000,
+  -3px -3px #40C000, -3px -2px #40C000, -3px -1px #40C000, -3px  0px #40C000, -3px  1px #40C000, -3px  2px #40C000, -3px  3px #40C000, -2px -3px #40C000,
+  -2px  3px #40C000, -1px -3px #40C000, -1px  3px #40C000,  0px -3px #40C000,  0px  3px #40C000,  1px -3px #40C000,  1px  3px #40C000,  2px -3px #40C000,
+   2px  3px #40C000,  3px -3px #40C000,  3px -2px #40C000,  3px -1px #40C000,  3px  0px #40C000,  3px  1px #40C000,  3px  2px #40C000,  3px  3px #40C000;}
+::cue(.outline2harlequin)        {text-shadow:
+  -1px -1px #40C000, -1px  0px #40C000, -1px  1px #40C000,  0px -1px #40C000,  0px  1px #40C000,  1px -1px #40C000,  1px  0px #40C000,  1px  1px #40C000,
+  -2px -2px #40C000, -2px -1px #40C000, -2px  0px #40C000, -2px  1px #40C000, -2px  2px #40C000, -1px -2px #40C000, -1px  2px #40C000,  0px -2px #40C000,
+   0px  2px #40C000,  1px -2px #40C000,  1px  2px #40C000,  2px -2px #40C000,  2px -1px #40C000,  2px  0px #40C000,  2px  1px #40C000,  2px  2px #40C000;}
+::cue(.outline1harlequin)        {text-shadow:
+  -1px -1px #40C000, -1px  0px #40C000, -1px  1px #40C000,  0px -1px #40C000,  0px  1px #40C000,  1px -1px #40C000,  1px  0px #40C000,  1px  1px #40C000;}
+::cue(.outline3emerald)        {text-shadow:
+  -1px -1px #40C040, -1px  0px #40C040, -1px  1px #40C040,  0px -1px #40C040,  0px  1px #40C040,  1px -1px #40C040,  1px  0px #40C040,  1px  1px #40C040,
+  -2px -2px #40C040, -2px -1px #40C040, -2px  0px #40C040, -2px  1px #40C040, -2px  2px #40C040, -1px -2px #40C040, -1px  2px #40C040,  0px -2px #40C040,
+   0px  2px #40C040,  1px -2px #40C040,  1px  2px #40C040,  2px -2px #40C040,  2px -1px #40C040,  2px  0px #40C040,  2px  1px #40C040,  2px  2px #40C040,
+  -3px -3px #40C040, -3px -2px #40C040, -3px -1px #40C040, -3px  0px #40C040, -3px  1px #40C040, -3px  2px #40C040, -3px  3px #40C040, -2px -3px #40C040,
+  -2px  3px #40C040, -1px -3px #40C040, -1px  3px #40C040,  0px -3px #40C040,  0px  3px #40C040,  1px -3px #40C040,  1px  3px #40C040,  2px -3px #40C040,
+   2px  3px #40C040,  3px -3px #40C040,  3px -2px #40C040,  3px -1px #40C040,  3px  0px #40C040,  3px  1px #40C040,  3px  2px #40C040,  3px  3px #40C040;}
+::cue(.outline2emerald)        {text-shadow:
+  -1px -1px #40C040, -1px  0px #40C040, -1px  1px #40C040,  0px -1px #40C040,  0px  1px #40C040,  1px -1px #40C040,  1px  0px #40C040,  1px  1px #40C040,
+  -2px -2px #40C040, -2px -1px #40C040, -2px  0px #40C040, -2px  1px #40C040, -2px  2px #40C040, -1px -2px #40C040, -1px  2px #40C040,  0px -2px #40C040,
+   0px  2px #40C040,  1px -2px #40C040,  1px  2px #40C040,  2px -2px #40C040,  2px -1px #40C040,  2px  0px #40C040,  2px  1px #40C040,  2px  2px #40C040;}
+::cue(.outline1emerald)        {text-shadow:
+  -1px -1px #40C040, -1px  0px #40C040, -1px  1px #40C040,  0px -1px #40C040,  0px  1px #40C040,  1px -1px #40C040,  1px  0px #40C040,  1px  1px #40C040;}
+::cue(.outline3shamrock)        {text-shadow:
+  -1px -1px #40C080, -1px  0px #40C080, -1px  1px #40C080,  0px -1px #40C080,  0px  1px #40C080,  1px -1px #40C080,  1px  0px #40C080,  1px  1px #40C080,
+  -2px -2px #40C080, -2px -1px #40C080, -2px  0px #40C080, -2px  1px #40C080, -2px  2px #40C080, -1px -2px #40C080, -1px  2px #40C080,  0px -2px #40C080,
+   0px  2px #40C080,  1px -2px #40C080,  1px  2px #40C080,  2px -2px #40C080,  2px -1px #40C080,  2px  0px #40C080,  2px  1px #40C080,  2px  2px #40C080,
+  -3px -3px #40C080, -3px -2px #40C080, -3px -1px #40C080, -3px  0px #40C080, -3px  1px #40C080, -3px  2px #40C080, -3px  3px #40C080, -2px -3px #40C080,
+  -2px  3px #40C080, -1px -3px #40C080, -1px  3px #40C080,  0px -3px #40C080,  0px  3px #40C080,  1px -3px #40C080,  1px  3px #40C080,  2px -3px #40C080,
+   2px  3px #40C080,  3px -3px #40C080,  3px -2px #40C080,  3px -1px #40C080,  3px  0px #40C080,  3px  1px #40C080,  3px  2px #40C080,  3px  3px #40C080;}
+::cue(.outline2shamrock)        {text-shadow:
+  -1px -1px #40C080, -1px  0px #40C080, -1px  1px #40C080,  0px -1px #40C080,  0px  1px #40C080,  1px -1px #40C080,  1px  0px #40C080,  1px  1px #40C080,
+  -2px -2px #40C080, -2px -1px #40C080, -2px  0px #40C080, -2px  1px #40C080, -2px  2px #40C080, -1px -2px #40C080, -1px  2px #40C080,  0px -2px #40C080,
+   0px  2px #40C080,  1px -2px #40C080,  1px  2px #40C080,  2px -2px #40C080,  2px -1px #40C080,  2px  0px #40C080,  2px  1px #40C080,  2px  2px #40C080;}
+::cue(.outline1shamrock)        {text-shadow:
+  -1px -1px #40C080, -1px  0px #40C080, -1px  1px #40C080,  0px -1px #40C080,  0px  1px #40C080,  1px -1px #40C080,  1px  0px #40C080,  1px  1px #40C080;}
+::cue(.outline3pelorous)        {text-shadow:
+  -1px -1px #40C0C0, -1px  0px #40C0C0, -1px  1px #40C0C0,  0px -1px #40C0C0,  0px  1px #40C0C0,  1px -1px #40C0C0,  1px  0px #40C0C0,  1px  1px #40C0C0,
+  -2px -2px #40C0C0, -2px -1px #40C0C0, -2px  0px #40C0C0, -2px  1px #40C0C0, -2px  2px #40C0C0, -1px -2px #40C0C0, -1px  2px #40C0C0,  0px -2px #40C0C0,
+   0px  2px #40C0C0,  1px -2px #40C0C0,  1px  2px #40C0C0,  2px -2px #40C0C0,  2px -1px #40C0C0,  2px  0px #40C0C0,  2px  1px #40C0C0,  2px  2px #40C0C0,
+  -3px -3px #40C0C0, -3px -2px #40C0C0, -3px -1px #40C0C0, -3px  0px #40C0C0, -3px  1px #40C0C0, -3px  2px #40C0C0, -3px  3px #40C0C0, -2px -3px #40C0C0,
+  -2px  3px #40C0C0, -1px -3px #40C0C0, -1px  3px #40C0C0,  0px -3px #40C0C0,  0px  3px #40C0C0,  1px -3px #40C0C0,  1px  3px #40C0C0,  2px -3px #40C0C0,
+   2px  3px #40C0C0,  3px -3px #40C0C0,  3px -2px #40C0C0,  3px -1px #40C0C0,  3px  0px #40C0C0,  3px  1px #40C0C0,  3px  2px #40C0C0,  3px  3px #40C0C0;}
+::cue(.outline2pelorous)        {text-shadow:
+  -1px -1px #40C0C0, -1px  0px #40C0C0, -1px  1px #40C0C0,  0px -1px #40C0C0,  0px  1px #40C0C0,  1px -1px #40C0C0,  1px  0px #40C0C0,  1px  1px #40C0C0,
+  -2px -2px #40C0C0, -2px -1px #40C0C0, -2px  0px #40C0C0, -2px  1px #40C0C0, -2px  2px #40C0C0, -1px -2px #40C0C0, -1px  2px #40C0C0,  0px -2px #40C0C0,
+   0px  2px #40C0C0,  1px -2px #40C0C0,  1px  2px #40C0C0,  2px -2px #40C0C0,  2px -1px #40C0C0,  2px  0px #40C0C0,  2px  1px #40C0C0,  2px  2px #40C0C0;}
+::cue(.outline1pelorous)        {text-shadow:
+  -1px -1px #40C0C0, -1px  0px #40C0C0, -1px  1px #40C0C0,  0px -1px #40C0C0,  0px  1px #40C0C0,  1px -1px #40C0C0,  1px  0px #40C0C0,  1px  1px #40C0C0;}
+::cue(.outline3dodgerblue)        {text-shadow:
+  -1px -1px #40C0FF, -1px  0px #40C0FF, -1px  1px #40C0FF,  0px -1px #40C0FF,  0px  1px #40C0FF,  1px -1px #40C0FF,  1px  0px #40C0FF,  1px  1px #40C0FF,
+  -2px -2px #40C0FF, -2px -1px #40C0FF, -2px  0px #40C0FF, -2px  1px #40C0FF, -2px  2px #40C0FF, -1px -2px #40C0FF, -1px  2px #40C0FF,  0px -2px #40C0FF,
+   0px  2px #40C0FF,  1px -2px #40C0FF,  1px  2px #40C0FF,  2px -2px #40C0FF,  2px -1px #40C0FF,  2px  0px #40C0FF,  2px  1px #40C0FF,  2px  2px #40C0FF,
+  -3px -3px #40C0FF, -3px -2px #40C0FF, -3px -1px #40C0FF, -3px  0px #40C0FF, -3px  1px #40C0FF, -3px  2px #40C0FF, -3px  3px #40C0FF, -2px -3px #40C0FF,
+  -2px  3px #40C0FF, -1px -3px #40C0FF, -1px  3px #40C0FF,  0px -3px #40C0FF,  0px  3px #40C0FF,  1px -3px #40C0FF,  1px  3px #40C0FF,  2px -3px #40C0FF,
+   2px  3px #40C0FF,  3px -3px #40C0FF,  3px -2px #40C0FF,  3px -1px #40C0FF,  3px  0px #40C0FF,  3px  1px #40C0FF,  3px  2px #40C0FF,  3px  3px #40C0FF;}
+::cue(.outline2dodgerblue)        {text-shadow:
+  -1px -1px #40C0FF, -1px  0px #40C0FF, -1px  1px #40C0FF,  0px -1px #40C0FF,  0px  1px #40C0FF,  1px -1px #40C0FF,  1px  0px #40C0FF,  1px  1px #40C0FF,
+  -2px -2px #40C0FF, -2px -1px #40C0FF, -2px  0px #40C0FF, -2px  1px #40C0FF, -2px  2px #40C0FF, -1px -2px #40C0FF, -1px  2px #40C0FF,  0px -2px #40C0FF,
+   0px  2px #40C0FF,  1px -2px #40C0FF,  1px  2px #40C0FF,  2px -2px #40C0FF,  2px -1px #40C0FF,  2px  0px #40C0FF,  2px  1px #40C0FF,  2px  2px #40C0FF;}
+::cue(.outline1dodgerblue)        {text-shadow:
+  -1px -1px #40C0FF, -1px  0px #40C0FF, -1px  1px #40C0FF,  0px -1px #40C0FF,  0px  1px #40C0FF,  1px -1px #40C0FF,  1px  0px #40C0FF,  1px  1px #40C0FF;}
+::cue(.outline3brightgreen)        {text-shadow:
+  -1px -1px #40FF00, -1px  0px #40FF00, -1px  1px #40FF00,  0px -1px #40FF00,  0px  1px #40FF00,  1px -1px #40FF00,  1px  0px #40FF00,  1px  1px #40FF00,
+  -2px -2px #40FF00, -2px -1px #40FF00, -2px  0px #40FF00, -2px  1px #40FF00, -2px  2px #40FF00, -1px -2px #40FF00, -1px  2px #40FF00,  0px -2px #40FF00,
+   0px  2px #40FF00,  1px -2px #40FF00,  1px  2px #40FF00,  2px -2px #40FF00,  2px -1px #40FF00,  2px  0px #40FF00,  2px  1px #40FF00,  2px  2px #40FF00,
+  -3px -3px #40FF00, -3px -2px #40FF00, -3px -1px #40FF00, -3px  0px #40FF00, -3px  1px #40FF00, -3px  2px #40FF00, -3px  3px #40FF00, -2px -3px #40FF00,
+  -2px  3px #40FF00, -1px -3px #40FF00, -1px  3px #40FF00,  0px -3px #40FF00,  0px  3px #40FF00,  1px -3px #40FF00,  1px  3px #40FF00,  2px -3px #40FF00,
+   2px  3px #40FF00,  3px -3px #40FF00,  3px -2px #40FF00,  3px -1px #40FF00,  3px  0px #40FF00,  3px  1px #40FF00,  3px  2px #40FF00,  3px  3px #40FF00;}
+::cue(.outline2brightgreen)        {text-shadow:
+  -1px -1px #40FF00, -1px  0px #40FF00, -1px  1px #40FF00,  0px -1px #40FF00,  0px  1px #40FF00,  1px -1px #40FF00,  1px  0px #40FF00,  1px  1px #40FF00,
+  -2px -2px #40FF00, -2px -1px #40FF00, -2px  0px #40FF00, -2px  1px #40FF00, -2px  2px #40FF00, -1px -2px #40FF00, -1px  2px #40FF00,  0px -2px #40FF00,
+   0px  2px #40FF00,  1px -2px #40FF00,  1px  2px #40FF00,  2px -2px #40FF00,  2px -1px #40FF00,  2px  0px #40FF00,  2px  1px #40FF00,  2px  2px #40FF00;}
+::cue(.outline1brightgreen)        {text-shadow:
+  -1px -1px #40FF00, -1px  0px #40FF00, -1px  1px #40FF00,  0px -1px #40FF00,  0px  1px #40FF00,  1px -1px #40FF00,  1px  0px #40FF00,  1px  1px #40FF00;}
+::cue(.outline3pastelgreen)        {text-shadow:
+  -1px -1px #40FF40, -1px  0px #40FF40, -1px  1px #40FF40,  0px -1px #40FF40,  0px  1px #40FF40,  1px -1px #40FF40,  1px  0px #40FF40,  1px  1px #40FF40,
+  -2px -2px #40FF40, -2px -1px #40FF40, -2px  0px #40FF40, -2px  1px #40FF40, -2px  2px #40FF40, -1px -2px #40FF40, -1px  2px #40FF40,  0px -2px #40FF40,
+   0px  2px #40FF40,  1px -2px #40FF40,  1px  2px #40FF40,  2px -2px #40FF40,  2px -1px #40FF40,  2px  0px #40FF40,  2px  1px #40FF40,  2px  2px #40FF40,
+  -3px -3px #40FF40, -3px -2px #40FF40, -3px -1px #40FF40, -3px  0px #40FF40, -3px  1px #40FF40, -3px  2px #40FF40, -3px  3px #40FF40, -2px -3px #40FF40,
+  -2px  3px #40FF40, -1px -3px #40FF40, -1px  3px #40FF40,  0px -3px #40FF40,  0px  3px #40FF40,  1px -3px #40FF40,  1px  3px #40FF40,  2px -3px #40FF40,
+   2px  3px #40FF40,  3px -3px #40FF40,  3px -2px #40FF40,  3px -1px #40FF40,  3px  0px #40FF40,  3px  1px #40FF40,  3px  2px #40FF40,  3px  3px #40FF40;}
+::cue(.outline2pastelgreen)        {text-shadow:
+  -1px -1px #40FF40, -1px  0px #40FF40, -1px  1px #40FF40,  0px -1px #40FF40,  0px  1px #40FF40,  1px -1px #40FF40,  1px  0px #40FF40,  1px  1px #40FF40,
+  -2px -2px #40FF40, -2px -1px #40FF40, -2px  0px #40FF40, -2px  1px #40FF40, -2px  2px #40FF40, -1px -2px #40FF40, -1px  2px #40FF40,  0px -2px #40FF40,
+   0px  2px #40FF40,  1px -2px #40FF40,  1px  2px #40FF40,  2px -2px #40FF40,  2px -1px #40FF40,  2px  0px #40FF40,  2px  1px #40FF40,  2px  2px #40FF40;}
+::cue(.outline1pastelgreen)        {text-shadow:
+  -1px -1px #40FF40, -1px  0px #40FF40, -1px  1px #40FF40,  0px -1px #40FF40,  0px  1px #40FF40,  1px -1px #40FF40,  1px  0px #40FF40,  1px  1px #40FF40;}
+::cue(.outline3screaminggreen)        {text-shadow:
+  -1px -1px #40FF80, -1px  0px #40FF80, -1px  1px #40FF80,  0px -1px #40FF80,  0px  1px #40FF80,  1px -1px #40FF80,  1px  0px #40FF80,  1px  1px #40FF80,
+  -2px -2px #40FF80, -2px -1px #40FF80, -2px  0px #40FF80, -2px  1px #40FF80, -2px  2px #40FF80, -1px -2px #40FF80, -1px  2px #40FF80,  0px -2px #40FF80,
+   0px  2px #40FF80,  1px -2px #40FF80,  1px  2px #40FF80,  2px -2px #40FF80,  2px -1px #40FF80,  2px  0px #40FF80,  2px  1px #40FF80,  2px  2px #40FF80,
+  -3px -3px #40FF80, -3px -2px #40FF80, -3px -1px #40FF80, -3px  0px #40FF80, -3px  1px #40FF80, -3px  2px #40FF80, -3px  3px #40FF80, -2px -3px #40FF80,
+  -2px  3px #40FF80, -1px -3px #40FF80, -1px  3px #40FF80,  0px -3px #40FF80,  0px  3px #40FF80,  1px -3px #40FF80,  1px  3px #40FF80,  2px -3px #40FF80,
+   2px  3px #40FF80,  3px -3px #40FF80,  3px -2px #40FF80,  3px -1px #40FF80,  3px  0px #40FF80,  3px  1px #40FF80,  3px  2px #40FF80,  3px  3px #40FF80;}
+::cue(.outline2screaminggreen)        {text-shadow:
+  -1px -1px #40FF80, -1px  0px #40FF80, -1px  1px #40FF80,  0px -1px #40FF80,  0px  1px #40FF80,  1px -1px #40FF80,  1px  0px #40FF80,  1px  1px #40FF80,
+  -2px -2px #40FF80, -2px -1px #40FF80, -2px  0px #40FF80, -2px  1px #40FF80, -2px  2px #40FF80, -1px -2px #40FF80, -1px  2px #40FF80,  0px -2px #40FF80,
+   0px  2px #40FF80,  1px -2px #40FF80,  1px  2px #40FF80,  2px -2px #40FF80,  2px -1px #40FF80,  2px  0px #40FF80,  2px  1px #40FF80,  2px  2px #40FF80;}
+::cue(.outline1screaminggreen)        {text-shadow:
+  -1px -1px #40FF80, -1px  0px #40FF80, -1px  1px #40FF80,  0px -1px #40FF80,  0px  1px #40FF80,  1px -1px #40FF80,  1px  0px #40FF80,  1px  1px #40FF80;}
+::cue(.outline3aquamarine)        {text-shadow:
+  -1px -1px #40FFC0, -1px  0px #40FFC0, -1px  1px #40FFC0,  0px -1px #40FFC0,  0px  1px #40FFC0,  1px -1px #40FFC0,  1px  0px #40FFC0,  1px  1px #40FFC0,
+  -2px -2px #40FFC0, -2px -1px #40FFC0, -2px  0px #40FFC0, -2px  1px #40FFC0, -2px  2px #40FFC0, -1px -2px #40FFC0, -1px  2px #40FFC0,  0px -2px #40FFC0,
+   0px  2px #40FFC0,  1px -2px #40FFC0,  1px  2px #40FFC0,  2px -2px #40FFC0,  2px -1px #40FFC0,  2px  0px #40FFC0,  2px  1px #40FFC0,  2px  2px #40FFC0,
+  -3px -3px #40FFC0, -3px -2px #40FFC0, -3px -1px #40FFC0, -3px  0px #40FFC0, -3px  1px #40FFC0, -3px  2px #40FFC0, -3px  3px #40FFC0, -2px -3px #40FFC0,
+  -2px  3px #40FFC0, -1px -3px #40FFC0, -1px  3px #40FFC0,  0px -3px #40FFC0,  0px  3px #40FFC0,  1px -3px #40FFC0,  1px  3px #40FFC0,  2px -3px #40FFC0,
+   2px  3px #40FFC0,  3px -3px #40FFC0,  3px -2px #40FFC0,  3px -1px #40FFC0,  3px  0px #40FFC0,  3px  1px #40FFC0,  3px  2px #40FFC0,  3px  3px #40FFC0;}
+::cue(.outline2aquamarine)        {text-shadow:
+  -1px -1px #40FFC0, -1px  0px #40FFC0, -1px  1px #40FFC0,  0px -1px #40FFC0,  0px  1px #40FFC0,  1px -1px #40FFC0,  1px  0px #40FFC0,  1px  1px #40FFC0,
+  -2px -2px #40FFC0, -2px -1px #40FFC0, -2px  0px #40FFC0, -2px  1px #40FFC0, -2px  2px #40FFC0, -1px -2px #40FFC0, -1px  2px #40FFC0,  0px -2px #40FFC0,
+   0px  2px #40FFC0,  1px -2px #40FFC0,  1px  2px #40FFC0,  2px -2px #40FFC0,  2px -1px #40FFC0,  2px  0px #40FFC0,  2px  1px #40FFC0,  2px  2px #40FFC0;}
+::cue(.outline1aquamarine)        {text-shadow:
+  -1px -1px #40FFC0, -1px  0px #40FFC0, -1px  1px #40FFC0,  0px -1px #40FFC0,  0px  1px #40FFC0,  1px -1px #40FFC0,  1px  0px #40FFC0,  1px  1px #40FFC0;}
+::cue(.outline3aqua)        {text-shadow:
+  -1px -1px #40FFFF, -1px  0px #40FFFF, -1px  1px #40FFFF,  0px -1px #40FFFF,  0px  1px #40FFFF,  1px -1px #40FFFF,  1px  0px #40FFFF,  1px  1px #40FFFF,
+  -2px -2px #40FFFF, -2px -1px #40FFFF, -2px  0px #40FFFF, -2px  1px #40FFFF, -2px  2px #40FFFF, -1px -2px #40FFFF, -1px  2px #40FFFF,  0px -2px #40FFFF,
+   0px  2px #40FFFF,  1px -2px #40FFFF,  1px  2px #40FFFF,  2px -2px #40FFFF,  2px -1px #40FFFF,  2px  0px #40FFFF,  2px  1px #40FFFF,  2px  2px #40FFFF,
+  -3px -3px #40FFFF, -3px -2px #40FFFF, -3px -1px #40FFFF, -3px  0px #40FFFF, -3px  1px #40FFFF, -3px  2px #40FFFF, -3px  3px #40FFFF, -2px -3px #40FFFF,
+  -2px  3px #40FFFF, -1px -3px #40FFFF, -1px  3px #40FFFF,  0px -3px #40FFFF,  0px  3px #40FFFF,  1px -3px #40FFFF,  1px  3px #40FFFF,  2px -3px #40FFFF,
+   2px  3px #40FFFF,  3px -3px #40FFFF,  3px -2px #40FFFF,  3px -1px #40FFFF,  3px  0px #40FFFF,  3px  1px #40FFFF,  3px  2px #40FFFF,  3px  3px #40FFFF;}
+::cue(.outline2aqua)        {text-shadow:
+  -1px -1px #40FFFF, -1px  0px #40FFFF, -1px  1px #40FFFF,  0px -1px #40FFFF,  0px  1px #40FFFF,  1px -1px #40FFFF,  1px  0px #40FFFF,  1px  1px #40FFFF,
+  -2px -2px #40FFFF, -2px -1px #40FFFF, -2px  0px #40FFFF, -2px  1px #40FFFF, -2px  2px #40FFFF, -1px -2px #40FFFF, -1px  2px #40FFFF,  0px -2px #40FFFF,
+   0px  2px #40FFFF,  1px -2px #40FFFF,  1px  2px #40FFFF,  2px -2px #40FFFF,  2px -1px #40FFFF,  2px  0px #40FFFF,  2px  1px #40FFFF,  2px  2px #40FFFF;}
+::cue(.outline1aqua)        {text-shadow:
+  -1px -1px #40FFFF, -1px  0px #40FFFF, -1px  1px #40FFFF,  0px -1px #40FFFF,  0px  1px #40FFFF,  1px -1px #40FFFF,  1px  0px #40FFFF,  1px  1px #40FFFF;}
+
+::cue(.outline3maroon)             {text-shadow:
+  -1px -1px #800000, -1px  0px #800000, -1px  1px #800000,  0px -1px #800000,  0px  1px #800000,  1px -1px #800000,  1px  0px #800000,  1px  1px #800000,
+  -2px -2px #800000, -2px -1px #800000, -2px  0px #800000, -2px  1px #800000, -2px  2px #800000, -1px -2px #800000, -1px  2px #800000,  0px -2px #800000,
+   0px  2px #800000,  1px -2px #800000,  1px  2px #800000,  2px -2px #800000,  2px -1px #800000,  2px  0px #800000,  2px  1px #800000,  2px  2px #800000,
+  -3px -3px #800000, -3px -2px #800000, -3px -1px #800000, -3px  0px #800000, -3px  1px #800000, -3px  2px #800000, -3px  3px #800000, -2px -3px #800000,
+  -2px  3px #800000, -1px -3px #800000, -1px  3px #800000,  0px -3px #800000,  0px  3px #800000,  1px -3px #800000,  1px  3px #800000,  2px -3px #800000,
+   2px  3px #800000,  3px -3px #800000,  3px -2px #800000,  3px -1px #800000,  3px  0px #800000,  3px  1px #800000,  3px  2px #800000,  3px  3px #800000;}
+::cue(.outline2maroon)             {text-shadow:
+  -1px -1px #800000, -1px  0px #800000, -1px  1px #800000,  0px -1px #800000,  0px  1px #800000,  1px -1px #800000,  1px  0px #800000,  1px  1px #800000,
+  -2px -2px #800000, -2px -1px #800000, -2px  0px #800000, -2px  1px #800000, -2px  2px #800000, -1px -2px #800000, -1px  2px #800000,  0px -2px #800000,
+   0px  2px #800000,  1px -2px #800000,  1px  2px #800000,  2px -2px #800000,  2px -1px #800000,  2px  0px #800000,  2px  1px #800000,  2px  2px #800000;}
+::cue(.outline1maroon)             {text-shadow:
+  -1px -1px #800000, -1px  0px #800000, -1px  1px #800000,  0px -1px #800000,  0px  1px #800000,  1px -1px #800000,  1px  0px #800000,  1px  1px #800000;}
+::cue(.outline3siren)           {text-shadow:
+  -1px -1px #800040, -1px  0px #800040, -1px  1px #800040,  0px -1px #800040,  0px  1px #800040,  1px -1px #800040,  1px  0px #800040,  1px  1px #800040,
+  -2px -2px #800040, -2px -1px #800040, -2px  0px #800040, -2px  1px #800040, -2px  2px #800040, -1px -2px #800040, -1px  2px #800040,  0px -2px #800040,
+   0px  2px #800040,  1px -2px #800040,  1px  2px #800040,  2px -2px #800040,  2px -1px #800040,  2px  0px #800040,  2px  1px #800040,  2px  2px #800040,
+  -3px -3px #800040, -3px -2px #800040, -3px -1px #800040, -3px  0px #800040, -3px  1px #800040, -3px  2px #800040, -3px  3px #800040, -2px -3px #800040,
+  -2px  3px #800040, -1px -3px #800040, -1px  3px #800040,  0px -3px #800040,  0px  3px #800040,  1px -3px #800040,  1px  3px #800040,  2px -3px #800040,
+   2px  3px #800040,  3px -3px #800040,  3px -2px #800040,  3px -1px #800040,  3px  0px #800040,  3px  1px #800040,  3px  2px #800040,  3px  3px #800040;}
+::cue(.outline2siren)           {text-shadow:
+  -1px -1px #800040, -1px  0px #800040, -1px  1px #800040,  0px -1px #800040,  0px  1px #800040,  1px -1px #800040,  1px  0px #800040,  1px  1px #800040,
+  -2px -2px #800040, -2px -1px #800040, -2px  0px #800040, -2px  1px #800040, -2px  2px #800040, -1px -2px #800040, -1px  2px #800040,  0px -2px #800040,
+   0px  2px #800040,  1px -2px #800040,  1px  2px #800040,  2px -2px #800040,  2px -1px #800040,  2px  0px #800040,  2px  1px #800040,  2px  2px #800040;}
+::cue(.outline1siren)           {text-shadow:
+  -1px -1px #800040, -1px  0px #800040, -1px  1px #800040,  0px -1px #800040,  0px  1px #800040,  1px -1px #800040,  1px  0px #800040,  1px  1px #800040;}
+::cue(.outline3eggplant)              {text-shadow:
+  -1px -1px #800080, -1px  0px #800080, -1px  1px #800080,  0px -1px #800080,  0px  1px #800080,  1px -1px #800080,  1px  0px #800080,  1px  1px #800080,
+  -2px -2px #800080, -2px -1px #800080, -2px  0px #800080, -2px  1px #800080, -2px  2px #800080, -1px -2px #800080, -1px  2px #800080,  0px -2px #800080,
+   0px  2px #800080,  1px -2px #800080,  1px  2px #800080,  2px -2px #800080,  2px -1px #800080,  2px  0px #800080,  2px  1px #800080,  2px  2px #800080,
+  -3px -3px #800080, -3px -2px #800080, -3px -1px #800080, -3px  0px #800080, -3px  1px #800080, -3px  2px #800080, -3px  3px #800080, -2px -3px #800080,
+  -2px  3px #800080, -1px -3px #800080, -1px  3px #800080,  0px -3px #800080,  0px  3px #800080,  1px -3px #800080,  1px  3px #800080,  2px -3px #800080,
+   2px  3px #800080,  3px -3px #800080,  3px -2px #800080,  3px -1px #800080,  3px  0px #800080,  3px  1px #800080,  3px  2px #800080,  3px  3px #800080;}
+::cue(.outline2eggplant)              {text-shadow:
+  -1px -1px #800080, -1px  0px #800080, -1px  1px #800080,  0px -1px #800080,  0px  1px #800080,  1px -1px #800080,  1px  0px #800080,  1px  1px #800080,
+  -2px -2px #800080, -2px -1px #800080, -2px  0px #800080, -2px  1px #800080, -2px  2px #800080, -1px -2px #800080, -1px  2px #800080,  0px -2px #800080,
+   0px  2px #800080,  1px -2px #800080,  1px  2px #800080,  2px -2px #800080,  2px -1px #800080,  2px  0px #800080,  2px  1px #800080,  2px  2px #800080;}
+::cue(.outline1eggplant)              {text-shadow:
+  -1px -1px #800080, -1px  0px #800080, -1px  1px #800080,  0px -1px #800080,  0px  1px #800080,  1px -1px #800080,  1px  0px #800080,  1px  1px #800080;}
+::cue(.outline3purple)        {text-shadow:
+  -1px -1px #8000C0, -1px  0px #8000C0, -1px  1px #8000C0,  0px -1px #8000C0,  0px  1px #8000C0,  1px -1px #8000C0,  1px  0px #8000C0,  1px  1px #8000C0,
+  -2px -2px #8000C0, -2px -1px #8000C0, -2px  0px #8000C0, -2px  1px #8000C0, -2px  2px #8000C0, -1px -2px #8000C0, -1px  2px #8000C0,  0px -2px #8000C0,
+   0px  2px #8000C0,  1px -2px #8000C0,  1px  2px #8000C0,  2px -2px #8000C0,  2px -1px #8000C0,  2px  0px #8000C0,  2px  1px #8000C0,  2px  2px #8000C0,
+  -3px -3px #8000C0, -3px -2px #8000C0, -3px -1px #8000C0, -3px  0px #8000C0, -3px  1px #8000C0, -3px  2px #8000C0, -3px  3px #8000C0, -2px -3px #8000C0,
+  -2px  3px #8000C0, -1px -3px #8000C0, -1px  3px #8000C0,  0px -3px #8000C0,  0px  3px #8000C0,  1px -3px #8000C0,  1px  3px #8000C0,  2px -3px #8000C0,
+   2px  3px #8000C0,  3px -3px #8000C0,  3px -2px #8000C0,  3px -1px #8000C0,  3px  0px #8000C0,  3px  1px #8000C0,  3px  2px #8000C0,  3px  3px #8000C0;}
+::cue(.outline2purple)        {text-shadow:
+  -1px -1px #8000C0, -1px  0px #8000C0, -1px  1px #8000C0,  0px -1px #8000C0,  0px  1px #8000C0,  1px -1px #8000C0,  1px  0px #8000C0,  1px  1px #8000C0,
+  -2px -2px #8000C0, -2px -1px #8000C0, -2px  0px #8000C0, -2px  1px #8000C0, -2px  2px #8000C0, -1px -2px #8000C0, -1px  2px #8000C0,  0px -2px #8000C0,
+   0px  2px #8000C0,  1px -2px #8000C0,  1px  2px #8000C0,  2px -2px #8000C0,  2px -1px #8000C0,  2px  0px #8000C0,  2px  1px #8000C0,  2px  2px #8000C0;}
+::cue(.outline1purple)        {text-shadow:
+  -1px -1px #8000C0, -1px  0px #8000C0, -1px  1px #8000C0,  0px -1px #8000C0,  0px  1px #8000C0,  1px -1px #8000C0,  1px  0px #8000C0,  1px  1px #8000C0;}
+::cue(.outline3electric)              {text-shadow:
+  -1px -1px #8000FF, -1px  0px #8000FF, -1px  1px #8000FF,  0px -1px #8000FF,  0px  1px #8000FF,  1px -1px #8000FF,  1px  0px #8000FF,  1px  1px #8000FF,
+  -2px -2px #8000FF, -2px -1px #8000FF, -2px  0px #8000FF, -2px  1px #8000FF, -2px  2px #8000FF, -1px -2px #8000FF, -1px  2px #8000FF,  0px -2px #8000FF,
+   0px  2px #8000FF,  1px -2px #8000FF,  1px  2px #8000FF,  2px -2px #8000FF,  2px -1px #8000FF,  2px  0px #8000FF,  2px  1px #8000FF,  2px  2px #8000FF,
+  -3px -3px #8000FF, -3px -2px #8000FF, -3px -1px #8000FF, -3px  0px #8000FF, -3px  1px #8000FF, -3px  2px #8000FF, -3px  3px #8000FF, -2px -3px #8000FF,
+  -2px  3px #8000FF, -1px -3px #8000FF, -1px  3px #8000FF,  0px -3px #8000FF,  0px  3px #8000FF,  1px -3px #8000FF,  1px  3px #8000FF,  2px -3px #8000FF,
+   2px  3px #8000FF,  3px -3px #8000FF,  3px -2px #8000FF,  3px -1px #8000FF,  3px  0px #8000FF,  3px  1px #8000FF,  3px  2px #8000FF,  3px  3px #8000FF;}
+::cue(.outline2electric)              {text-shadow:
+  -1px -1px #8000FF, -1px  0px #8000FF, -1px  1px #8000FF,  0px -1px #8000FF,  0px  1px #8000FF,  1px -1px #8000FF,  1px  0px #8000FF,  1px  1px #8000FF,
+  -2px -2px #8000FF, -2px -1px #8000FF, -2px  0px #8000FF, -2px  1px #8000FF, -2px  2px #8000FF, -1px -2px #8000FF, -1px  2px #8000FF,  0px -2px #8000FF,
+   0px  2px #8000FF,  1px -2px #8000FF,  1px  2px #8000FF,  2px -2px #8000FF,  2px -1px #8000FF,  2px  0px #8000FF,  2px  1px #8000FF,  2px  2px #8000FF;}
+::cue(.outline1electric)              {text-shadow:
+  -1px -1px #8000FF, -1px  0px #8000FF, -1px  1px #8000FF,  0px -1px #8000FF,  0px  1px #8000FF,  1px -1px #8000FF,  1px  0px #8000FF,  1px  1px #8000FF;}
+::cue(.outline3cinnamon)        {text-shadow:
+  -1px -1px #804000, -1px  0px #804000, -1px  1px #804000,  0px -1px #804000,  0px  1px #804000,  1px -1px #804000,  1px  0px #804000,  1px  1px #804000,
+  -2px -2px #804000, -2px -1px #804000, -2px  0px #804000, -2px  1px #804000, -2px  2px #804000, -1px -2px #804000, -1px  2px #804000,  0px -2px #804000,
+   0px  2px #804000,  1px -2px #804000,  1px  2px #804000,  2px -2px #804000,  2px -1px #804000,  2px  0px #804000,  2px  1px #804000,  2px  2px #804000,
+  -3px -3px #804000, -3px -2px #804000, -3px -1px #804000, -3px  0px #804000, -3px  1px #804000, -3px  2px #804000, -3px  3px #804000, -2px -3px #804000,
+  -2px  3px #804000, -1px -3px #804000, -1px  3px #804000,  0px -3px #804000,  0px  3px #804000,  1px -3px #804000,  1px  3px #804000,  2px -3px #804000,
+   2px  3px #804000,  3px -3px #804000,  3px -2px #804000,  3px -1px #804000,  3px  0px #804000,  3px  1px #804000,  3px  2px #804000,  3px  3px #804000;}
+::cue(.outline2cinnamon)        {text-shadow:
+  -1px -1px #804000, -1px  0px #804000, -1px  1px #804000,  0px -1px #804000,  0px  1px #804000,  1px -1px #804000,  1px  0px #804000,  1px  1px #804000,
+  -2px -2px #804000, -2px -1px #804000, -2px  0px #804000, -2px  1px #804000, -2px  2px #804000, -1px -2px #804000, -1px  2px #804000,  0px -2px #804000,
+   0px  2px #804000,  1px -2px #804000,  1px  2px #804000,  2px -2px #804000,  2px -1px #804000,  2px  0px #804000,  2px  1px #804000,  2px  2px #804000;}
+::cue(.outline1cinnamon)        {text-shadow:
+  -1px -1px #804000, -1px  0px #804000, -1px  1px #804000,  0px -1px #804000,  0px  1px #804000,  1px -1px #804000,  1px  0px #804000,  1px  1px #804000;}
+::cue(.outline3lotus)        {text-shadow:
+  -1px -1px #804040, -1px  0px #804040, -1px  1px #804040,  0px -1px #804040,  0px  1px #804040,  1px -1px #804040,  1px  0px #804040,  1px  1px #804040,
+  -2px -2px #804040, -2px -1px #804040, -2px  0px #804040, -2px  1px #804040, -2px  2px #804040, -1px -2px #804040, -1px  2px #804040,  0px -2px #804040,
+   0px  2px #804040,  1px -2px #804040,  1px  2px #804040,  2px -2px #804040,  2px -1px #804040,  2px  0px #804040,  2px  1px #804040,  2px  2px #804040,
+  -3px -3px #804040, -3px -2px #804040, -3px -1px #804040, -3px  0px #804040, -3px  1px #804040, -3px  2px #804040, -3px  3px #804040, -2px -3px #804040,
+  -2px  3px #804040, -1px -3px #804040, -1px  3px #804040,  0px -3px #804040,  0px  3px #804040,  1px -3px #804040,  1px  3px #804040,  2px -3px #804040,
+   2px  3px #804040,  3px -3px #804040,  3px -2px #804040,  3px -1px #804040,  3px  0px #804040,  3px  1px #804040,  3px  2px #804040,  3px  3px #804040;}
+::cue(.outline2lotus)        {text-shadow:
+  -1px -1px #804040, -1px  0px #804040, -1px  1px #804040,  0px -1px #804040,  0px  1px #804040,  1px -1px #804040,  1px  0px #804040,  1px  1px #804040,
+  -2px -2px #804040, -2px -1px #804040, -2px  0px #804040, -2px  1px #804040, -2px  2px #804040, -1px -2px #804040, -1px  2px #804040,  0px -2px #804040,
+   0px  2px #804040,  1px -2px #804040,  1px  2px #804040,  2px -2px #804040,  2px -1px #804040,  2px  0px #804040,  2px  1px #804040,  2px  2px #804040;}
+::cue(.outline1lotus)        {text-shadow:
+  -1px -1px #804040, -1px  0px #804040, -1px  1px #804040,  0px -1px #804040,  0px  1px #804040,  1px -1px #804040,  1px  0px #804040,  1px  1px #804040;}
+::cue(.outline3cannonpink)        {text-shadow:
+  -1px -1px #804080, -1px  0px #804080, -1px  1px #804080,  0px -1px #804080,  0px  1px #804080,  1px -1px #804080,  1px  0px #804080,  1px  1px #804080,
+  -2px -2px #804080, -2px -1px #804080, -2px  0px #804080, -2px  1px #804080, -2px  2px #804080, -1px -2px #804080, -1px  2px #804080,  0px -2px #804080,
+   0px  2px #804080,  1px -2px #804080,  1px  2px #804080,  2px -2px #804080,  2px -1px #804080,  2px  0px #804080,  2px  1px #804080,  2px  2px #804080,
+  -3px -3px #804080, -3px -2px #804080, -3px -1px #804080, -3px  0px #804080, -3px  1px #804080, -3px  2px #804080, -3px  3px #804080, -2px -3px #804080,
+  -2px  3px #804080, -1px -3px #804080, -1px  3px #804080,  0px -3px #804080,  0px  3px #804080,  1px -3px #804080,  1px  3px #804080,  2px -3px #804080,
+   2px  3px #804080,  3px -3px #804080,  3px -2px #804080,  3px -1px #804080,  3px  0px #804080,  3px  1px #804080,  3px  2px #804080,  3px  3px #804080;}
+::cue(.outline2cannonpink)        {text-shadow:
+  -1px -1px #804080, -1px  0px #804080, -1px  1px #804080,  0px -1px #804080,  0px  1px #804080,  1px -1px #804080,  1px  0px #804080,  1px  1px #804080,
+  -2px -2px #804080, -2px -1px #804080, -2px  0px #804080, -2px  1px #804080, -2px  2px #804080, -1px -2px #804080, -1px  2px #804080,  0px -2px #804080,
+   0px  2px #804080,  1px -2px #804080,  1px  2px #804080,  2px -2px #804080,  2px -1px #804080,  2px  0px #804080,  2px  1px #804080,  2px  2px #804080;}
+::cue(.outline1cannonpink)        {text-shadow:
+  -1px -1px #804080, -1px  0px #804080, -1px  1px #804080,  0px -1px #804080,  0px  1px #804080,  1px -1px #804080,  1px  0px #804080,  1px  1px #804080;}
+::cue(.outline3fuchsiablue)        {text-shadow:
+  -1px -1px #8040C0, -1px  0px #8040C0, -1px  1px #8040C0,  0px -1px #8040C0,  0px  1px #8040C0,  1px -1px #8040C0,  1px  0px #8040C0,  1px  1px #8040C0,
+  -2px -2px #8040C0, -2px -1px #8040C0, -2px  0px #8040C0, -2px  1px #8040C0, -2px  2px #8040C0, -1px -2px #8040C0, -1px  2px #8040C0,  0px -2px #8040C0,
+   0px  2px #8040C0,  1px -2px #8040C0,  1px  2px #8040C0,  2px -2px #8040C0,  2px -1px #8040C0,  2px  0px #8040C0,  2px  1px #8040C0,  2px  2px #8040C0,
+  -3px -3px #8040C0, -3px -2px #8040C0, -3px -1px #8040C0, -3px  0px #8040C0, -3px  1px #8040C0, -3px  2px #8040C0, -3px  3px #8040C0, -2px -3px #8040C0,
+  -2px  3px #8040C0, -1px -3px #8040C0, -1px  3px #8040C0,  0px -3px #8040C0,  0px  3px #8040C0,  1px -3px #8040C0,  1px  3px #8040C0,  2px -3px #8040C0,
+   2px  3px #8040C0,  3px -3px #8040C0,  3px -2px #8040C0,  3px -1px #8040C0,  3px  0px #8040C0,  3px  1px #8040C0,  3px  2px #8040C0,  3px  3px #8040C0;}
+::cue(.outline2fuchsiablue)        {text-shadow:
+  -1px -1px #8040C0, -1px  0px #8040C0, -1px  1px #8040C0,  0px -1px #8040C0,  0px  1px #8040C0,  1px -1px #8040C0,  1px  0px #8040C0,  1px  1px #8040C0,
+  -2px -2px #8040C0, -2px -1px #8040C0, -2px  0px #8040C0, -2px  1px #8040C0, -2px  2px #8040C0, -1px -2px #8040C0, -1px  2px #8040C0,  0px -2px #8040C0,
+   0px  2px #8040C0,  1px -2px #8040C0,  1px  2px #8040C0,  2px -2px #8040C0,  2px -1px #8040C0,  2px  0px #8040C0,  2px  1px #8040C0,  2px  2px #8040C0;}
+::cue(.outline1fuchsiablue)        {text-shadow:
+  -1px -1px #8040C0, -1px  0px #8040C0, -1px  1px #8040C0,  0px -1px #8040C0,  0px  1px #8040C0,  1px -1px #8040C0,  1px  0px #8040C0,  1px  1px #8040C0;}
+::cue(.outline3heliotrope)        {text-shadow:
+  -1px -1px #8040FF, -1px  0px #8040FF, -1px  1px #8040FF,  0px -1px #8040FF,  0px  1px #8040FF,  1px -1px #8040FF,  1px  0px #8040FF,  1px  1px #8040FF,
+  -2px -2px #8040FF, -2px -1px #8040FF, -2px  0px #8040FF, -2px  1px #8040FF, -2px  2px #8040FF, -1px -2px #8040FF, -1px  2px #8040FF,  0px -2px #8040FF,
+   0px  2px #8040FF,  1px -2px #8040FF,  1px  2px #8040FF,  2px -2px #8040FF,  2px -1px #8040FF,  2px  0px #8040FF,  2px  1px #8040FF,  2px  2px #8040FF,
+  -3px -3px #8040FF, -3px -2px #8040FF, -3px -1px #8040FF, -3px  0px #8040FF, -3px  1px #8040FF, -3px  2px #8040FF, -3px  3px #8040FF, -2px -3px #8040FF,
+  -2px  3px #8040FF, -1px -3px #8040FF, -1px  3px #8040FF,  0px -3px #8040FF,  0px  3px #8040FF,  1px -3px #8040FF,  1px  3px #8040FF,  2px -3px #8040FF,
+   2px  3px #8040FF,  3px -3px #8040FF,  3px -2px #8040FF,  3px -1px #8040FF,  3px  0px #8040FF,  3px  1px #8040FF,  3px  2px #8040FF,  3px  3px #8040FF;}
+::cue(.outline2heliotrope)        {text-shadow:
+  -1px -1px #8040FF, -1px  0px #8040FF, -1px  1px #8040FF,  0px -1px #8040FF,  0px  1px #8040FF,  1px -1px #8040FF,  1px  0px #8040FF,  1px  1px #8040FF,
+  -2px -2px #8040FF, -2px -1px #8040FF, -2px  0px #8040FF, -2px  1px #8040FF, -2px  2px #8040FF, -1px -2px #8040FF, -1px  2px #8040FF,  0px -2px #8040FF,
+   0px  2px #8040FF,  1px -2px #8040FF,  1px  2px #8040FF,  2px -2px #8040FF,  2px -1px #8040FF,  2px  0px #8040FF,  2px  1px #8040FF,  2px  2px #8040FF;}
+::cue(.outline1heliotrope)        {text-shadow:
+  -1px -1px #8040FF, -1px  0px #8040FF, -1px  1px #8040FF,  0px -1px #8040FF,  0px  1px #8040FF,  1px -1px #8040FF,  1px  0px #8040FF,  1px  1px #8040FF;}
+::cue(.outline3olive)        {text-shadow:
+  -1px -1px #808000, -1px  0px #808000, -1px  1px #808000,  0px -1px #808000,  0px  1px #808000,  1px -1px #808000,  1px  0px #808000,  1px  1px #808000,
+  -2px -2px #808000, -2px -1px #808000, -2px  0px #808000, -2px  1px #808000, -2px  2px #808000, -1px -2px #808000, -1px  2px #808000,  0px -2px #808000,
+   0px  2px #808000,  1px -2px #808000,  1px  2px #808000,  2px -2px #808000,  2px -1px #808000,  2px  0px #808000,  2px  1px #808000,  2px  2px #808000,
+  -3px -3px #808000, -3px -2px #808000, -3px -1px #808000, -3px  0px #808000, -3px  1px #808000, -3px  2px #808000, -3px  3px #808000, -2px -3px #808000,
+  -2px  3px #808000, -1px -3px #808000, -1px  3px #808000,  0px -3px #808000,  0px  3px #808000,  1px -3px #808000,  1px  3px #808000,  2px -3px #808000,
+   2px  3px #808000,  3px -3px #808000,  3px -2px #808000,  3px -1px #808000,  3px  0px #808000,  3px  1px #808000,  3px  2px #808000,  3px  3px #808000;}
+::cue(.outline2olive)        {text-shadow:
+  -1px -1px #808000, -1px  0px #808000, -1px  1px #808000,  0px -1px #808000,  0px  1px #808000,  1px -1px #808000,  1px  0px #808000,  1px  1px #808000,
+  -2px -2px #808000, -2px -1px #808000, -2px  0px #808000, -2px  1px #808000, -2px  2px #808000, -1px -2px #808000, -1px  2px #808000,  0px -2px #808000,
+   0px  2px #808000,  1px -2px #808000,  1px  2px #808000,  2px -2px #808000,  2px -1px #808000,  2px  0px #808000,  2px  1px #808000,  2px  2px #808000;}
+::cue(.outline1olive)        {text-shadow:
+  -1px -1px #808000, -1px  0px #808000, -1px  1px #808000,  0px -1px #808000,  0px  1px #808000,  1px -1px #808000,  1px  0px #808000,  1px  1px #808000;}
+::cue(.outline3yellowmetal)        {text-shadow:
+  -1px -1px #808040, -1px  0px #808040, -1px  1px #808040,  0px -1px #808040,  0px  1px #808040,  1px -1px #808040,  1px  0px #808040,  1px  1px #808040,
+  -2px -2px #808040, -2px -1px #808040, -2px  0px #808040, -2px  1px #808040, -2px  2px #808040, -1px -2px #808040, -1px  2px #808040,  0px -2px #808040,
+   0px  2px #808040,  1px -2px #808040,  1px  2px #808040,  2px -2px #808040,  2px -1px #808040,  2px  0px #808040,  2px  1px #808040,  2px  2px #808040,
+  -3px -3px #808040, -3px -2px #808040, -3px -1px #808040, -3px  0px #808040, -3px  1px #808040, -3px  2px #808040, -3px  3px #808040, -2px -3px #808040,
+  -2px  3px #808040, -1px -3px #808040, -1px  3px #808040,  0px -3px #808040,  0px  3px #808040,  1px -3px #808040,  1px  3px #808040,  2px -3px #808040,
+   2px  3px #808040,  3px -3px #808040,  3px -2px #808040,  3px -1px #808040,  3px  0px #808040,  3px  1px #808040,  3px  2px #808040,  3px  3px #808040;}
+::cue(.outline2yellowmetal)        {text-shadow:
+  -1px -1px #808040, -1px  0px #808040, -1px  1px #808040,  0px -1px #808040,  0px  1px #808040,  1px -1px #808040,  1px  0px #808040,  1px  1px #808040,
+  -2px -2px #808040, -2px -1px #808040, -2px  0px #808040, -2px  1px #808040, -2px  2px #808040, -1px -2px #808040, -1px  2px #808040,  0px -2px #808040,
+   0px  2px #808040,  1px -2px #808040,  1px  2px #808040,  2px -2px #808040,  2px -1px #808040,  2px  0px #808040,  2px  1px #808040,  2px  2px #808040;}
+::cue(.outline1yellowmetal)        {text-shadow:
+  -1px -1px #808080, -1px  0px #808080, -1px  1px #808080,  0px -1px #808080,  0px  1px #808080,  1px -1px #808080,  1px  0px #808080,  1px  1px #808080;}
+::cue(.outline3gray)        {text-shadow:
+  -1px -1px #808080, -1px  0px #808080, -1px  1px #808080,  0px -1px #808080,  0px  1px #808080,  1px -1px #808080,  1px  0px #808080,  1px  1px #808080,
+  -2px -2px #808080, -2px -1px #808080, -2px  0px #808080, -2px  1px #808080, -2px  2px #808080, -1px -2px #808080, -1px  2px #808080,  0px -2px #808080,
+   0px  2px #808080,  1px -2px #808080,  1px  2px #808080,  2px -2px #808080,  2px -1px #808080,  2px  0px #808080,  2px  1px #808080,  2px  2px #808080,
+  -3px -3px #808080, -3px -2px #808080, -3px -1px #808080, -3px  0px #808080, -3px  1px #808080, -3px  2px #808080, -3px  3px #808080, -2px -3px #808080,
+  -2px  3px #808080, -1px -3px #808080, -1px  3px #808080,  0px -3px #808080,  0px  3px #808080,  1px -3px #808080,  1px  3px #808080,  2px -3px #808080,
+   2px  3px #808080,  3px -3px #808080,  3px -2px #808080,  3px -1px #808080,  3px  0px #808080,  3px  1px #808080,  3px  2px #808080,  3px  3px #808080;}
+::cue(.outline2gray)        {text-shadow:
+  -1px -1px #808080, -1px  0px #808080, -1px  1px #808080,  0px -1px #808080,  0px  1px #808080,  1px -1px #808080,  1px  0px #808080,  1px  1px #808080,
+  -2px -2px #808080, -2px -1px #808080, -2px  0px #808080, -2px  1px #808080, -2px  2px #808080, -1px -2px #808080, -1px  2px #808080,  0px -2px #808080,
+   0px  2px #808080,  1px -2px #808080,  1px  2px #808080,  2px -2px #808080,  2px -1px #808080,  2px  0px #808080,  2px  1px #808080,  2px  2px #808080;}
+::cue(.outline1gray)        {text-shadow:
+  -1px -1px #808080, -1px  0px #808080, -1px  1px #808080,  0px -1px #808080,  0px  1px #808080,  1px -1px #808080,  1px  0px #808080,  1px  1px #808080;}
+::cue(.outline3yonder)        {text-shadow:
+  -1px -1px #8080C0, -1px  0px #8080C0, -1px  1px #8080C0,  0px -1px #8080C0,  0px  1px #8080C0,  1px -1px #8080C0,  1px  0px #8080C0,  1px  1px #8080C0,
+  -2px -2px #8080C0, -2px -1px #8080C0, -2px  0px #8080C0, -2px  1px #8080C0, -2px  2px #8080C0, -1px -2px #8080C0, -1px  2px #8080C0,  0px -2px #8080C0,
+   0px  2px #8080C0,  1px -2px #8080C0,  1px  2px #8080C0,  2px -2px #8080C0,  2px -1px #8080C0,  2px  0px #8080C0,  2px  1px #8080C0,  2px  2px #8080C0,
+  -3px -3px #8080C0, -3px -2px #8080C0, -3px -1px #8080C0, -3px  0px #8080C0, -3px  1px #8080C0, -3px  2px #8080C0, -3px  3px #8080C0, -2px -3px #8080C0,
+  -2px  3px #8080C0, -1px -3px #8080C0, -1px  3px #8080C0,  0px -3px #8080C0,  0px  3px #8080C0,  1px -3px #8080C0,  1px  3px #8080C0,  2px -3px #8080C0,
+   2px  3px #8080C0,  3px -3px #8080C0,  3px -2px #8080C0,  3px -1px #8080C0,  3px  0px #8080C0,  3px  1px #8080C0,  3px  2px #8080C0,  3px  3px #8080C0;}
+::cue(.outline2yonder)        {text-shadow:
+  -1px -1px #8080C0, -1px  0px #8080C0, -1px  1px #8080C0,  0px -1px #8080C0,  0px  1px #8080C0,  1px -1px #8080C0,  1px  0px #8080C0,  1px  1px #8080C0,
+  -2px -2px #8080C0, -2px -1px #8080C0, -2px  0px #8080C0, -2px  1px #8080C0, -2px  2px #8080C0, -1px -2px #8080C0, -1px  2px #8080C0,  0px -2px #8080C0,
+   0px  2px #8080C0,  1px -2px #8080C0,  1px  2px #8080C0,  2px -2px #8080C0,  2px -1px #8080C0,  2px  0px #8080C0,  2px  1px #8080C0,  2px  2px #8080C0;}
+::cue(.outline1yonder)        {text-shadow:
+  -1px -1px #8080C0, -1px  0px #8080C0, -1px  1px #8080C0,  0px -1px #8080C0,  0px  1px #8080C0,  1px -1px #8080C0,  1px  0px #8080C0,  1px  1px #8080C0;}
+::cue(.outline3malibu)        {text-shadow:
+  -1px -1px #8080FF, -1px  0px #8080FF, -1px  1px #8080FF,  0px -1px #8080FF,  0px  1px #8080FF,  1px -1px #8080FF,  1px  0px #8080FF,  1px  1px #8080FF,
+  -2px -2px #8080FF, -2px -1px #8080FF, -2px  0px #8080FF, -2px  1px #8080FF, -2px  2px #8080FF, -1px -2px #8080FF, -1px  2px #8080FF,  0px -2px #8080FF,
+   0px  2px #8080FF,  1px -2px #8080FF,  1px  2px #8080FF,  2px -2px #8080FF,  2px -1px #8080FF,  2px  0px #8080FF,  2px  1px #8080FF,  2px  2px #8080FF,
+  -3px -3px #8080FF, -3px -2px #8080FF, -3px -1px #8080FF, -3px  0px #8080FF, -3px  1px #8080FF, -3px  2px #8080FF, -3px  3px #8080FF, -2px -3px #8080FF,
+  -2px  3px #8080FF, -1px -3px #8080FF, -1px  3px #8080FF,  0px -3px #8080FF,  0px  3px #8080FF,  1px -3px #8080FF,  1px  3px #8080FF,  2px -3px #8080FF,
+   2px  3px #8080FF,  3px -3px #8080FF,  3px -2px #8080FF,  3px -1px #8080FF,  3px  0px #8080FF,  3px  1px #8080FF,  3px  2px #8080FF,  3px  3px #8080FF;}
+::cue(.outline2malibu)        {text-shadow:
+  -1px -1px #8080FF, -1px  0px #8080FF, -1px  1px #8080FF,  0px -1px #8080FF,  0px  1px #8080FF,  1px -1px #8080FF,  1px  0px #8080FF,  1px  1px #8080FF,
+  -2px -2px #8080FF, -2px -1px #8080FF, -2px  0px #8080FF, -2px  1px #8080FF, -2px  2px #8080FF, -1px -2px #8080FF, -1px  2px #8080FF,  0px -2px #8080FF,
+   0px  2px #8080FF,  1px -2px #8080FF,  1px  2px #8080FF,  2px -2px #8080FF,  2px -1px #8080FF,  2px  0px #8080FF,  2px  1px #8080FF,  2px  2px #8080FF;}
+::cue(.outline1malibu)        {text-shadow:
+  -1px -1px #8080FF, -1px  0px #8080FF, -1px  1px #8080FF,  0px -1px #8080FF,  0px  1px #8080FF,  1px -1px #8080FF,  1px  0px #8080FF,  1px  1px #8080FF;}
+::cue(.outline3pistachio)        {text-shadow:
+  -1px -1px #80C000, -1px  0px #80C000, -1px  1px #80C000,  0px -1px #80C000,  0px  1px #80C000,  1px -1px #80C000,  1px  0px #80C000,  1px  1px #80C000,
+  -2px -2px #80C000, -2px -1px #80C000, -2px  0px #80C000, -2px  1px #80C000, -2px  2px #80C000, -1px -2px #80C000, -1px  2px #80C000,  0px -2px #80C000,
+   0px  2px #80C000,  1px -2px #80C000,  1px  2px #80C000,  2px -2px #80C000,  2px -1px #80C000,  2px  0px #80C000,  2px  1px #80C000,  2px  2px #80C000,
+  -3px -3px #80C000, -3px -2px #80C000, -3px -1px #80C000, -3px  0px #80C000, -3px  1px #80C000, -3px  2px #80C000, -3px  3px #80C000, -2px -3px #80C000,
+  -2px  3px #80C000, -1px -3px #80C000, -1px  3px #80C000,  0px -3px #80C000,  0px  3px #80C000,  1px -3px #80C000,  1px  3px #80C000,  2px -3px #80C000,
+   2px  3px #80C000,  3px -3px #80C000,  3px -2px #80C000,  3px -1px #80C000,  3px  0px #80C000,  3px  1px #80C000,  3px  2px #80C000,  3px  3px #80C000;}
+::cue(.outline2pistachio)        {text-shadow:
+  -1px -1px #80C000, -1px  0px #80C000, -1px  1px #80C000,  0px -1px #80C000,  0px  1px #80C000,  1px -1px #80C000,  1px  0px #80C000,  1px  1px #80C000,
+  -2px -2px #80C000, -2px -1px #80C000, -2px  0px #80C000, -2px  1px #80C000, -2px  2px #80C000, -1px -2px #80C000, -1px  2px #80C000,  0px -2px #80C000,
+   0px  2px #80C000,  1px -2px #80C000,  1px  2px #80C000,  2px -2px #80C000,  2px -1px #80C000,  2px  0px #80C000,  2px  1px #80C000,  2px  2px #80C000;}
+::cue(.outline1pistachio)        {text-shadow:
+  -1px -1px #80C000, -1px  0px #80C000, -1px  1px #80C000,  0px -1px #80C000,  0px  1px #80C000,  1px -1px #80C000,  1px  0px #80C000,  1px  1px #80C000;}
+::cue(.outline3wasabi)        {text-shadow:
+  -1px -1px #80C040, -1px  0px #80C040, -1px  1px #80C040,  0px -1px #80C040,  0px  1px #80C040,  1px -1px #80C040,  1px  0px #80C040,  1px  1px #80C040,
+  -2px -2px #80C040, -2px -1px #80C040, -2px  0px #80C040, -2px  1px #80C040, -2px  2px #80C040, -1px -2px #80C040, -1px  2px #80C040,  0px -2px #80C040,
+   0px  2px #80C040,  1px -2px #80C040,  1px  2px #80C040,  2px -2px #80C040,  2px -1px #80C040,  2px  0px #80C040,  2px  1px #80C040,  2px  2px #80C040,
+  -3px -3px #80C040, -3px -2px #80C040, -3px -1px #80C040, -3px  0px #80C040, -3px  1px #80C040, -3px  2px #80C040, -3px  3px #80C040, -2px -3px #80C040,
+  -2px  3px #80C040, -1px -3px #80C040, -1px  3px #80C040,  0px -3px #80C040,  0px  3px #80C040,  1px -3px #80C040,  1px  3px #80C040,  2px -3px #80C040,
+   2px  3px #80C040,  3px -3px #80C040,  3px -2px #80C040,  3px -1px #80C040,  3px  0px #80C040,  3px  1px #80C040,  3px  2px #80C040,  3px  3px #80C040;}
+::cue(.outline2wasabi)        {text-shadow:
+  -1px -1px #80C040, -1px  0px #80C040, -1px  1px #80C040,  0px -1px #80C040,  0px  1px #80C040,  1px -1px #80C040,  1px  0px #80C040,  1px  1px #80C040,
+  -2px -2px #80C040, -2px -1px #80C040, -2px  0px #80C040, -2px  1px #80C040, -2px  2px #80C040, -1px -2px #80C040, -1px  2px #80C040,  0px -2px #80C040,
+   0px  2px #80C040,  1px -2px #80C040,  1px  2px #80C040,  2px -2px #80C040,  2px -1px #80C040,  2px  0px #80C040,  2px  1px #80C040,  2px  2px #80C040;}
+::cue(.outline1wasabi)        {text-shadow:
+  -1px -1px #80C040, -1px  0px #80C040, -1px  1px #80C040,  0px -1px #80C040,  0px  1px #80C040,  1px -1px #80C040,  1px  0px #80C040,  1px  1px #80C040;}
+::cue(.outline3deyork)        {text-shadow:
+  -1px -1px #80C080, -1px  0px #80C080, -1px  1px #80C080,  0px -1px #80C080,  0px  1px #80C080,  1px -1px #80C080,  1px  0px #80C080,  1px  1px #80C080,
+  -2px -2px #80C080, -2px -1px #80C080, -2px  0px #80C080, -2px  1px #80C080, -2px  2px #80C080, -1px -2px #80C080, -1px  2px #80C080,  0px -2px #80C080,
+   0px  2px #80C080,  1px -2px #80C080,  1px  2px #80C080,  2px -2px #80C080,  2px -1px #80C080,  2px  0px #80C080,  2px  1px #80C080,  2px  2px #80C080,
+  -3px -3px #80C080, -3px -2px #80C080, -3px -1px #80C080, -3px  0px #80C080, -3px  1px #80C080, -3px  2px #80C080, -3px  3px #80C080, -2px -3px #80C080,
+  -2px  3px #80C080, -1px -3px #80C080, -1px  3px #80C080,  0px -3px #80C080,  0px  3px #80C080,  1px -3px #80C080,  1px  3px #80C080,  2px -3px #80C080,
+   2px  3px #80C080,  3px -3px #80C080,  3px -2px #80C080,  3px -1px #80C080,  3px  0px #80C080,  3px  1px #80C080,  3px  2px #80C080,  3px  3px #80C080;}
+::cue(.outline2deyork)        {text-shadow:
+  -1px -1px #80C080, -1px  0px #80C080, -1px  1px #80C080,  0px -1px #80C080,  0px  1px #80C080,  1px -1px #80C080,  1px  0px #80C080,  1px  1px #80C080,
+  -2px -2px #80C080, -2px -1px #80C080, -2px  0px #80C080, -2px  1px #80C080, -2px  2px #80C080, -1px -2px #80C080, -1px  2px #80C080,  0px -2px #80C080,
+   0px  2px #80C080,  1px -2px #80C080,  1px  2px #80C080,  2px -2px #80C080,  2px -1px #80C080,  2px  0px #80C080,  2px  1px #80C080,  2px  2px #80C080;}
+::cue(.outline1deyork)        {text-shadow:
+  -1px -1px #80C080, -1px  0px #80C080, -1px  1px #80C080,  0px -1px #80C080,  0px  1px #80C080,  1px -1px #80C080,  1px  0px #80C080,  1px  1px #80C080;}
+::cue(.outline3neptune)        {text-shadow:
+  -1px -1px #80C0C0, -1px  0px #80C0C0, -1px  1px #80C0C0,  0px -1px #80C0C0,  0px  1px #80C0C0,  1px -1px #80C0C0,  1px  0px #80C0C0,  1px  1px #80C0C0,
+  -2px -2px #80C0C0, -2px -1px #80C0C0, -2px  0px #80C0C0, -2px  1px #80C0C0, -2px  2px #80C0C0, -1px -2px #80C0C0, -1px  2px #80C0C0,  0px -2px #80C0C0,
+   0px  2px #80C0C0,  1px -2px #80C0C0,  1px  2px #80C0C0,  2px -2px #80C0C0,  2px -1px #80C0C0,  2px  0px #80C0C0,  2px  1px #80C0C0,  2px  2px #80C0C0,
+  -3px -3px #80C0C0, -3px -2px #80C0C0, -3px -1px #80C0C0, -3px  0px #80C0C0, -3px  1px #80C0C0, -3px  2px #80C0C0, -3px  3px #80C0C0, -2px -3px #80C0C0,
+  -2px  3px #80C0C0, -1px -3px #80C0C0, -1px  3px #80C0C0,  0px -3px #80C0C0,  0px  3px #80C0C0,  1px -3px #80C0C0,  1px  3px #80C0C0,  2px -3px #80C0C0,
+   2px  3px #80C0C0,  3px -3px #80C0C0,  3px -2px #80C0C0,  3px -1px #80C0C0,  3px  0px #80C0C0,  3px  1px #80C0C0,  3px  2px #80C0C0,  3px  3px #80C0C0;}
+::cue(.outline2neptune)        {text-shadow:
+  -1px -1px #80C0C0, -1px  0px #80C0C0, -1px  1px #80C0C0,  0px -1px #80C0C0,  0px  1px #80C0C0,  1px -1px #80C0C0,  1px  0px #80C0C0,  1px  1px #80C0C0,
+  -2px -2px #80C0C0, -2px -1px #80C0C0, -2px  0px #80C0C0, -2px  1px #80C0C0, -2px  2px #80C0C0, -1px -2px #80C0C0, -1px  2px #80C0C0,  0px -2px #80C0C0,
+   0px  2px #80C0C0,  1px -2px #80C0C0,  1px  2px #80C0C0,  2px -2px #80C0C0,  2px -1px #80C0C0,  2px  0px #80C0C0,  2px  1px #80C0C0,  2px  2px #80C0C0;}
+::cue(.outline1neptune)        {text-shadow:
+  -1px -1px #80C0C0, -1px  0px #80C0C0, -1px  1px #80C0C0,  0px -1px #80C0C0,  0px  1px #80C0C0,  1px -1px #80C0C0,  1px  0px #80C0C0,  1px  1px #80C0C0;}
+::cue(.outline3anakiwa)        {text-shadow:
+  -1px -1px #80C0FF, -1px  0px #80C0FF, -1px  1px #80C0FF,  0px -1px #80C0FF,  0px  1px #80C0FF,  1px -1px #80C0FF,  1px  0px #80C0FF,  1px  1px #80C0FF,
+  -2px -2px #80C0FF, -2px -1px #80C0FF, -2px  0px #80C0FF, -2px  1px #80C0FF, -2px  2px #80C0FF, -1px -2px #80C0FF, -1px  2px #80C0FF,  0px -2px #80C0FF,
+   0px  2px #80C0FF,  1px -2px #80C0FF,  1px  2px #80C0FF,  2px -2px #80C0FF,  2px -1px #80C0FF,  2px  0px #80C0FF,  2px  1px #80C0FF,  2px  2px #80C0FF,
+  -3px -3px #80C0FF, -3px -2px #80C0FF, -3px -1px #80C0FF, -3px  0px #80C0FF, -3px  1px #80C0FF, -3px  2px #80C0FF, -3px  3px #80C0FF, -2px -3px #80C0FF,
+  -2px  3px #80C0FF, -1px -3px #80C0FF, -1px  3px #80C0FF,  0px -3px #80C0FF,  0px  3px #80C0FF,  1px -3px #80C0FF,  1px  3px #80C0FF,  2px -3px #80C0FF,
+   2px  3px #80C0FF,  3px -3px #80C0FF,  3px -2px #80C0FF,  3px -1px #80C0FF,  3px  0px #80C0FF,  3px  1px #80C0FF,  3px  2px #80C0FF,  3px  3px #80C0FF;}
+::cue(.outline2anakiwa)        {text-shadow:
+  -1px -1px #80C0FF, -1px  0px #80C0FF, -1px  1px #80C0FF,  0px -1px #80C0FF,  0px  1px #80C0FF,  1px -1px #80C0FF,  1px  0px #80C0FF,  1px  1px #80C0FF,
+  -2px -2px #80C0FF, -2px -1px #80C0FF, -2px  0px #80C0FF, -2px  1px #80C0FF, -2px  2px #80C0FF, -1px -2px #80C0FF, -1px  2px #80C0FF,  0px -2px #80C0FF,
+   0px  2px #80C0FF,  1px -2px #80C0FF,  1px  2px #80C0FF,  2px -2px #80C0FF,  2px -1px #80C0FF,  2px  0px #80C0FF,  2px  1px #80C0FF,  2px  2px #80C0FF;}
+::cue(.outline1anakiwa)        {text-shadow:
+  -1px -1px #80C0FF, -1px  0px #80C0FF, -1px  1px #80C0FF,  0px -1px #80C0FF,  0px  1px #80C0FF,  1px -1px #80C0FF,  1px  0px #80C0FF,  1px  1px #80C0FF;}
+::cue(.outline3chartreuse)        {text-shadow:
+  -1px -1px #80FF00, -1px  0px #80FF00, -1px  1px #80FF00,  0px -1px #80FF00,  0px  1px #80FF00,  1px -1px #80FF00,  1px  0px #80FF00,  1px  1px #80FF00,
+  -2px -2px #80FF00, -2px -1px #80FF00, -2px  0px #80FF00, -2px  1px #80FF00, -2px  2px #80FF00, -1px -2px #80FF00, -1px  2px #80FF00,  0px -2px #80FF00,
+   0px  2px #80FF00,  1px -2px #80FF00,  1px  2px #80FF00,  2px -2px #80FF00,  2px -1px #80FF00,  2px  0px #80FF00,  2px  1px #80FF00,  2px  2px #80FF00,
+  -3px -3px #80FF00, -3px -2px #80FF00, -3px -1px #80FF00, -3px  0px #80FF00, -3px  1px #80FF00, -3px  2px #80FF00, -3px  3px #80FF00, -2px -3px #80FF00,
+  -2px  3px #80FF00, -1px -3px #80FF00, -1px  3px #80FF00,  0px -3px #80FF00,  0px  3px #80FF00,  1px -3px #80FF00,  1px  3px #80FF00,  2px -3px #80FF00,
+   2px  3px #80FF00,  3px -3px #80FF00,  3px -2px #80FF00,  3px -1px #80FF00,  3px  0px #80FF00,  3px  1px #80FF00,  3px  2px #80FF00,  3px  3px #80FF00;}
+::cue(.outline2chartreuse)        {text-shadow:
+  -1px -1px #80FF00, -1px  0px #80FF00, -1px  1px #80FF00,  0px -1px #80FF00,  0px  1px #80FF00,  1px -1px #80FF00,  1px  0px #80FF00,  1px  1px #80FF00,
+  -2px -2px #80FF00, -2px -1px #80FF00, -2px  0px #80FF00, -2px  1px #80FF00, -2px  2px #80FF00, -1px -2px #80FF00, -1px  2px #80FF00,  0px -2px #80FF00,
+   0px  2px #80FF00,  1px -2px #80FF00,  1px  2px #80FF00,  2px -2px #80FF00,  2px -1px #80FF00,  2px  0px #80FF00,  2px  1px #80FF00,  2px  2px #80FF00;}
+::cue(.outline1chartreuse)        {text-shadow:
+  -1px -1px #80FF00, -1px  0px #80FF00, -1px  1px #80FF00,  0px -1px #80FF00,  0px  1px #80FF00,  1px -1px #80FF00,  1px  0px #80FF00,  1px  1px #80FF00;}
+::cue(.outline3greenyellow)        {text-shadow:
+  -1px -1px #80FF40, -1px  0px #80FF40, -1px  1px #80FF40,  0px -1px #80FF40,  0px  1px #80FF40,  1px -1px #80FF40,  1px  0px #80FF40,  1px  1px #80FF40,
+  -2px -2px #80FF40, -2px -1px #80FF40, -2px  0px #80FF40, -2px  1px #80FF40, -2px  2px #80FF40, -1px -2px #80FF40, -1px  2px #80FF40,  0px -2px #80FF40,
+   0px  2px #80FF40,  1px -2px #80FF40,  1px  2px #80FF40,  2px -2px #80FF40,  2px -1px #80FF40,  2px  0px #80FF40,  2px  1px #80FF40,  2px  2px #80FF40,
+  -3px -3px #80FF40, -3px -2px #80FF40, -3px -1px #80FF40, -3px  0px #80FF40, -3px  1px #80FF40, -3px  2px #80FF40, -3px  3px #80FF40, -2px -3px #80FF40,
+  -2px  3px #80FF40, -1px -3px #80FF40, -1px  3px #80FF40,  0px -3px #80FF40,  0px  3px #80FF40,  1px -3px #80FF40,  1px  3px #80FF40,  2px -3px #80FF40,
+   2px  3px #80FF40,  3px -3px #80FF40,  3px -2px #80FF40,  3px -1px #80FF40,  3px  0px #80FF40,  3px  1px #80FF40,  3px  2px #80FF40,  3px  3px #80FF40;}
+::cue(.outline2greenyellow)        {text-shadow:
+  -1px -1px #80FF40, -1px  0px #80FF40, -1px  1px #80FF40,  0px -1px #80FF40,  0px  1px #80FF40,  1px -1px #80FF40,  1px  0px #80FF40,  1px  1px #80FF40,
+  -2px -2px #80FF40, -2px -1px #80FF40, -2px  0px #80FF40, -2px  1px #80FF40, -2px  2px #80FF40, -1px -2px #80FF40, -1px  2px #80FF40,  0px -2px #80FF40,
+   0px  2px #80FF40,  1px -2px #80FF40,  1px  2px #80FF40,  2px -2px #80FF40,  2px -1px #80FF40,  2px  0px #80FF40,  2px  1px #80FF40,  2px  2px #80FF40;}
+::cue(.outline1greenyellow)        {text-shadow:
+  -1px -1px #80FF40, -1px  0px #80FF40, -1px  1px #80FF40,  0px -1px #80FF40,  0px  1px #80FF40,  1px -1px #80FF40,  1px  0px #80FF40,  1px  1px #80FF40;}
+::cue(.outline3mintgreen)        {text-shadow:
+  -1px -1px #80FF80, -1px  0px #80FF80, -1px  1px #80FF80,  0px -1px #80FF80,  0px  1px #80FF80,  1px -1px #80FF80,  1px  0px #80FF80,  1px  1px #80FF80,
+  -2px -2px #80FF80, -2px -1px #80FF80, -2px  0px #80FF80, -2px  1px #80FF80, -2px  2px #80FF80, -1px -2px #80FF80, -1px  2px #80FF80,  0px -2px #80FF80,
+   0px  2px #80FF80,  1px -2px #80FF80,  1px  2px #80FF80,  2px -2px #80FF80,  2px -1px #80FF80,  2px  0px #80FF80,  2px  1px #80FF80,  2px  2px #80FF80,
+  -3px -3px #80FF80, -3px -2px #80FF80, -3px -1px #80FF80, -3px  0px #80FF80, -3px  1px #80FF80, -3px  2px #80FF80, -3px  3px #80FF80, -2px -3px #80FF80,
+  -2px  3px #80FF80, -1px -3px #80FF80, -1px  3px #80FF80,  0px -3px #80FF80,  0px  3px #80FF80,  1px -3px #80FF80,  1px  3px #80FF80,  2px -3px #80FF80,
+   2px  3px #80FF80,  3px -3px #80FF80,  3px -2px #80FF80,  3px -1px #80FF80,  3px  0px #80FF80,  3px  1px #80FF80,  3px  2px #80FF80,  3px  3px #80FF80;}
+::cue(.outline2mintgreen)        {text-shadow:
+  -1px -1px #80FF80, -1px  0px #80FF80, -1px  1px #80FF80,  0px -1px #80FF80,  0px  1px #80FF80,  1px -1px #80FF80,  1px  0px #80FF80,  1px  1px #80FF80,
+  -2px -2px #80FF80, -2px -1px #80FF80, -2px  0px #80FF80, -2px  1px #80FF80, -2px  2px #80FF80, -1px -2px #80FF80, -1px  2px #80FF80,  0px -2px #80FF80,
+   0px  2px #80FF80,  1px -2px #80FF80,  1px  2px #80FF80,  2px -2px #80FF80,  2px -1px #80FF80,  2px  0px #80FF80,  2px  1px #80FF80,  2px  2px #80FF80;}
+::cue(.outline1mintgreen)        {text-shadow:
+  -1px -1px #80FF80, -1px  0px #80FF80, -1px  1px #80FF80,  0px -1px #80FF80,  0px  1px #80FF80,  1px -1px #80FF80,  1px  0px #80FF80,  1px  1px #80FF80;}
+::cue(.outline3magicmint)        {text-shadow:
+  -1px -1px #80FFC0, -1px  0px #80FFC0, -1px  1px #80FFC0,  0px -1px #80FFC0,  0px  1px #80FFC0,  1px -1px #80FFC0,  1px  0px #80FFC0,  1px  1px #80FFC0,
+  -2px -2px #80FFC0, -2px -1px #80FFC0, -2px  0px #80FFC0, -2px  1px #80FFC0, -2px  2px #80FFC0, -1px -2px #80FFC0, -1px  2px #80FFC0,  0px -2px #80FFC0,
+   0px  2px #80FFC0,  1px -2px #80FFC0,  1px  2px #80FFC0,  2px -2px #80FFC0,  2px -1px #80FFC0,  2px  0px #80FFC0,  2px  1px #80FFC0,  2px  2px #80FFC0,
+  -3px -3px #80FFC0, -3px -2px #80FFC0, -3px -1px #80FFC0, -3px  0px #80FFC0, -3px  1px #80FFC0, -3px  2px #80FFC0, -3px  3px #80FFC0, -2px -3px #80FFC0,
+  -2px  3px #80FFC0, -1px -3px #80FFC0, -1px  3px #80FFC0,  0px -3px #80FFC0,  0px  3px #80FFC0,  1px -3px #80FFC0,  1px  3px #80FFC0,  2px -3px #80FFC0,
+   2px  3px #80FFC0,  3px -3px #80FFC0,  3px -2px #80FFC0,  3px -1px #80FFC0,  3px  0px #80FFC0,  3px  1px #80FFC0,  3px  2px #80FFC0,  3px  3px #80FFC0;}
+::cue(.outline2magicmint)        {text-shadow:
+  -1px -1px #80FFC0, -1px  0px #80FFC0, -1px  1px #80FFC0,  0px -1px #80FFC0,  0px  1px #80FFC0,  1px -1px #80FFC0,  1px  0px #80FFC0,  1px  1px #80FFC0,
+  -2px -2px #80FFC0, -2px -1px #80FFC0, -2px  0px #80FFC0, -2px  1px #80FFC0, -2px  2px #80FFC0, -1px -2px #80FFC0, -1px  2px #80FFC0,  0px -2px #80FFC0,
+   0px  2px #80FFC0,  1px -2px #80FFC0,  1px  2px #80FFC0,  2px -2px #80FFC0,  2px -1px #80FFC0,  2px  0px #80FFC0,  2px  1px #80FFC0,  2px  2px #80FFC0;}
+::cue(.outline1magicmint)        {text-shadow:
+  -1px -1px #80FFC0, -1px  0px #80FFC0, -1px  1px #80FFC0,  0px -1px #80FFC0,  0px  1px #80FFC0,  1px -1px #80FFC0,  1px  0px #80FFC0,  1px  1px #80FFC0;}
+::cue(.outline3turquoise)        {text-shadow:
+  -1px -1px #80FFFF, -1px  0px #80FFFF, -1px  1px #80FFFF,  0px -1px #80FFFF,  0px  1px #80FFFF,  1px -1px #80FFFF,  1px  0px #80FFFF,  1px  1px #80FFFF,
+  -2px -2px #80FFFF, -2px -1px #80FFFF, -2px  0px #80FFFF, -2px  1px #80FFFF, -2px  2px #80FFFF, -1px -2px #80FFFF, -1px  2px #80FFFF,  0px -2px #80FFFF,
+   0px  2px #80FFFF,  1px -2px #80FFFF,  1px  2px #80FFFF,  2px -2px #80FFFF,  2px -1px #80FFFF,  2px  0px #80FFFF,  2px  1px #80FFFF,  2px  2px #80FFFF,
+  -3px -3px #80FFFF, -3px -2px #80FFFF, -3px -1px #80FFFF, -3px  0px #80FFFF, -3px  1px #80FFFF, -3px  2px #80FFFF, -3px  3px #80FFFF, -2px -3px #80FFFF,
+  -2px  3px #80FFFF, -1px -3px #80FFFF, -1px  3px #80FFFF,  0px -3px #80FFFF,  0px  3px #80FFFF,  1px -3px #80FFFF,  1px  3px #80FFFF,  2px -3px #80FFFF,
+   2px  3px #80FFFF,  3px -3px #80FFFF,  3px -2px #80FFFF,  3px -1px #80FFFF,  3px  0px #80FFFF,  3px  1px #80FFFF,  3px  2px #80FFFF,  3px  3px #80FFFF;}
+::cue(.outline2turquoise)        {text-shadow:
+  -1px -1px #80FFFF, -1px  0px #80FFFF, -1px  1px #80FFFF,  0px -1px #80FFFF,  0px  1px #80FFFF,  1px -1px #80FFFF,  1px  0px #80FFFF,  1px  1px #80FFFF,
+  -2px -2px #80FFFF, -2px -1px #80FFFF, -2px  0px #80FFFF, -2px  1px #80FFFF, -2px  2px #80FFFF, -1px -2px #80FFFF, -1px  2px #80FFFF,  0px -2px #80FFFF,
+   0px  2px #80FFFF,  1px -2px #80FFFF,  1px  2px #80FFFF,  2px -2px #80FFFF,  2px -1px #80FFFF,  2px  0px #80FFFF,  2px  1px #80FFFF,  2px  2px #80FFFF;}
+::cue(.outline1turquoise)        {text-shadow:
+  -1px -1px #80FFFF, -1px  0px #80FFFF, -1px  1px #80FFFF,  0px -1px #80FFFF,  0px  1px #80FFFF,  1px -1px #80FFFF,  1px  0px #80FFFF,  1px  1px #80FFFF;}
+
+::cue(.outline3guardsman)             {text-shadow:
+  -1px -1px #C00000, -1px  0px #C00000, -1px  1px #C00000,  0px -1px #C00000,  0px  1px #C00000,  1px -1px #C00000,  1px  0px #C00000,  1px  1px #C00000,
+  -2px -2px #C00000, -2px -1px #C00000, -2px  0px #C00000, -2px  1px #C00000, -2px  2px #C00000, -1px -2px #C00000, -1px  2px #C00000,  0px -2px #C00000,
+   0px  2px #C00000,  1px -2px #C00000,  1px  2px #C00000,  2px -2px #C00000,  2px -1px #C00000,  2px  0px #C00000,  2px  1px #C00000,  2px  2px #C00000,
+  -3px -3px #C00000, -3px -2px #C00000, -3px -1px #C00000, -3px  0px #C00000, -3px  1px #C00000, -3px  2px #C00000, -3px  3px #C00000, -2px -3px #C00000,
+  -2px  3px #C00000, -1px -3px #C00000, -1px  3px #C00000,  0px -3px #C00000,  0px  3px #C00000,  1px -3px #C00000,  1px  3px #C00000,  2px -3px #C00000,
+   2px  3px #C00000,  3px -3px #C00000,  3px -2px #C00000,  3px -1px #C00000,  3px  0px #C00000,  3px  1px #C00000,  3px  2px #C00000,  3px  3px #C00000;}
+::cue(.outline2guardsman)             {text-shadow:
+  -1px -1px #C00000, -1px  0px #C00000, -1px  1px #C00000,  0px -1px #C00000,  0px  1px #C00000,  1px -1px #C00000,  1px  0px #C00000,  1px  1px #C00000,
+  -2px -2px #C00000, -2px -1px #C00000, -2px  0px #C00000, -2px  1px #C00000, -2px  2px #C00000, -1px -2px #C00000, -1px  2px #C00000,  0px -2px #C00000,
+   0px  2px #C00000,  1px -2px #C00000,  1px  2px #C00000,  2px -2px #C00000,  2px -1px #C00000,  2px  0px #C00000,  2px  1px #C00000,  2px  2px #C00000;}
+::cue(.outline1guardsman)             {text-shadow:
+  -1px -1px #C00000, -1px  0px #C00000, -1px  1px #C00000,  0px -1px #C00000,  0px  1px #C00000,  1px -1px #C00000,  1px  0px #C00000,  1px  1px #C00000;}
+::cue(.outline3monza)           {text-shadow:
+  -1px -1px #C00040, -1px  0px #C00040, -1px  1px #C00040,  0px -1px #C00040,  0px  1px #C00040,  1px -1px #C00040,  1px  0px #C00040,  1px  1px #C00040,
+  -2px -2px #C00040, -2px -1px #C00040, -2px  0px #C00040, -2px  1px #C00040, -2px  2px #C00040, -1px -2px #C00040, -1px  2px #C00040,  0px -2px #C00040,
+   0px  2px #C00040,  1px -2px #C00040,  1px  2px #C00040,  2px -2px #C00040,  2px -1px #C00040,  2px  0px #C00040,  2px  1px #C00040,  2px  2px #C00040,
+  -3px -3px #C00040, -3px -2px #C00040, -3px -1px #C00040, -3px  0px #C00040, -3px  1px #C00040, -3px  2px #C00040, -3px  3px #C00040, -2px -3px #C00040,
+  -2px  3px #C00040, -1px -3px #C00040, -1px  3px #C00040,  0px -3px #C00040,  0px  3px #C00040,  1px -3px #C00040,  1px  3px #C00040,  2px -3px #C00040,
+   2px  3px #C00040,  3px -3px #C00040,  3px -2px #C00040,  3px -1px #C00040,  3px  0px #C00040,  3px  1px #C00040,  3px  2px #C00040,  3px  3px #C00040;}
+::cue(.outline2monza)           {text-shadow:
+  -1px -1px #C00040, -1px  0px #C00040, -1px  1px #C00040,  0px -1px #C00040,  0px  1px #C00040,  1px -1px #C00040,  1px  0px #C00040,  1px  1px #C00040,
+  -2px -2px #C00040, -2px -1px #C00040, -2px  0px #C00040, -2px  1px #C00040, -2px  2px #C00040, -1px -2px #C00040, -1px  2px #C00040,  0px -2px #C00040,
+   0px  2px #C00040,  1px -2px #C00040,  1px  2px #C00040,  2px -2px #C00040,  2px -1px #C00040,  2px  0px #C00040,  2px  1px #C00040,  2px  2px #C00040;}
+::cue(.outline1monza)           {text-shadow:
+  -1px -1px #C00040, -1px  0px #C00040, -1px  1px #C00040,  0px -1px #C00040,  0px  1px #C00040,  1px -1px #C00040,  1px  0px #C00040,  1px  1px #C00040;}
+::cue(.outline3flirt)              {text-shadow:
+  -1px -1px #C00080, -1px  0px #C00080, -1px  1px #C00080,  0px -1px #C00080,  0px  1px #C00080,  1px -1px #C00080,  1px  0px #C00080,  1px  1px #C00080,
+  -2px -2px #C00080, -2px -1px #C00080, -2px  0px #C00080, -2px  1px #C00080, -2px  2px #C00080, -1px -2px #C00080, -1px  2px #C00080,  0px -2px #C00080,
+   0px  2px #C00080,  1px -2px #C00080,  1px  2px #C00080,  2px -2px #C00080,  2px -1px #C00080,  2px  0px #C00080,  2px  1px #C00080,  2px  2px #C00080,
+  -3px -3px #C00080, -3px -2px #C00080, -3px -1px #C00080, -3px  0px #C00080, -3px  1px #C00080, -3px  2px #C00080, -3px  3px #C00080, -2px -3px #C00080,
+  -2px  3px #C00080, -1px -3px #C00080, -1px  3px #C00080,  0px -3px #C00080,  0px  3px #C00080,  1px -3px #C00080,  1px  3px #C00080,  2px -3px #C00080,
+   2px  3px #C00080,  3px -3px #C00080,  3px -2px #C00080,  3px -1px #C00080,  3px  0px #C00080,  3px  1px #C00080,  3px  2px #C00080,  3px  3px #C00080;}
+::cue(.outline2flirt)              {text-shadow:
+  -1px -1px #C00080, -1px  0px #C00080, -1px  1px #C00080,  0px -1px #C00080,  0px  1px #C00080,  1px -1px #C00080,  1px  0px #C00080,  1px  1px #C00080,
+  -2px -2px #C00080, -2px -1px #C00080, -2px  0px #C00080, -2px  1px #C00080, -2px  2px #C00080, -1px -2px #C00080, -1px  2px #C00080,  0px -2px #C00080,
+   0px  2px #C00080,  1px -2px #C00080,  1px  2px #C00080,  2px -2px #C00080,  2px -1px #C00080,  2px  0px #C00080,  2px  1px #C00080,  2px  2px #C00080;}
+::cue(.outline1flirt)              {text-shadow:
+  -1px -1px #C00080, -1px  0px #C00080, -1px  1px #C00080,  0px -1px #C00080,  0px  1px #C00080,  1px -1px #C00080,  1px  0px #C00080,  1px  1px #C00080;}
+::cue(.outline3cerise)        {text-shadow:
+  -1px -1px #C000C0, -1px  0px #C000C0, -1px  1px #C000C0,  0px -1px #C000C0,  0px  1px #C000C0,  1px -1px #C000C0,  1px  0px #C000C0,  1px  1px #C000C0,
+  -2px -2px #C000C0, -2px -1px #C000C0, -2px  0px #C000C0, -2px  1px #C000C0, -2px  2px #C000C0, -1px -2px #C000C0, -1px  2px #C000C0,  0px -2px #C000C0,
+   0px  2px #C000C0,  1px -2px #C000C0,  1px  2px #C000C0,  2px -2px #C000C0,  2px -1px #C000C0,  2px  0px #C000C0,  2px  1px #C000C0,  2px  2px #C000C0,
+  -3px -3px #C000C0, -3px -2px #C000C0, -3px -1px #C000C0, -3px  0px #C000C0, -3px  1px #C000C0, -3px  2px #C000C0, -3px  3px #C000C0, -2px -3px #C000C0,
+  -2px  3px #C000C0, -1px -3px #C000C0, -1px  3px #C000C0,  0px -3px #C000C0,  0px  3px #C000C0,  1px -3px #C000C0,  1px  3px #C000C0,  2px -3px #C000C0,
+   2px  3px #C000C0,  3px -3px #C000C0,  3px -2px #C000C0,  3px -1px #C000C0,  3px  0px #C000C0,  3px  1px #C000C0,  3px  2px #C000C0,  3px  3px #C000C0;}
+::cue(.outline2cerise)        {text-shadow:
+  -1px -1px #C000C0, -1px  0px #C000C0, -1px  1px #C000C0,  0px -1px #C000C0,  0px  1px #C000C0,  1px -1px #C000C0,  1px  0px #C000C0,  1px  1px #C000C0,
+  -2px -2px #C000C0, -2px -1px #C000C0, -2px  0px #C000C0, -2px  1px #C000C0, -2px  2px #C000C0, -1px -2px #C000C0, -1px  2px #C000C0,  0px -2px #C000C0,
+   0px  2px #C000C0,  1px -2px #C000C0,  1px  2px #C000C0,  2px -2px #C000C0,  2px -1px #C000C0,  2px  0px #C000C0,  2px  1px #C000C0,  2px  2px #C000C0;}
+::cue(.outline1cerise)        {text-shadow:
+  -1px -1px #C000C0, -1px  0px #C000C0, -1px  1px #C000C0,  0px -1px #C000C0,  0px  1px #C000C0,  1px -1px #C000C0,  1px  0px #C000C0,  1px  1px #C000C0;}
+::cue(.outline3purpleheart)              {text-shadow:
+  -1px -1px #C000FF, -1px  0px #C000FF, -1px  1px #C000FF,  0px -1px #C000FF,  0px  1px #C000FF,  1px -1px #C000FF,  1px  0px #C000FF,  1px  1px #C000FF,
+  -2px -2px #C000FF, -2px -1px #C000FF, -2px  0px #C000FF, -2px  1px #C000FF, -2px  2px #C000FF, -1px -2px #C000FF, -1px  2px #C000FF,  0px -2px #C000FF,
+   0px  2px #C000FF,  1px -2px #C000FF,  1px  2px #C000FF,  2px -2px #C000FF,  2px -1px #C000FF,  2px  0px #C000FF,  2px  1px #C000FF,  2px  2px #C000FF,
+  -3px -3px #C000FF, -3px -2px #C000FF, -3px -1px #C000FF, -3px  0px #C000FF, -3px  1px #C000FF, -3px  2px #C000FF, -3px  3px #C000FF, -2px -3px #C000FF,
+  -2px  3px #C000FF, -1px -3px #C000FF, -1px  3px #C000FF,  0px -3px #C000FF,  0px  3px #C000FF,  1px -3px #C000FF,  1px  3px #C000FF,  2px -3px #C000FF,
+   2px  3px #C000FF,  3px -3px #C000FF,  3px -2px #C000FF,  3px -1px #C000FF,  3px  0px #C000FF,  3px  1px #C000FF,  3px  2px #C000FF,  3px  3px #C000FF;}
+::cue(.outline2purpleheart)              {text-shadow:
+  -1px -1px #C000FF, -1px  0px #C000FF, -1px  1px #C000FF,  0px -1px #C000FF,  0px  1px #C000FF,  1px -1px #C000FF,  1px  0px #C000FF,  1px  1px #C000FF,
+  -2px -2px #C000FF, -2px -1px #C000FF, -2px  0px #C000FF, -2px  1px #C000FF, -2px  2px #C000FF, -1px -2px #C000FF, -1px  2px #C000FF,  0px -2px #C000FF,
+   0px  2px #C000FF,  1px -2px #C000FF,  1px  2px #C000FF,  2px -2px #C000FF,  2px -1px #C000FF,  2px  0px #C000FF,  2px  1px #C000FF,  2px  2px #C000FF;}
+::cue(.outline1purpleheart)              {text-shadow:
+  -1px -1px #C000FF, -1px  0px #C000FF, -1px  1px #C000FF,  0px -1px #C000FF,  0px  1px #C000FF,  1px -1px #C000FF,  1px  0px #C000FF,  1px  1px #C000FF;}
+::cue(.outline3sharonrose)        {text-shadow:
+  -1px -1px #C04000, -1px  0px #C04000, -1px  1px #C04000,  0px -1px #C04000,  0px  1px #C04000,  1px -1px #C04000,  1px  0px #C04000,  1px  1px #C04000,
+  -2px -2px #C04000, -2px -1px #C04000, -2px  0px #C04000, -2px  1px #C04000, -2px  2px #C04000, -1px -2px #C04000, -1px  2px #C04000,  0px -2px #C04000,
+   0px  2px #C04000,  1px -2px #C04000,  1px  2px #C04000,  2px -2px #C04000,  2px -1px #C04000,  2px  0px #C04000,  2px  1px #C04000,  2px  2px #C04000,
+  -3px -3px #C04000, -3px -2px #C04000, -3px -1px #C04000, -3px  0px #C04000, -3px  1px #C04000, -3px  2px #C04000, -3px  3px #C04000, -2px -3px #C04000,
+  -2px  3px #C04000, -1px -3px #C04000, -1px  3px #C04000,  0px -3px #C04000,  0px  3px #C04000,  1px -3px #C04000,  1px  3px #C04000,  2px -3px #C04000,
+   2px  3px #C04000,  3px -3px #C04000,  3px -2px #C04000,  3px -1px #C04000,  3px  0px #C04000,  3px  1px #C04000,  3px  2px #C04000,  3px  3px #C04000;}
+::cue(.outline2sharonrose)        {text-shadow:
+  -1px -1px #C04000, -1px  0px #C04000, -1px  1px #C04000,  0px -1px #C04000,  0px  1px #C04000,  1px -1px #C04000,  1px  0px #C04000,  1px  1px #C04000,
+  -2px -2px #C04000, -2px -1px #C04000, -2px  0px #C04000, -2px  1px #C04000, -2px  2px #C04000, -1px -2px #C04000, -1px  2px #C04000,  0px -2px #C04000,
+   0px  2px #C04000,  1px -2px #C04000,  1px  2px #C04000,  2px -2px #C04000,  2px -1px #C04000,  2px  0px #C04000,  2px  1px #C04000,  2px  2px #C04000;}
+::cue(.outline1sharonrose)        {text-shadow:
+  -1px -1px #C04000, -1px  0px #C04000, -1px  1px #C04000,  0px -1px #C04000,  0px  1px #C04000,  1px -1px #C04000,  1px  0px #C04000,  1px  1px #C04000;}
+::cue(.outline3crail)        {text-shadow:
+  -1px -1px #C04040, -1px  0px #C04040, -1px  1px #C04040,  0px -1px #C04040,  0px  1px #C04040,  1px -1px #C04040,  1px  0px #C04040,  1px  1px #C04040,
+  -2px -2px #C04040, -2px -1px #C04040, -2px  0px #C04040, -2px  1px #C04040, -2px  2px #C04040, -1px -2px #C04040, -1px  2px #C04040,  0px -2px #C04040,
+   0px  2px #C04040,  1px -2px #C04040,  1px  2px #C04040,  2px -2px #C04040,  2px -1px #C04040,  2px  0px #C04040,  2px  1px #C04040,  2px  2px #C04040,
+  -3px -3px #C04040, -3px -2px #C04040, -3px -1px #C04040, -3px  0px #C04040, -3px  1px #C04040, -3px  2px #C04040, -3px  3px #C04040, -2px -3px #C04040,
+  -2px  3px #C04040, -1px -3px #C04040, -1px  3px #C04040,  0px -3px #C04040,  0px  3px #C04040,  1px -3px #C04040,  1px  3px #C04040,  2px -3px #C04040,
+   2px  3px #C04040,  3px -3px #C04040,  3px -2px #C04040,  3px -1px #C04040,  3px  0px #C04040,  3px  1px #C04040,  3px  2px #C04040,  3px  3px #C04040;}
+::cue(.outline2crail)        {text-shadow:
+  -1px -1px #C04040, -1px  0px #C04040, -1px  1px #C04040,  0px -1px #C04040,  0px  1px #C04040,  1px -1px #C04040,  1px  0px #C04040,  1px  1px #C04040,
+  -2px -2px #C04040, -2px -1px #C04040, -2px  0px #C04040, -2px  1px #C04040, -2px  2px #C04040, -1px -2px #C04040, -1px  2px #C04040,  0px -2px #C04040,
+   0px  2px #C04040,  1px -2px #C04040,  1px  2px #C04040,  2px -2px #C04040,  2px -1px #C04040,  2px  0px #C04040,  2px  1px #C04040,  2px  2px #C04040;}
+::cue(.outline1crail)        {text-shadow:
+  -1px -1px #C04040, -1px  0px #C04040, -1px  1px #C04040,  0px -1px #C04040,  0px  1px #C04040,  1px -1px #C04040,  1px  0px #C04040,  1px  1px #C04040;}
+::cue(.outline3mulberry)        {text-shadow:
+  -1px -1px #C04080, -1px  0px #C04080, -1px  1px #C04080,  0px -1px #C04080,  0px  1px #C04080,  1px -1px #C04080,  1px  0px #C04080,  1px  1px #C04080,
+  -2px -2px #C04080, -2px -1px #C04080, -2px  0px #C04080, -2px  1px #C04080, -2px  2px #C04080, -1px -2px #C04080, -1px  2px #C04080,  0px -2px #C04080,
+   0px  2px #C04080,  1px -2px #C04080,  1px  2px #C04080,  2px -2px #C04080,  2px -1px #C04080,  2px  0px #C04080,  2px  1px #C04080,  2px  2px #C04080,
+  -3px -3px #C04080, -3px -2px #C04080, -3px -1px #C04080, -3px  0px #C04080, -3px  1px #C04080, -3px  2px #C04080, -3px  3px #C04080, -2px -3px #C04080,
+  -2px  3px #C04080, -1px -3px #C04080, -1px  3px #C04080,  0px -3px #C04080,  0px  3px #C04080,  1px -3px #C04080,  1px  3px #C04080,  2px -3px #C04080,
+   2px  3px #C04080,  3px -3px #C04080,  3px -2px #C04080,  3px -1px #C04080,  3px  0px #C04080,  3px  1px #C04080,  3px  2px #C04080,  3px  3px #C04080;}
+::cue(.outline2mulberry)        {text-shadow:
+  -1px -1px #C04080, -1px  0px #C04080, -1px  1px #C04080,  0px -1px #C04080,  0px  1px #C04080,  1px -1px #C04080,  1px  0px #C04080,  1px  1px #C04080,
+  -2px -2px #C04080, -2px -1px #C04080, -2px  0px #C04080, -2px  1px #C04080, -2px  2px #C04080, -1px -2px #C04080, -1px  2px #C04080,  0px -2px #C04080,
+   0px  2px #C04080,  1px -2px #C04080,  1px  2px #C04080,  2px -2px #C04080,  2px -1px #C04080,  2px  0px #C04080,  2px  1px #C04080,  2px  2px #C04080;}
+::cue(.outline1mulberry)        {text-shadow:
+  -1px -1px #C04080, -1px  0px #C04080, -1px  1px #C04080,  0px -1px #C04080,  0px  1px #C04080,  1px -1px #C04080,  1px  0px #C04080,  1px  1px #C04080;}
+::cue(.outline3amethyst)        {text-shadow:
+  -1px -1px #C040C0, -1px  0px #C040C0, -1px  1px #C040C0,  0px -1px #C040C0,  0px  1px #C040C0,  1px -1px #C040C0,  1px  0px #C040C0,  1px  1px #C040C0,
+  -2px -2px #C040C0, -2px -1px #C040C0, -2px  0px #C040C0, -2px  1px #C040C0, -2px  2px #C040C0, -1px -2px #C040C0, -1px  2px #C040C0,  0px -2px #C040C0,
+   0px  2px #C040C0,  1px -2px #C040C0,  1px  2px #C040C0,  2px -2px #C040C0,  2px -1px #C040C0,  2px  0px #C040C0,  2px  1px #C040C0,  2px  2px #C040C0,
+  -3px -3px #C040C0, -3px -2px #C040C0, -3px -1px #C040C0, -3px  0px #C040C0, -3px  1px #C040C0, -3px  2px #C040C0, -3px  3px #C040C0, -2px -3px #C040C0,
+  -2px  3px #C040C0, -1px -3px #C040C0, -1px  3px #C040C0,  0px -3px #C040C0,  0px  3px #C040C0,  1px -3px #C040C0,  1px  3px #C040C0,  2px -3px #C040C0,
+   2px  3px #C040C0,  3px -3px #C040C0,  3px -2px #C040C0,  3px -1px #C040C0,  3px  0px #C040C0,  3px  1px #C040C0,  3px  2px #C040C0,  3px  3px #C040C0;}
+::cue(.outline2amethyst)        {text-shadow:
+  -1px -1px #C040C0, -1px  0px #C040C0, -1px  1px #C040C0,  0px -1px #C040C0,  0px  1px #C040C0,  1px -1px #C040C0,  1px  0px #C040C0,  1px  1px #C040C0,
+  -2px -2px #C040C0, -2px -1px #C040C0, -2px  0px #C040C0, -2px  1px #C040C0, -2px  2px #C040C0, -1px -2px #C040C0, -1px  2px #C040C0,  0px -2px #C040C0,
+   0px  2px #C040C0,  1px -2px #C040C0,  1px  2px #C040C0,  2px -2px #C040C0,  2px -1px #C040C0,  2px  0px #C040C0,  2px  1px #C040C0,  2px  2px #C040C0;}
+::cue(.outline1amethyst)        {text-shadow:
+  -1px -1px #C040C0, -1px  0px #C040C0, -1px  1px #C040C0,  0px -1px #C040C0,  0px  1px #C040C0,  1px -1px #C040C0,  1px  0px #C040C0,  1px  1px #C040C0;}
+::cue(.outline3violet)        {text-shadow:
+  -1px -1px #C040FF, -1px  0px #C040FF, -1px  1px #C040FF,  0px -1px #C040FF,  0px  1px #C040FF,  1px -1px #C040FF,  1px  0px #C040FF,  1px  1px #C040FF,
+  -2px -2px #C040FF, -2px -1px #C040FF, -2px  0px #C040FF, -2px  1px #C040FF, -2px  2px #C040FF, -1px -2px #C040FF, -1px  2px #C040FF,  0px -2px #C040FF,
+   0px  2px #C040FF,  1px -2px #C040FF,  1px  2px #C040FF,  2px -2px #C040FF,  2px -1px #C040FF,  2px  0px #C040FF,  2px  1px #C040FF,  2px  2px #C040FF,
+  -3px -3px #C040FF, -3px -2px #C040FF, -3px -1px #C040FF, -3px  0px #C040FF, -3px  1px #C040FF, -3px  2px #C040FF, -3px  3px #C040FF, -2px -3px #C040FF,
+  -2px  3px #C040FF, -1px -3px #C040FF, -1px  3px #C040FF,  0px -3px #C040FF,  0px  3px #C040FF,  1px -3px #C040FF,  1px  3px #C040FF,  2px -3px #C040FF,
+   2px  3px #C040FF,  3px -3px #C040FF,  3px -2px #C040FF,  3px -1px #C040FF,  3px  0px #C040FF,  3px  1px #C040FF,  3px  2px #C040FF,  3px  3px #C040FF;}
+::cue(.outline2violet)        {text-shadow:
+  -1px -1px #C040FF, -1px  0px #C040FF, -1px  1px #C040FF,  0px -1px #C040FF,  0px  1px #C040FF,  1px -1px #C040FF,  1px  0px #C040FF,  1px  1px #C040FF,
+  -2px -2px #C040FF, -2px -1px #C040FF, -2px  0px #C040FF, -2px  1px #C040FF, -2px  2px #C040FF, -1px -2px #C040FF, -1px  2px #C040FF,  0px -2px #C040FF,
+   0px  2px #C040FF,  1px -2px #C040FF,  1px  2px #C040FF,  2px -2px #C040FF,  2px -1px #C040FF,  2px  0px #C040FF,  2px  1px #C040FF,  2px  2px #C040FF;}
+::cue(.outline1violet)        {text-shadow:
+  -1px -1px #C040FF, -1px  0px #C040FF, -1px  1px #C040FF,  0px -1px #C040FF,  0px  1px #C040FF,  1px -1px #C040FF,  1px  0px #C040FF,  1px  1px #C040FF;}
+::cue(.outline3pirategold)        {text-shadow:
+  -1px -1px #C08000, -1px  0px #C08000, -1px  1px #C08000,  0px -1px #C08000,  0px  1px #C08000,  1px -1px #C08000,  1px  0px #C08000,  1px  1px #C08000,
+  -2px -2px #C08000, -2px -1px #C08000, -2px  0px #C08000, -2px  1px #C08000, -2px  2px #C08000, -1px -2px #C08000, -1px  2px #C08000,  0px -2px #C08000,
+   0px  2px #C08000,  1px -2px #C08000,  1px  2px #C08000,  2px -2px #C08000,  2px -1px #C08000,  2px  0px #C08000,  2px  1px #C08000,  2px  2px #C08000,
+  -3px -3px #C08000, -3px -2px #C08000, -3px -1px #C08000, -3px  0px #C08000, -3px  1px #C08000, -3px  2px #C08000, -3px  3px #C08000, -2px -3px #C08000,
+  -2px  3px #C08000, -1px -3px #C08000, -1px  3px #C08000,  0px -3px #C08000,  0px  3px #C08000,  1px -3px #C08000,  1px  3px #C08000,  2px -3px #C08000,
+   2px  3px #C08000,  3px -3px #C08000,  3px -2px #C08000,  3px -1px #C08000,  3px  0px #C08000,  3px  1px #C08000,  3px  2px #C08000,  3px  3px #C08000;}
+::cue(.outline2pirategold)        {text-shadow:
+  -1px -1px #C08000, -1px  0px #C08000, -1px  1px #C08000,  0px -1px #C08000,  0px  1px #C08000,  1px -1px #C08000,  1px  0px #C08000,  1px  1px #C08000,
+  -2px -2px #C08000, -2px -1px #C08000, -2px  0px #C08000, -2px  1px #C08000, -2px  2px #C08000, -1px -2px #C08000, -1px  2px #C08000,  0px -2px #C08000,
+   0px  2px #C08000,  1px -2px #C08000,  1px  2px #C08000,  2px -2px #C08000,  2px -1px #C08000,  2px  0px #C08000,  2px  1px #C08000,  2px  2px #C08000;}
+::cue(.outline1pirategold)        {text-shadow:
+  -1px -1px #C08000, -1px  0px #C08000, -1px  1px #C08000,  0px -1px #C08000,  0px  1px #C08000,  1px -1px #C08000,  1px  0px #C08000,  1px  1px #C08000;}
+::cue(.outline3tussock)        {text-shadow:
+  -1px -1px #C08040, -1px  0px #C08040, -1px  1px #C08040,  0px -1px #C08040,  0px  1px #C08040,  1px -1px #C08040,  1px  0px #C08040,  1px  1px #C08040,
+  -2px -2px #C08040, -2px -1px #C08040, -2px  0px #C08040, -2px  1px #C08040, -2px  2px #C08040, -1px -2px #C08040, -1px  2px #C08040,  0px -2px #C08040,
+   0px  2px #C08040,  1px -2px #C08040,  1px  2px #C08040,  2px -2px #C08040,  2px -1px #C08040,  2px  0px #C08040,  2px  1px #C08040,  2px  2px #C08040,
+  -3px -3px #C08040, -3px -2px #C08040, -3px -1px #C08040, -3px  0px #C08040, -3px  1px #C08040, -3px  2px #C08040, -3px  3px #C08040, -2px -3px #C08040,
+  -2px  3px #C08040, -1px -3px #C08040, -1px  3px #C08040,  0px -3px #C08040,  0px  3px #C08040,  1px -3px #C08040,  1px  3px #C08040,  2px -3px #C08040,
+   2px  3px #C08040,  3px -3px #C08040,  3px -2px #C08040,  3px -1px #C08040,  3px  0px #C08040,  3px  1px #C08040,  3px  2px #C08040,  3px  3px #C08040;}
+::cue(.outline2tussock)        {text-shadow:
+  -1px -1px #C08040, -1px  0px #C08040, -1px  1px #C08040,  0px -1px #C08040,  0px  1px #C08040,  1px -1px #C08040,  1px  0px #C08040,  1px  1px #C08040,
+  -2px -2px #C08040, -2px -1px #C08040, -2px  0px #C08040, -2px  1px #C08040, -2px  2px #C08040, -1px -2px #C08040, -1px  2px #C08040,  0px -2px #C08040,
+   0px  2px #C08040,  1px -2px #C08040,  1px  2px #C08040,  2px -2px #C08040,  2px -1px #C08040,  2px  0px #C08040,  2px  1px #C08040,  2px  2px #C08040;}
+::cue(.outline1tussock)        {text-shadow:
+  -1px -1px #C08080, -1px  0px #C08080, -1px  1px #C08080,  0px -1px #C08080,  0px  1px #C08080,  1px -1px #C08080,  1px  0px #C08080,  1px  1px #C08080;}
+::cue(.outline3oldrose)        {text-shadow:
+  -1px -1px #C08080, -1px  0px #C08080, -1px  1px #C08080,  0px -1px #C08080,  0px  1px #C08080,  1px -1px #C08080,  1px  0px #C08080,  1px  1px #C08080,
+  -2px -2px #C08080, -2px -1px #C08080, -2px  0px #C08080, -2px  1px #C08080, -2px  2px #C08080, -1px -2px #C08080, -1px  2px #C08080,  0px -2px #C08080,
+   0px  2px #C08080,  1px -2px #C08080,  1px  2px #C08080,  2px -2px #C08080,  2px -1px #C08080,  2px  0px #C08080,  2px  1px #C08080,  2px  2px #C08080,
+  -3px -3px #C08080, -3px -2px #C08080, -3px -1px #C08080, -3px  0px #C08080, -3px  1px #C08080, -3px  2px #C08080, -3px  3px #C08080, -2px -3px #C08080,
+  -2px  3px #C08080, -1px -3px #C08080, -1px  3px #C08080,  0px -3px #C08080,  0px  3px #C08080,  1px -3px #C08080,  1px  3px #C08080,  2px -3px #C08080,
+   2px  3px #C08080,  3px -3px #C08080,  3px -2px #C08080,  3px -1px #C08080,  3px  0px #C08080,  3px  1px #C08080,  3px  2px #C08080,  3px  3px #C08080;}
+::cue(.outline2oldrose)        {text-shadow:
+  -1px -1px #C08080, -1px  0px #C08080, -1px  1px #C08080,  0px -1px #C08080,  0px  1px #C08080,  1px -1px #C08080,  1px  0px #C08080,  1px  1px #C08080,
+  -2px -2px #C08080, -2px -1px #C08080, -2px  0px #C08080, -2px  1px #C08080, -2px  2px #C08080, -1px -2px #C08080, -1px  2px #C08080,  0px -2px #C08080,
+   0px  2px #C08080,  1px -2px #C08080,  1px  2px #C08080,  2px -2px #C08080,  2px -1px #C08080,  2px  0px #C08080,  2px  1px #C08080,  2px  2px #C08080;}
+::cue(.outline1oldrose)        {text-shadow:
+  -1px -1px #C08080, -1px  0px #C08080, -1px  1px #C08080,  0px -1px #C08080,  0px  1px #C08080,  1px -1px #C08080,  1px  0px #C08080,  1px  1px #C08080;}
+::cue(.outline3viola)        {text-shadow:
+  -1px -1px #C080C0, -1px  0px #C080C0, -1px  1px #C080C0,  0px -1px #C080C0,  0px  1px #C080C0,  1px -1px #C080C0,  1px  0px #C080C0,  1px  1px #C080C0,
+  -2px -2px #C080C0, -2px -1px #C080C0, -2px  0px #C080C0, -2px  1px #C080C0, -2px  2px #C080C0, -1px -2px #C080C0, -1px  2px #C080C0,  0px -2px #C080C0,
+   0px  2px #C080C0,  1px -2px #C080C0,  1px  2px #C080C0,  2px -2px #C080C0,  2px -1px #C080C0,  2px  0px #C080C0,  2px  1px #C080C0,  2px  2px #C080C0,
+  -3px -3px #C080C0, -3px -2px #C080C0, -3px -1px #C080C0, -3px  0px #C080C0, -3px  1px #C080C0, -3px  2px #C080C0, -3px  3px #C080C0, -2px -3px #C080C0,
+  -2px  3px #C080C0, -1px -3px #C080C0, -1px  3px #C080C0,  0px -3px #C080C0,  0px  3px #C080C0,  1px -3px #C080C0,  1px  3px #C080C0,  2px -3px #C080C0,
+   2px  3px #C080C0,  3px -3px #C080C0,  3px -2px #C080C0,  3px -1px #C080C0,  3px  0px #C080C0,  3px  1px #C080C0,  3px  2px #C080C0,  3px  3px #C080C0;}
+::cue(.outline2viola)        {text-shadow:
+  -1px -1px #C080C0, -1px  0px #C080C0, -1px  1px #C080C0,  0px -1px #C080C0,  0px  1px #C080C0,  1px -1px #C080C0,  1px  0px #C080C0,  1px  1px #C080C0,
+  -2px -2px #C080C0, -2px -1px #C080C0, -2px  0px #C080C0, -2px  1px #C080C0, -2px  2px #C080C0, -1px -2px #C080C0, -1px  2px #C080C0,  0px -2px #C080C0,
+   0px  2px #C080C0,  1px -2px #C080C0,  1px  2px #C080C0,  2px -2px #C080C0,  2px -1px #C080C0,  2px  0px #C080C0,  2px  1px #C080C0,  2px  2px #C080C0;}
+::cue(.outline1viola)        {text-shadow:
+  -1px -1px #C080C0, -1px  0px #C080C0, -1px  1px #C080C0,  0px -1px #C080C0,  0px  1px #C080C0,  1px -1px #C080C0,  1px  0px #C080C0,  1px  1px #C080C0;}
+::cue(.outline3orchid)        {text-shadow:
+  -1px -1px #C080FF, -1px  0px #C080FF, -1px  1px #C080FF,  0px -1px #C080FF,  0px  1px #C080FF,  1px -1px #C080FF,  1px  0px #C080FF,  1px  1px #C080FF,
+  -2px -2px #C080FF, -2px -1px #C080FF, -2px  0px #C080FF, -2px  1px #C080FF, -2px  2px #C080FF, -1px -2px #C080FF, -1px  2px #C080FF,  0px -2px #C080FF,
+   0px  2px #C080FF,  1px -2px #C080FF,  1px  2px #C080FF,  2px -2px #C080FF,  2px -1px #C080FF,  2px  0px #C080FF,  2px  1px #C080FF,  2px  2px #C080FF,
+  -3px -3px #C080FF, -3px -2px #C080FF, -3px -1px #C080FF, -3px  0px #C080FF, -3px  1px #C080FF, -3px  2px #C080FF, -3px  3px #C080FF, -2px -3px #C080FF,
+  -2px  3px #C080FF, -1px -3px #C080FF, -1px  3px #C080FF,  0px -3px #C080FF,  0px  3px #C080FF,  1px -3px #C080FF,  1px  3px #C080FF,  2px -3px #C080FF,
+   2px  3px #C080FF,  3px -3px #C080FF,  3px -2px #C080FF,  3px -1px #C080FF,  3px  0px #C080FF,  3px  1px #C080FF,  3px  2px #C080FF,  3px  3px #C080FF;}
+::cue(.outline2orchid)        {text-shadow:
+  -1px -1px #C080FF, -1px  0px #C080FF, -1px  1px #C080FF,  0px -1px #C080FF,  0px  1px #C080FF,  1px -1px #C080FF,  1px  0px #C080FF,  1px  1px #C080FF,
+  -2px -2px #C080FF, -2px -1px #C080FF, -2px  0px #C080FF, -2px  1px #C080FF, -2px  2px #C080FF, -1px -2px #C080FF, -1px  2px #C080FF,  0px -2px #C080FF,
+   0px  2px #C080FF,  1px -2px #C080FF,  1px  2px #C080FF,  2px -2px #C080FF,  2px -1px #C080FF,  2px  0px #C080FF,  2px  1px #C080FF,  2px  2px #C080FF;}
+::cue(.outline1orchid)        {text-shadow:
+  -1px -1px #C080FF, -1px  0px #C080FF, -1px  1px #C080FF,  0px -1px #C080FF,  0px  1px #C080FF,  1px -1px #C080FF,  1px  0px #C080FF,  1px  1px #C080FF;}
+::cue(.outline3buddhagold)        {text-shadow:
+  -1px -1px #C0C000, -1px  0px #C0C000, -1px  1px #C0C000,  0px -1px #C0C000,  0px  1px #C0C000,  1px -1px #C0C000,  1px  0px #C0C000,  1px  1px #C0C000,
+  -2px -2px #C0C000, -2px -1px #C0C000, -2px  0px #C0C000, -2px  1px #C0C000, -2px  2px #C0C000, -1px -2px #C0C000, -1px  2px #C0C000,  0px -2px #C0C000,
+   0px  2px #C0C000,  1px -2px #C0C000,  1px  2px #C0C000,  2px -2px #C0C000,  2px -1px #C0C000,  2px  0px #C0C000,  2px  1px #C0C000,  2px  2px #C0C000,
+  -3px -3px #C0C000, -3px -2px #C0C000, -3px -1px #C0C000, -3px  0px #C0C000, -3px  1px #C0C000, -3px  2px #C0C000, -3px  3px #C0C000, -2px -3px #C0C000,
+  -2px  3px #C0C000, -1px -3px #C0C000, -1px  3px #C0C000,  0px -3px #C0C000,  0px  3px #C0C000,  1px -3px #C0C000,  1px  3px #C0C000,  2px -3px #C0C000,
+   2px  3px #C0C000,  3px -3px #C0C000,  3px -2px #C0C000,  3px -1px #C0C000,  3px  0px #C0C000,  3px  1px #C0C000,  3px  2px #C0C000,  3px  3px #C0C000;}
+::cue(.outline2buddhagold)        {text-shadow:
+  -1px -1px #C0C000, -1px  0px #C0C000, -1px  1px #C0C000,  0px -1px #C0C000,  0px  1px #C0C000,  1px -1px #C0C000,  1px  0px #C0C000,  1px  1px #C0C000,
+  -2px -2px #C0C000, -2px -1px #C0C000, -2px  0px #C0C000, -2px  1px #C0C000, -2px  2px #C0C000, -1px -2px #C0C000, -1px  2px #C0C000,  0px -2px #C0C000,
+   0px  2px #C0C000,  1px -2px #C0C000,  1px  2px #C0C000,  2px -2px #C0C000,  2px -1px #C0C000,  2px  0px #C0C000,  2px  1px #C0C000,  2px  2px #C0C000;}
+::cue(.outline1buddhagold)        {text-shadow:
+  -1px -1px #C0C000, -1px  0px #C0C000, -1px  1px #C0C000,  0px -1px #C0C000,  0px  1px #C0C000,  1px -1px #C0C000,  1px  0px #C0C000,  1px  1px #C0C000;}
+::cue(.outline3turmeric)        {text-shadow:
+  -1px -1px #C0C040, -1px  0px #C0C040, -1px  1px #C0C040,  0px -1px #C0C040,  0px  1px #C0C040,  1px -1px #C0C040,  1px  0px #C0C040,  1px  1px #C0C040,
+  -2px -2px #C0C040, -2px -1px #C0C040, -2px  0px #C0C040, -2px  1px #C0C040, -2px  2px #C0C040, -1px -2px #C0C040, -1px  2px #C0C040,  0px -2px #C0C040,
+   0px  2px #C0C040,  1px -2px #C0C040,  1px  2px #C0C040,  2px -2px #C0C040,  2px -1px #C0C040,  2px  0px #C0C040,  2px  1px #C0C040,  2px  2px #C0C040,
+  -3px -3px #C0C040, -3px -2px #C0C040, -3px -1px #C0C040, -3px  0px #C0C040, -3px  1px #C0C040, -3px  2px #C0C040, -3px  3px #C0C040, -2px -3px #C0C040,
+  -2px  3px #C0C040, -1px -3px #C0C040, -1px  3px #C0C040,  0px -3px #C0C040,  0px  3px #C0C040,  1px -3px #C0C040,  1px  3px #C0C040,  2px -3px #C0C040,
+   2px  3px #C0C040,  3px -3px #C0C040,  3px -2px #C0C040,  3px -1px #C0C040,  3px  0px #C0C040,  3px  1px #C0C040,  3px  2px #C0C040,  3px  3px #C0C040;}
+::cue(.outline2turmeric)        {text-shadow:
+  -1px -1px #C0C040, -1px  0px #C0C040, -1px  1px #C0C040,  0px -1px #C0C040,  0px  1px #C0C040,  1px -1px #C0C040,  1px  0px #C0C040,  1px  1px #C0C040,
+  -2px -2px #C0C040, -2px -1px #C0C040, -2px  0px #C0C040, -2px  1px #C0C040, -2px  2px #C0C040, -1px -2px #C0C040, -1px  2px #C0C040,  0px -2px #C0C040,
+   0px  2px #C0C040,  1px -2px #C0C040,  1px  2px #C0C040,  2px -2px #C0C040,  2px -1px #C0C040,  2px  0px #C0C040,  2px  1px #C0C040,  2px  2px #C0C040;}
+::cue(.outline1turmeric)        {text-shadow:
+  -1px -1px #C0C040, -1px  0px #C0C040, -1px  1px #C0C040,  0px -1px #C0C040,  0px  1px #C0C040,  1px -1px #C0C040,  1px  0px #C0C040,  1px  1px #C0C040;}
+::cue(.outline3pineglade)        {text-shadow:
+  -1px -1px #C0C080, -1px  0px #C0C080, -1px  1px #C0C080,  0px -1px #C0C080,  0px  1px #C0C080,  1px -1px #C0C080,  1px  0px #C0C080,  1px  1px #C0C080,
+  -2px -2px #C0C080, -2px -1px #C0C080, -2px  0px #C0C080, -2px  1px #C0C080, -2px  2px #C0C080, -1px -2px #C0C080, -1px  2px #C0C080,  0px -2px #C0C080,
+   0px  2px #C0C080,  1px -2px #C0C080,  1px  2px #C0C080,  2px -2px #C0C080,  2px -1px #C0C080,  2px  0px #C0C080,  2px  1px #C0C080,  2px  2px #C0C080,
+  -3px -3px #C0C080, -3px -2px #C0C080, -3px -1px #C0C080, -3px  0px #C0C080, -3px  1px #C0C080, -3px  2px #C0C080, -3px  3px #C0C080, -2px -3px #C0C080,
+  -2px  3px #C0C080, -1px -3px #C0C080, -1px  3px #C0C080,  0px -3px #C0C080,  0px  3px #C0C080,  1px -3px #C0C080,  1px  3px #C0C080,  2px -3px #C0C080,
+   2px  3px #C0C080,  3px -3px #C0C080,  3px -2px #C0C080,  3px -1px #C0C080,  3px  0px #C0C080,  3px  1px #C0C080,  3px  2px #C0C080,  3px  3px #C0C080;}
+::cue(.outline2pineglade)        {text-shadow:
+  -1px -1px #C0C080, -1px  0px #C0C080, -1px  1px #C0C080,  0px -1px #C0C080,  0px  1px #C0C080,  1px -1px #C0C080,  1px  0px #C0C080,  1px  1px #C0C080,
+  -2px -2px #C0C080, -2px -1px #C0C080, -2px  0px #C0C080, -2px  1px #C0C080, -2px  2px #C0C080, -1px -2px #C0C080, -1px  2px #C0C080,  0px -2px #C0C080,
+   0px  2px #C0C080,  1px -2px #C0C080,  1px  2px #C0C080,  2px -2px #C0C080,  2px -1px #C0C080,  2px  0px #C0C080,  2px  1px #C0C080,  2px  2px #C0C080;}
+::cue(.outline1pineglade)        {text-shadow:
+  -1px -1px #C0C080, -1px  0px #C0C080, -1px  1px #C0C080,  0px -1px #C0C080,  0px  1px #C0C080,  1px -1px #C0C080,  1px  0px #C0C080,  1px  1px #C0C080;}
+::cue(.outline3silver)        {text-shadow:
+  -1px -1px #C0C0C0, -1px  0px #C0C0C0, -1px  1px #C0C0C0,  0px -1px #C0C0C0,  0px  1px #C0C0C0,  1px -1px #C0C0C0,  1px  0px #C0C0C0,  1px  1px #C0C0C0,
+  -2px -2px #C0C0C0, -2px -1px #C0C0C0, -2px  0px #C0C0C0, -2px  1px #C0C0C0, -2px  2px #C0C0C0, -1px -2px #C0C0C0, -1px  2px #C0C0C0,  0px -2px #C0C0C0,
+   0px  2px #C0C0C0,  1px -2px #C0C0C0,  1px  2px #C0C0C0,  2px -2px #C0C0C0,  2px -1px #C0C0C0,  2px  0px #C0C0C0,  2px  1px #C0C0C0,  2px  2px #C0C0C0,
+  -3px -3px #C0C0C0, -3px -2px #C0C0C0, -3px -1px #C0C0C0, -3px  0px #C0C0C0, -3px  1px #C0C0C0, -3px  2px #C0C0C0, -3px  3px #C0C0C0, -2px -3px #C0C0C0,
+  -2px  3px #C0C0C0, -1px -3px #C0C0C0, -1px  3px #C0C0C0,  0px -3px #C0C0C0,  0px  3px #C0C0C0,  1px -3px #C0C0C0,  1px  3px #C0C0C0,  2px -3px #C0C0C0,
+   2px  3px #C0C0C0,  3px -3px #C0C0C0,  3px -2px #C0C0C0,  3px -1px #C0C0C0,  3px  0px #C0C0C0,  3px  1px #C0C0C0,  3px  2px #C0C0C0,  3px  3px #C0C0C0;}
+::cue(.outline2silver)        {text-shadow:
+  -1px -1px #C0C0C0, -1px  0px #C0C0C0, -1px  1px #C0C0C0,  0px -1px #C0C0C0,  0px  1px #C0C0C0,  1px -1px #C0C0C0,  1px  0px #C0C0C0,  1px  1px #C0C0C0,
+  -2px -2px #C0C0C0, -2px -1px #C0C0C0, -2px  0px #C0C0C0, -2px  1px #C0C0C0, -2px  2px #C0C0C0, -1px -2px #C0C0C0, -1px  2px #C0C0C0,  0px -2px #C0C0C0,
+   0px  2px #C0C0C0,  1px -2px #C0C0C0,  1px  2px #C0C0C0,  2px -2px #C0C0C0,  2px -1px #C0C0C0,  2px  0px #C0C0C0,  2px  1px #C0C0C0,  2px  2px #C0C0C0;}
+::cue(.outline1silver)        {text-shadow:
+  -1px -1px #C0C0C0, -1px  0px #C0C0C0, -1px  1px #C0C0C0,  0px -1px #C0C0C0,  0px  1px #C0C0C0,  1px -1px #C0C0C0,  1px  0px #C0C0C0,  1px  1px #C0C0C0;}
+::cue(.outline3melrose)        {text-shadow:
+  -1px -1px #C0C0FF, -1px  0px #C0C0FF, -1px  1px #C0C0FF,  0px -1px #C0C0FF,  0px  1px #C0C0FF,  1px -1px #C0C0FF,  1px  0px #C0C0FF,  1px  1px #C0C0FF,
+  -2px -2px #C0C0FF, -2px -1px #C0C0FF, -2px  0px #C0C0FF, -2px  1px #C0C0FF, -2px  2px #C0C0FF, -1px -2px #C0C0FF, -1px  2px #C0C0FF,  0px -2px #C0C0FF,
+   0px  2px #C0C0FF,  1px -2px #C0C0FF,  1px  2px #C0C0FF,  2px -2px #C0C0FF,  2px -1px #C0C0FF,  2px  0px #C0C0FF,  2px  1px #C0C0FF,  2px  2px #C0C0FF,
+  -3px -3px #C0C0FF, -3px -2px #C0C0FF, -3px -1px #C0C0FF, -3px  0px #C0C0FF, -3px  1px #C0C0FF, -3px  2px #C0C0FF, -3px  3px #C0C0FF, -2px -3px #C0C0FF,
+  -2px  3px #C0C0FF, -1px -3px #C0C0FF, -1px  3px #C0C0FF,  0px -3px #C0C0FF,  0px  3px #C0C0FF,  1px -3px #C0C0FF,  1px  3px #C0C0FF,  2px -3px #C0C0FF,
+   2px  3px #C0C0FF,  3px -3px #C0C0FF,  3px -2px #C0C0FF,  3px -1px #C0C0FF,  3px  0px #C0C0FF,  3px  1px #C0C0FF,  3px  2px #C0C0FF,  3px  3px #C0C0FF;}
+::cue(.outline2melrose)        {text-shadow:
+  -1px -1px #C0C0FF, -1px  0px #C0C0FF, -1px  1px #C0C0FF,  0px -1px #C0C0FF,  0px  1px #C0C0FF,  1px -1px #C0C0FF,  1px  0px #C0C0FF,  1px  1px #C0C0FF,
+  -2px -2px #C0C0FF, -2px -1px #C0C0FF, -2px  0px #C0C0FF, -2px  1px #C0C0FF, -2px  2px #C0C0FF, -1px -2px #C0C0FF, -1px  2px #C0C0FF,  0px -2px #C0C0FF,
+   0px  2px #C0C0FF,  1px -2px #C0C0FF,  1px  2px #C0C0FF,  2px -2px #C0C0FF,  2px -1px #C0C0FF,  2px  0px #C0C0FF,  2px  1px #C0C0FF,  2px  2px #C0C0FF;}
+::cue(.outline1melrose)        {text-shadow:
+  -1px -1px #C0C0FF, -1px  0px #C0C0FF, -1px  1px #C0C0FF,  0px -1px #C0C0FF,  0px  1px #C0C0FF,  1px -1px #C0C0FF,  1px  0px #C0C0FF,  1px  1px #C0C0FF;}
+::cue(.outline3laspalmas)        {text-shadow:
+  -1px -1px #C0FF00, -1px  0px #C0FF00, -1px  1px #C0FF00,  0px -1px #C0FF00,  0px  1px #C0FF00,  1px -1px #C0FF00,  1px  0px #C0FF00,  1px  1px #C0FF00,
+  -2px -2px #C0FF00, -2px -1px #C0FF00, -2px  0px #C0FF00, -2px  1px #C0FF00, -2px  2px #C0FF00, -1px -2px #C0FF00, -1px  2px #C0FF00,  0px -2px #C0FF00,
+   0px  2px #C0FF00,  1px -2px #C0FF00,  1px  2px #C0FF00,  2px -2px #C0FF00,  2px -1px #C0FF00,  2px  0px #C0FF00,  2px  1px #C0FF00,  2px  2px #C0FF00,
+  -3px -3px #C0FF00, -3px -2px #C0FF00, -3px -1px #C0FF00, -3px  0px #C0FF00, -3px  1px #C0FF00, -3px  2px #C0FF00, -3px  3px #C0FF00, -2px -3px #C0FF00,
+  -2px  3px #C0FF00, -1px -3px #C0FF00, -1px  3px #C0FF00,  0px -3px #C0FF00,  0px  3px #C0FF00,  1px -3px #C0FF00,  1px  3px #C0FF00,  2px -3px #C0FF00,
+   2px  3px #C0FF00,  3px -3px #C0FF00,  3px -2px #C0FF00,  3px -1px #C0FF00,  3px  0px #C0FF00,  3px  1px #C0FF00,  3px  2px #C0FF00,  3px  3px #C0FF00;}
+::cue(.outline2laspalmas)        {text-shadow:
+  -1px -1px #C0FF00, -1px  0px #C0FF00, -1px  1px #C0FF00,  0px -1px #C0FF00,  0px  1px #C0FF00,  1px -1px #C0FF00,  1px  0px #C0FF00,  1px  1px #C0FF00,
+  -2px -2px #C0FF00, -2px -1px #C0FF00, -2px  0px #C0FF00, -2px  1px #C0FF00, -2px  2px #C0FF00, -1px -2px #C0FF00, -1px  2px #C0FF00,  0px -2px #C0FF00,
+   0px  2px #C0FF00,  1px -2px #C0FF00,  1px  2px #C0FF00,  2px -2px #C0FF00,  2px -1px #C0FF00,  2px  0px #C0FF00,  2px  1px #C0FF00,  2px  2px #C0FF00;}
+::cue(.outline1laspalmas)        {text-shadow:
+  -1px -1px #C0FF00, -1px  0px #C0FF00, -1px  1px #C0FF00,  0px -1px #C0FF00,  0px  1px #C0FF00,  1px -1px #C0FF00,  1px  0px #C0FF00,  1px  1px #C0FF00;}
+::cue(.outline3starship)        {text-shadow:
+  -1px -1px #C0FF40, -1px  0px #C0FF40, -1px  1px #C0FF40,  0px -1px #C0FF40,  0px  1px #C0FF40,  1px -1px #C0FF40,  1px  0px #C0FF40,  1px  1px #C0FF40,
+  -2px -2px #C0FF40, -2px -1px #C0FF40, -2px  0px #C0FF40, -2px  1px #C0FF40, -2px  2px #C0FF40, -1px -2px #C0FF40, -1px  2px #C0FF40,  0px -2px #C0FF40,
+   0px  2px #C0FF40,  1px -2px #C0FF40,  1px  2px #C0FF40,  2px -2px #C0FF40,  2px -1px #C0FF40,  2px  0px #C0FF40,  2px  1px #C0FF40,  2px  2px #C0FF40,
+  -3px -3px #C0FF40, -3px -2px #C0FF40, -3px -1px #C0FF40, -3px  0px #C0FF40, -3px  1px #C0FF40, -3px  2px #C0FF40, -3px  3px #C0FF40, -2px -3px #C0FF40,
+  -2px  3px #C0FF40, -1px -3px #C0FF40, -1px  3px #C0FF40,  0px -3px #C0FF40,  0px  3px #C0FF40,  1px -3px #C0FF40,  1px  3px #C0FF40,  2px -3px #C0FF40,
+   2px  3px #C0FF40,  3px -3px #C0FF40,  3px -2px #C0FF40,  3px -1px #C0FF40,  3px  0px #C0FF40,  3px  1px #C0FF40,  3px  2px #C0FF40,  3px  3px #C0FF40;}
+::cue(.outline2starship)        {text-shadow:
+  -1px -1px #C0FF40, -1px  0px #C0FF40, -1px  1px #C0FF40,  0px -1px #C0FF40,  0px  1px #C0FF40,  1px -1px #C0FF40,  1px  0px #C0FF40,  1px  1px #C0FF40,
+  -2px -2px #C0FF40, -2px -1px #C0FF40, -2px  0px #C0FF40, -2px  1px #C0FF40, -2px  2px #C0FF40, -1px -2px #C0FF40, -1px  2px #C0FF40,  0px -2px #C0FF40,
+   0px  2px #C0FF40,  1px -2px #C0FF40,  1px  2px #C0FF40,  2px -2px #C0FF40,  2px -1px #C0FF40,  2px  0px #C0FF40,  2px  1px #C0FF40,  2px  2px #C0FF40;}
+::cue(.outline1starship)        {text-shadow:
+  -1px -1px #C0FF40, -1px  0px #C0FF40, -1px  1px #C0FF40,  0px -1px #C0FF40,  0px  1px #C0FF40,  1px -1px #C0FF40,  1px  0px #C0FF40,  1px  1px #C0FF40;}
+::cue(.outline3reef)        {text-shadow:
+  -1px -1px #C0FF80, -1px  0px #C0FF80, -1px  1px #C0FF80,  0px -1px #C0FF80,  0px  1px #C0FF80,  1px -1px #C0FF80,  1px  0px #C0FF80,  1px  1px #C0FF80,
+  -2px -2px #C0FF80, -2px -1px #C0FF80, -2px  0px #C0FF80, -2px  1px #C0FF80, -2px  2px #C0FF80, -1px -2px #C0FF80, -1px  2px #C0FF80,  0px -2px #C0FF80,
+   0px  2px #C0FF80,  1px -2px #C0FF80,  1px  2px #C0FF80,  2px -2px #C0FF80,  2px -1px #C0FF80,  2px  0px #C0FF80,  2px  1px #C0FF80,  2px  2px #C0FF80,
+  -3px -3px #C0FF80, -3px -2px #C0FF80, -3px -1px #C0FF80, -3px  0px #C0FF80, -3px  1px #C0FF80, -3px  2px #C0FF80, -3px  3px #C0FF80, -2px -3px #C0FF80,
+  -2px  3px #C0FF80, -1px -3px #C0FF80, -1px  3px #C0FF80,  0px -3px #C0FF80,  0px  3px #C0FF80,  1px -3px #C0FF80,  1px  3px #C0FF80,  2px -3px #C0FF80,
+   2px  3px #C0FF80,  3px -3px #C0FF80,  3px -2px #C0FF80,  3px -1px #C0FF80,  3px  0px #C0FF80,  3px  1px #C0FF80,  3px  2px #C0FF80,  3px  3px #C0FF80;}
+::cue(.outline2reef)        {text-shadow:
+  -1px -1px #C0FF80, -1px  0px #C0FF80, -1px  1px #C0FF80,  0px -1px #C0FF80,  0px  1px #C0FF80,  1px -1px #C0FF80,  1px  0px #C0FF80,  1px  1px #C0FF80,
+  -2px -2px #C0FF80, -2px -1px #C0FF80, -2px  0px #C0FF80, -2px  1px #C0FF80, -2px  2px #C0FF80, -1px -2px #C0FF80, -1px  2px #C0FF80,  0px -2px #C0FF80,
+   0px  2px #C0FF80,  1px -2px #C0FF80,  1px  2px #C0FF80,  2px -2px #C0FF80,  2px -1px #C0FF80,  2px  0px #C0FF80,  2px  1px #C0FF80,  2px  2px #C0FF80;}
+::cue(.outline1reef)        {text-shadow:
+  -1px -1px #C0FF80, -1px  0px #C0FF80, -1px  1px #C0FF80,  0px -1px #C0FF80,  0px  1px #C0FF80,  1px -1px #C0FF80,  1px  0px #C0FF80,  1px  1px #C0FF80;}
+::cue(.outline3snowymint)        {text-shadow:
+  -1px -1px #C0FFC0, -1px  0px #C0FFC0, -1px  1px #C0FFC0,  0px -1px #C0FFC0,  0px  1px #C0FFC0,  1px -1px #C0FFC0,  1px  0px #C0FFC0,  1px  1px #C0FFC0,
+  -2px -2px #C0FFC0, -2px -1px #C0FFC0, -2px  0px #C0FFC0, -2px  1px #C0FFC0, -2px  2px #C0FFC0, -1px -2px #C0FFC0, -1px  2px #C0FFC0,  0px -2px #C0FFC0,
+   0px  2px #C0FFC0,  1px -2px #C0FFC0,  1px  2px #C0FFC0,  2px -2px #C0FFC0,  2px -1px #C0FFC0,  2px  0px #C0FFC0,  2px  1px #C0FFC0,  2px  2px #C0FFC0,
+  -3px -3px #C0FFC0, -3px -2px #C0FFC0, -3px -1px #C0FFC0, -3px  0px #C0FFC0, -3px  1px #C0FFC0, -3px  2px #C0FFC0, -3px  3px #C0FFC0, -2px -3px #C0FFC0,
+  -2px  3px #C0FFC0, -1px -3px #C0FFC0, -1px  3px #C0FFC0,  0px -3px #C0FFC0,  0px  3px #C0FFC0,  1px -3px #C0FFC0,  1px  3px #C0FFC0,  2px -3px #C0FFC0,
+   2px  3px #C0FFC0,  3px -3px #C0FFC0,  3px -2px #C0FFC0,  3px -1px #C0FFC0,  3px  0px #C0FFC0,  3px  1px #C0FFC0,  3px  2px #C0FFC0,  3px  3px #C0FFC0;}
+::cue(.outline2snowymint)        {text-shadow:
+  -1px -1px #C0FFC0, -1px  0px #C0FFC0, -1px  1px #C0FFC0,  0px -1px #C0FFC0,  0px  1px #C0FFC0,  1px -1px #C0FFC0,  1px  0px #C0FFC0,  1px  1px #C0FFC0,
+  -2px -2px #C0FFC0, -2px -1px #C0FFC0, -2px  0px #C0FFC0, -2px  1px #C0FFC0, -2px  2px #C0FFC0, -1px -2px #C0FFC0, -1px  2px #C0FFC0,  0px -2px #C0FFC0,
+   0px  2px #C0FFC0,  1px -2px #C0FFC0,  1px  2px #C0FFC0,  2px -2px #C0FFC0,  2px -1px #C0FFC0,  2px  0px #C0FFC0,  2px  1px #C0FFC0,  2px  2px #C0FFC0;}
+::cue(.outline1snowymint)        {text-shadow:
+  -1px -1px #C0FFC0, -1px  0px #C0FFC0, -1px  1px #C0FFC0,  0px -1px #C0FFC0,  0px  1px #C0FFC0,  1px -1px #C0FFC0,  1px  0px #C0FFC0,  1px  1px #C0FFC0;}
+::cue(.outline3onahau)        {text-shadow:
+  -1px -1px #C0FFFF, -1px  0px #C0FFFF, -1px  1px #C0FFFF,  0px -1px #C0FFFF,  0px  1px #C0FFFF,  1px -1px #C0FFFF,  1px  0px #C0FFFF,  1px  1px #C0FFFF,
+  -2px -2px #C0FFFF, -2px -1px #C0FFFF, -2px  0px #C0FFFF, -2px  1px #C0FFFF, -2px  2px #C0FFFF, -1px -2px #C0FFFF, -1px  2px #C0FFFF,  0px -2px #C0FFFF,
+   0px  2px #C0FFFF,  1px -2px #C0FFFF,  1px  2px #C0FFFF,  2px -2px #C0FFFF,  2px -1px #C0FFFF,  2px  0px #C0FFFF,  2px  1px #C0FFFF,  2px  2px #C0FFFF,
+  -3px -3px #C0FFFF, -3px -2px #C0FFFF, -3px -1px #C0FFFF, -3px  0px #C0FFFF, -3px  1px #C0FFFF, -3px  2px #C0FFFF, -3px  3px #C0FFFF, -2px -3px #C0FFFF,
+  -2px  3px #C0FFFF, -1px -3px #C0FFFF, -1px  3px #C0FFFF,  0px -3px #C0FFFF,  0px  3px #C0FFFF,  1px -3px #C0FFFF,  1px  3px #C0FFFF,  2px -3px #C0FFFF,
+   2px  3px #C0FFFF,  3px -3px #C0FFFF,  3px -2px #C0FFFF,  3px -1px #C0FFFF,  3px  0px #C0FFFF,  3px  1px #C0FFFF,  3px  2px #C0FFFF,  3px  3px #C0FFFF;}
+::cue(.outline2onahau)        {text-shadow:
+  -1px -1px #C0FFFF, -1px  0px #C0FFFF, -1px  1px #C0FFFF,  0px -1px #C0FFFF,  0px  1px #C0FFFF,  1px -1px #C0FFFF,  1px  0px #C0FFFF,  1px  1px #C0FFFF,
+  -2px -2px #C0FFFF, -2px -1px #C0FFFF, -2px  0px #C0FFFF, -2px  1px #C0FFFF, -2px  2px #C0FFFF, -1px -2px #C0FFFF, -1px  2px #C0FFFF,  0px -2px #C0FFFF,
+   0px  2px #C0FFFF,  1px -2px #C0FFFF,  1px  2px #C0FFFF,  2px -2px #C0FFFF,  2px -1px #C0FFFF,  2px  0px #C0FFFF,  2px  1px #C0FFFF,  2px  2px #C0FFFF;}
+::cue(.outline1onahau)        {text-shadow:
+  -1px -1px #C0FFFF, -1px  0px #C0FFFF, -1px  1px #C0FFFF,  0px -1px #C0FFFF,  0px  1px #C0FFFF,  1px -1px #C0FFFF,  1px  0px #C0FFFF,  1px  1px #C0FFFF;}
+
+::cue(.outline3red)             {text-shadow:
+  -1px -1px #FF0000, -1px  0px #FF0000, -1px  1px #FF0000,  0px -1px #FF0000,  0px  1px #FF0000,  1px -1px #FF0000,  1px  0px #FF0000,  1px  1px #FF0000,
+  -2px -2px #FF0000, -2px -1px #FF0000, -2px  0px #FF0000, -2px  1px #FF0000, -2px  2px #FF0000, -1px -2px #FF0000, -1px  2px #FF0000,  0px -2px #FF0000,
+   0px  2px #FF0000,  1px -2px #FF0000,  1px  2px #FF0000,  2px -2px #FF0000,  2px -1px #FF0000,  2px  0px #FF0000,  2px  1px #FF0000,  2px  2px #FF0000,
+  -3px -3px #FF0000, -3px -2px #FF0000, -3px -1px #FF0000, -3px  0px #FF0000, -3px  1px #FF0000, -3px  2px #FF0000, -3px  3px #FF0000, -2px -3px #FF0000,
+  -2px  3px #FF0000, -1px -3px #FF0000, -1px  3px #FF0000,  0px -3px #FF0000,  0px  3px #FF0000,  1px -3px #FF0000,  1px  3px #FF0000,  2px -3px #FF0000,
+   2px  3px #FF0000,  3px -3px #FF0000,  3px -2px #FF0000,  3px -1px #FF0000,  3px  0px #FF0000,  3px  1px #FF0000,  3px  2px #FF0000,  3px  3px #FF0000;}
+::cue(.outline2red)             {text-shadow:
+  -1px -1px #FF0000, -1px  0px #FF0000, -1px  1px #FF0000,  0px -1px #FF0000,  0px  1px #FF0000,  1px -1px #FF0000,  1px  0px #FF0000,  1px  1px #FF0000,
+  -2px -2px #FF0000, -2px -1px #FF0000, -2px  0px #FF0000, -2px  1px #FF0000, -2px  2px #FF0000, -1px -2px #FF0000, -1px  2px #FF0000,  0px -2px #FF0000,
+   0px  2px #FF0000,  1px -2px #FF0000,  1px  2px #FF0000,  2px -2px #FF0000,  2px -1px #FF0000,  2px  0px #FF0000,  2px  1px #FF0000,  2px  2px #FF0000;}
+::cue(.outline1red)             {text-shadow:
+  -1px -1px #FF0000, -1px  0px #FF0000, -1px  1px #FF0000,  0px -1px #FF0000,  0px  1px #FF0000,  1px -1px #FF0000,  1px  0px #FF0000,  1px  1px #FF0000;}
+::cue(.outline3torchred)           {text-shadow:
+  -1px -1px #FF0040, -1px  0px #FF0040, -1px  1px #FF0040,  0px -1px #FF0040,  0px  1px #FF0040,  1px -1px #FF0040,  1px  0px #FF0040,  1px  1px #FF0040,
+  -2px -2px #FF0040, -2px -1px #FF0040, -2px  0px #FF0040, -2px  1px #FF0040, -2px  2px #FF0040, -1px -2px #FF0040, -1px  2px #FF0040,  0px -2px #FF0040,
+   0px  2px #FF0040,  1px -2px #FF0040,  1px  2px #FF0040,  2px -2px #FF0040,  2px -1px #FF0040,  2px  0px #FF0040,  2px  1px #FF0040,  2px  2px #FF0040,
+  -3px -3px #FF0040, -3px -2px #FF0040, -3px -1px #FF0040, -3px  0px #FF0040, -3px  1px #FF0040, -3px  2px #FF0040, -3px  3px #FF0040, -2px -3px #FF0040,
+  -2px  3px #FF0040, -1px -3px #FF0040, -1px  3px #FF0040,  0px -3px #FF0040,  0px  3px #FF0040,  1px -3px #FF0040,  1px  3px #FF0040,  2px -3px #FF0040,
+   2px  3px #FF0040,  3px -3px #FF0040,  3px -2px #FF0040,  3px -1px #FF0040,  3px  0px #FF0040,  3px  1px #FF0040,  3px  2px #FF0040,  3px  3px #FF0040;}
+::cue(.outline2torchred)           {text-shadow:
+  -1px -1px #FF0040, -1px  0px #FF0040, -1px  1px #FF0040,  0px -1px #FF0040,  0px  1px #FF0040,  1px -1px #FF0040,  1px  0px #FF0040,  1px  1px #FF0040,
+  -2px -2px #FF0040, -2px -1px #FF0040, -2px  0px #FF0040, -2px  1px #FF0040, -2px  2px #FF0040, -1px -2px #FF0040, -1px  2px #FF0040,  0px -2px #FF0040,
+   0px  2px #FF0040,  1px -2px #FF0040,  1px  2px #FF0040,  2px -2px #FF0040,  2px -1px #FF0040,  2px  0px #FF0040,  2px  1px #FF0040,  2px  2px #FF0040;}
+::cue(.outline1torchred)           {text-shadow:
+  -1px -1px #FF0040, -1px  0px #FF0040, -1px  1px #FF0040,  0px -1px #FF0040,  0px  1px #FF0040,  1px -1px #FF0040,  1px  0px #FF0040,  1px  1px #FF0040;}
+::cue(.outline3rose)              {text-shadow:
+  -1px -1px #FF0080, -1px  0px #FF0080, -1px  1px #FF0080,  0px -1px #FF0080,  0px  1px #FF0080,  1px -1px #FF0080,  1px  0px #FF0080,  1px  1px #FF0080,
+  -2px -2px #FF0080, -2px -1px #FF0080, -2px  0px #FF0080, -2px  1px #FF0080, -2px  2px #FF0080, -1px -2px #FF0080, -1px  2px #FF0080,  0px -2px #FF0080,
+   0px  2px #FF0080,  1px -2px #FF0080,  1px  2px #FF0080,  2px -2px #FF0080,  2px -1px #FF0080,  2px  0px #FF0080,  2px  1px #FF0080,  2px  2px #FF0080,
+  -3px -3px #FF0080, -3px -2px #FF0080, -3px -1px #FF0080, -3px  0px #FF0080, -3px  1px #FF0080, -3px  2px #FF0080, -3px  3px #FF0080, -2px -3px #FF0080,
+  -2px  3px #FF0080, -1px -3px #FF0080, -1px  3px #FF0080,  0px -3px #FF0080,  0px  3px #FF0080,  1px -3px #FF0080,  1px  3px #FF0080,  2px -3px #FF0080,
+   2px  3px #FF0080,  3px -3px #FF0080,  3px -2px #FF0080,  3px -1px #FF0080,  3px  0px #FF0080,  3px  1px #FF0080,  3px  2px #FF0080,  3px  3px #FF0080;}
+::cue(.outline2rose)              {text-shadow:
+  -1px -1px #FF0080, -1px  0px #FF0080, -1px  1px #FF0080,  0px -1px #FF0080,  0px  1px #FF0080,  1px -1px #FF0080,  1px  0px #FF0080,  1px  1px #FF0080,
+  -2px -2px #FF0080, -2px -1px #FF0080, -2px  0px #FF0080, -2px  1px #FF0080, -2px  2px #FF0080, -1px -2px #FF0080, -1px  2px #FF0080,  0px -2px #FF0080,
+   0px  2px #FF0080,  1px -2px #FF0080,  1px  2px #FF0080,  2px -2px #FF0080,  2px -1px #FF0080,  2px  0px #FF0080,  2px  1px #FF0080,  2px  2px #FF0080;}
+::cue(.outline1rose)              {text-shadow:
+  -1px -1px #FF0080, -1px  0px #FF0080, -1px  1px #FF0080,  0px -1px #FF0080,  0px  1px #FF0080,  1px -1px #FF0080,  1px  0px #FF0080,  1px  1px #FF0080;}
+::cue(.outline3pizzazz)        {text-shadow:
+  -1px -1px #FF00C0, -1px  0px #FF00C0, -1px  1px #FF00C0,  0px -1px #FF00C0,  0px  1px #FF00C0,  1px -1px #FF00C0,  1px  0px #FF00C0,  1px  1px #FF00C0,
+  -2px -2px #FF00C0, -2px -1px #FF00C0, -2px  0px #FF00C0, -2px  1px #FF00C0, -2px  2px #FF00C0, -1px -2px #FF00C0, -1px  2px #FF00C0,  0px -2px #FF00C0,
+   0px  2px #FF00C0,  1px -2px #FF00C0,  1px  2px #FF00C0,  2px -2px #FF00C0,  2px -1px #FF00C0,  2px  0px #FF00C0,  2px  1px #FF00C0,  2px  2px #FF00C0,
+  -3px -3px #FF00C0, -3px -2px #FF00C0, -3px -1px #FF00C0, -3px  0px #FF00C0, -3px  1px #FF00C0, -3px  2px #FF00C0, -3px  3px #FF00C0, -2px -3px #FF00C0,
+  -2px  3px #FF00C0, -1px -3px #FF00C0, -1px  3px #FF00C0,  0px -3px #FF00C0,  0px  3px #FF00C0,  1px -3px #FF00C0,  1px  3px #FF00C0,  2px -3px #FF00C0,
+   2px  3px #FF00C0,  3px -3px #FF00C0,  3px -2px #FF00C0,  3px -1px #FF00C0,  3px  0px #FF00C0,  3px  1px #FF00C0,  3px  2px #FF00C0,  3px  3px #FF00C0;}
+::cue(.outline2pizzazz)        {text-shadow:
+  -1px -1px #FF00C0, -1px  0px #FF00C0, -1px  1px #FF00C0,  0px -1px #FF00C0,  0px  1px #FF00C0,  1px -1px #FF00C0,  1px  0px #FF00C0,  1px  1px #FF00C0,
+  -2px -2px #FF00C0, -2px -1px #FF00C0, -2px  0px #FF00C0, -2px  1px #FF00C0, -2px  2px #FF00C0, -1px -2px #FF00C0, -1px  2px #FF00C0,  0px -2px #FF00C0,
+   0px  2px #FF00C0,  1px -2px #FF00C0,  1px  2px #FF00C0,  2px -2px #FF00C0,  2px -1px #FF00C0,  2px  0px #FF00C0,  2px  1px #FF00C0,  2px  2px #FF00C0;}
+::cue(.outline1pizzazz)        {text-shadow:
+  -1px -1px #FF00C0, -1px  0px #FF00C0, -1px  1px #FF00C0,  0px -1px #FF00C0,  0px  1px #FF00C0,  1px -1px #FF00C0,  1px  0px #FF00C0,  1px  1px #FF00C0;}
+::cue(.outline3magenta)              {text-shadow:
+  -1px -1px #FF00FF, -1px  0px #FF00FF, -1px  1px #FF00FF,  0px -1px #FF00FF,  0px  1px #FF00FF,  1px -1px #FF00FF,  1px  0px #FF00FF,  1px  1px #FF00FF,
+  -2px -2px #FF00FF, -2px -1px #FF00FF, -2px  0px #FF00FF, -2px  1px #FF00FF, -2px  2px #FF00FF, -1px -2px #FF00FF, -1px  2px #FF00FF,  0px -2px #FF00FF,
+   0px  2px #FF00FF,  1px -2px #FF00FF,  1px  2px #FF00FF,  2px -2px #FF00FF,  2px -1px #FF00FF,  2px  0px #FF00FF,  2px  1px #FF00FF,  2px  2px #FF00FF,
+  -3px -3px #FF00FF, -3px -2px #FF00FF, -3px -1px #FF00FF, -3px  0px #FF00FF, -3px  1px #FF00FF, -3px  2px #FF00FF, -3px  3px #FF00FF, -2px -3px #FF00FF,
+  -2px  3px #FF00FF, -1px -3px #FF00FF, -1px  3px #FF00FF,  0px -3px #FF00FF,  0px  3px #FF00FF,  1px -3px #FF00FF,  1px  3px #FF00FF,  2px -3px #FF00FF,
+   2px  3px #FF00FF,  3px -3px #FF00FF,  3px -2px #FF00FF,  3px -1px #FF00FF,  3px  0px #FF00FF,  3px  1px #FF00FF,  3px  2px #FF00FF,  3px  3px #FF00FF;}
+::cue(.outline2magenta)              {text-shadow:
+  -1px -1px #FF00FF, -1px  0px #FF00FF, -1px  1px #FF00FF,  0px -1px #FF00FF,  0px  1px #FF00FF,  1px -1px #FF00FF,  1px  0px #FF00FF,  1px  1px #FF00FF,
+  -2px -2px #FF00FF, -2px -1px #FF00FF, -2px  0px #FF00FF, -2px  1px #FF00FF, -2px  2px #FF00FF, -1px -2px #FF00FF, -1px  2px #FF00FF,  0px -2px #FF00FF,
+   0px  2px #FF00FF,  1px -2px #FF00FF,  1px  2px #FF00FF,  2px -2px #FF00FF,  2px -1px #FF00FF,  2px  0px #FF00FF,  2px  1px #FF00FF,  2px  2px #FF00FF;}
+::cue(.outline1magenta)              {text-shadow:
+  -1px -1px #FF00FF, -1px  0px #FF00FF, -1px  1px #FF00FF,  0px -1px #FF00FF,  0px  1px #FF00FF,  1px -1px #FF00FF,  1px  0px #FF00FF,  1px  1px #FF00FF;}
+::cue(.outline3vermilion)        {text-shadow:
+  -1px -1px #FF4000, -1px  0px #FF4000, -1px  1px #FF4000,  0px -1px #FF4000,  0px  1px #FF4000,  1px -1px #FF4000,  1px  0px #FF4000,  1px  1px #FF4000,
+  -2px -2px #FF4000, -2px -1px #FF4000, -2px  0px #FF4000, -2px  1px #FF4000, -2px  2px #FF4000, -1px -2px #FF4000, -1px  2px #FF4000,  0px -2px #FF4000,
+   0px  2px #FF4000,  1px -2px #FF4000,  1px  2px #FF4000,  2px -2px #FF4000,  2px -1px #FF4000,  2px  0px #FF4000,  2px  1px #FF4000,  2px  2px #FF4000,
+  -3px -3px #FF4000, -3px -2px #FF4000, -3px -1px #FF4000, -3px  0px #FF4000, -3px  1px #FF4000, -3px  2px #FF4000, -3px  3px #FF4000, -2px -3px #FF4000,
+  -2px  3px #FF4000, -1px -3px #FF4000, -1px  3px #FF4000,  0px -3px #FF4000,  0px  3px #FF4000,  1px -3px #FF4000,  1px  3px #FF4000,  2px -3px #FF4000,
+   2px  3px #FF4000,  3px -3px #FF4000,  3px -2px #FF4000,  3px -1px #FF4000,  3px  0px #FF4000,  3px  1px #FF4000,  3px  2px #FF4000,  3px  3px #FF4000;}
+::cue(.outline2vermilion)        {text-shadow:
+  -1px -1px #FF4000, -1px  0px #FF4000, -1px  1px #FF4000,  0px -1px #FF4000,  0px  1px #FF4000,  1px -1px #FF4000,  1px  0px #FF4000,  1px  1px #FF4000,
+  -2px -2px #FF4000, -2px -1px #FF4000, -2px  0px #FF4000, -2px  1px #FF4000, -2px  2px #FF4000, -1px -2px #FF4000, -1px  2px #FF4000,  0px -2px #FF4000,
+   0px  2px #FF4000,  1px -2px #FF4000,  1px  2px #FF4000,  2px -2px #FF4000,  2px -1px #FF4000,  2px  0px #FF4000,  2px  1px #FF4000,  2px  2px #FF4000;}
+::cue(.outline1vermilion)        {text-shadow:
+  -1px -1px #FF4000, -1px  0px #FF4000, -1px  1px #FF4000,  0px -1px #FF4000,  0px  1px #FF4000,  1px -1px #FF4000,  1px  0px #FF4000,  1px  1px #FF4000;}
+::cue(.outline3coral)        {text-shadow:
+  -1px -1px #FF4040, -1px  0px #FF4040, -1px  1px #FF4040,  0px -1px #FF4040,  0px  1px #FF4040,  1px -1px #FF4040,  1px  0px #FF4040,  1px  1px #FF4040,
+  -2px -2px #FF4040, -2px -1px #FF4040, -2px  0px #FF4040, -2px  1px #FF4040, -2px  2px #FF4040, -1px -2px #FF4040, -1px  2px #FF4040,  0px -2px #FF4040,
+   0px  2px #FF4040,  1px -2px #FF4040,  1px  2px #FF4040,  2px -2px #FF4040,  2px -1px #FF4040,  2px  0px #FF4040,  2px  1px #FF4040,  2px  2px #FF4040,
+  -3px -3px #FF4040, -3px -2px #FF4040, -3px -1px #FF4040, -3px  0px #FF4040, -3px  1px #FF4040, -3px  2px #FF4040, -3px  3px #FF4040, -2px -3px #FF4040,
+  -2px  3px #FF4040, -1px -3px #FF4040, -1px  3px #FF4040,  0px -3px #FF4040,  0px  3px #FF4040,  1px -3px #FF4040,  1px  3px #FF4040,  2px -3px #FF4040,
+   2px  3px #FF4040,  3px -3px #FF4040,  3px -2px #FF4040,  3px -1px #FF4040,  3px  0px #FF4040,  3px  1px #FF4040,  3px  2px #FF4040,  3px  3px #FF4040;}
+::cue(.outline2coral)        {text-shadow:
+  -1px -1px #FF4040, -1px  0px #FF4040, -1px  1px #FF4040,  0px -1px #FF4040,  0px  1px #FF4040,  1px -1px #FF4040,  1px  0px #FF4040,  1px  1px #FF4040,
+  -2px -2px #FF4040, -2px -1px #FF4040, -2px  0px #FF4040, -2px  1px #FF4040, -2px  2px #FF4040, -1px -2px #FF4040, -1px  2px #FF4040,  0px -2px #FF4040,
+   0px  2px #FF4040,  1px -2px #FF4040,  1px  2px #FF4040,  2px -2px #FF4040,  2px -1px #FF4040,  2px  0px #FF4040,  2px  1px #FF4040,  2px  2px #FF4040;}
+::cue(.outline1coral)        {text-shadow:
+  -1px -1px #FF4040, -1px  0px #FF4040, -1px  1px #FF4040,  0px -1px #FF4040,  0px  1px #FF4040,  1px -1px #FF4040,  1px  0px #FF4040,  1px  1px #FF4040;}
+::cue(.outline3strawberry)        {text-shadow:
+  -1px -1px #FF4080, -1px  0px #FF4080, -1px  1px #FF4080,  0px -1px #FF4080,  0px  1px #FF4080,  1px -1px #FF4080,  1px  0px #FF4080,  1px  1px #FF4080,
+  -2px -2px #FF4080, -2px -1px #FF4080, -2px  0px #FF4080, -2px  1px #FF4080, -2px  2px #FF4080, -1px -2px #FF4080, -1px  2px #FF4080,  0px -2px #FF4080,
+   0px  2px #FF4080,  1px -2px #FF4080,  1px  2px #FF4080,  2px -2px #FF4080,  2px -1px #FF4080,  2px  0px #FF4080,  2px  1px #FF4080,  2px  2px #FF4080,
+  -3px -3px #FF4080, -3px -2px #FF4080, -3px -1px #FF4080, -3px  0px #FF4080, -3px  1px #FF4080, -3px  2px #FF4080, -3px  3px #FF4080, -2px -3px #FF4080,
+  -2px  3px #FF4080, -1px -3px #FF4080, -1px  3px #FF4080,  0px -3px #FF4080,  0px  3px #FF4080,  1px -3px #FF4080,  1px  3px #FF4080,  2px -3px #FF4080,
+   2px  3px #FF4080,  3px -3px #FF4080,  3px -2px #FF4080,  3px -1px #FF4080,  3px  0px #FF4080,  3px  1px #FF4080,  3px  2px #FF4080,  3px  3px #FF4080;}
+::cue(.outline2strawberry)        {text-shadow:
+  -1px -1px #FF4080, -1px  0px #FF4080, -1px  1px #FF4080,  0px -1px #FF4080,  0px  1px #FF4080,  1px -1px #FF4080,  1px  0px #FF4080,  1px  1px #FF4080,
+  -2px -2px #FF4080, -2px -1px #FF4080, -2px  0px #FF4080, -2px  1px #FF4080, -2px  2px #FF4080, -1px -2px #FF4080, -1px  2px #FF4080,  0px -2px #FF4080,
+   0px  2px #FF4080,  1px -2px #FF4080,  1px  2px #FF4080,  2px -2px #FF4080,  2px -1px #FF4080,  2px  0px #FF4080,  2px  1px #FF4080,  2px  2px #FF4080;}
+::cue(.outline1strawberry)        {text-shadow:
+  -1px -1px #FF4080, -1px  0px #FF4080, -1px  1px #FF4080,  0px -1px #FF4080,  0px  1px #FF4080,  1px -1px #FF4080,  1px  0px #FF4080,  1px  1px #FF4080;}
+::cue(.outline3razzledazzle)        {text-shadow:
+  -1px -1px #FF40C0, -1px  0px #FF40C0, -1px  1px #FF40C0,  0px -1px #FF40C0,  0px  1px #FF40C0,  1px -1px #FF40C0,  1px  0px #FF40C0,  1px  1px #FF40C0,
+  -2px -2px #FF40C0, -2px -1px #FF40C0, -2px  0px #FF40C0, -2px  1px #FF40C0, -2px  2px #FF40C0, -1px -2px #FF40C0, -1px  2px #FF40C0,  0px -2px #FF40C0,
+   0px  2px #FF40C0,  1px -2px #FF40C0,  1px  2px #FF40C0,  2px -2px #FF40C0,  2px -1px #FF40C0,  2px  0px #FF40C0,  2px  1px #FF40C0,  2px  2px #FF40C0,
+  -3px -3px #FF40C0, -3px -2px #FF40C0, -3px -1px #FF40C0, -3px  0px #FF40C0, -3px  1px #FF40C0, -3px  2px #FF40C0, -3px  3px #FF40C0, -2px -3px #FF40C0,
+  -2px  3px #FF40C0, -1px -3px #FF40C0, -1px  3px #FF40C0,  0px -3px #FF40C0,  0px  3px #FF40C0,  1px -3px #FF40C0,  1px  3px #FF40C0,  2px -3px #FF40C0,
+   2px  3px #FF40C0,  3px -3px #FF40C0,  3px -2px #FF40C0,  3px -1px #FF40C0,  3px  0px #FF40C0,  3px  1px #FF40C0,  3px  2px #FF40C0,  3px  3px #FF40C0;}
+::cue(.outline2razzledazzle)        {text-shadow:
+  -1px -1px #FF40C0, -1px  0px #FF40C0, -1px  1px #FF40C0,  0px -1px #FF40C0,  0px  1px #FF40C0,  1px -1px #FF40C0,  1px  0px #FF40C0,  1px  1px #FF40C0,
+  -2px -2px #FF40C0, -2px -1px #FF40C0, -2px  0px #FF40C0, -2px  1px #FF40C0, -2px  2px #FF40C0, -1px -2px #FF40C0, -1px  2px #FF40C0,  0px -2px #FF40C0,
+   0px  2px #FF40C0,  1px -2px #FF40C0,  1px  2px #FF40C0,  2px -2px #FF40C0,  2px -1px #FF40C0,  2px  0px #FF40C0,  2px  1px #FF40C0,  2px  2px #FF40C0;}
+::cue(.outline1razzledazzle)        {text-shadow:
+  -1px -1px #FF40C0, -1px  0px #FF40C0, -1px  1px #FF40C0,  0px -1px #FF40C0,  0px  1px #FF40C0,  1px -1px #FF40C0,  1px  0px #FF40C0,  1px  1px #FF40C0;}
+::cue(.outline3flamingo)        {text-shadow:
+  -1px -1px #FF40FF, -1px  0px #FF40FF, -1px  1px #FF40FF,  0px -1px #FF40FF,  0px  1px #FF40FF,  1px -1px #FF40FF,  1px  0px #FF40FF,  1px  1px #FF40FF,
+  -2px -2px #FF40FF, -2px -1px #FF40FF, -2px  0px #FF40FF, -2px  1px #FF40FF, -2px  2px #FF40FF, -1px -2px #FF40FF, -1px  2px #FF40FF,  0px -2px #FF40FF,
+   0px  2px #FF40FF,  1px -2px #FF40FF,  1px  2px #FF40FF,  2px -2px #FF40FF,  2px -1px #FF40FF,  2px  0px #FF40FF,  2px  1px #FF40FF,  2px  2px #FF40FF,
+  -3px -3px #FF40FF, -3px -2px #FF40FF, -3px -1px #FF40FF, -3px  0px #FF40FF, -3px  1px #FF40FF, -3px  2px #FF40FF, -3px  3px #FF40FF, -2px -3px #FF40FF,
+  -2px  3px #FF40FF, -1px -3px #FF40FF, -1px  3px #FF40FF,  0px -3px #FF40FF,  0px  3px #FF40FF,  1px -3px #FF40FF,  1px  3px #FF40FF,  2px -3px #FF40FF,
+   2px  3px #FF40FF,  3px -3px #FF40FF,  3px -2px #FF40FF,  3px -1px #FF40FF,  3px  0px #FF40FF,  3px  1px #FF40FF,  3px  2px #FF40FF,  3px  3px #FF40FF;}
+::cue(.outline2flamingo)        {text-shadow:
+  -1px -1px #FF40FF, -1px  0px #FF40FF, -1px  1px #FF40FF,  0px -1px #FF40FF,  0px  1px #FF40FF,  1px -1px #FF40FF,  1px  0px #FF40FF,  1px  1px #FF40FF,
+  -2px -2px #FF40FF, -2px -1px #FF40FF, -2px  0px #FF40FF, -2px  1px #FF40FF, -2px  2px #FF40FF, -1px -2px #FF40FF, -1px  2px #FF40FF,  0px -2px #FF40FF,
+   0px  2px #FF40FF,  1px -2px #FF40FF,  1px  2px #FF40FF,  2px -2px #FF40FF,  2px -1px #FF40FF,  2px  0px #FF40FF,  2px  1px #FF40FF,  2px  2px #FF40FF;}
+::cue(.outline1flamingo)        {text-shadow:
+  -1px -1px #FF40FF, -1px  0px #FF40FF, -1px  1px #FF40FF,  0px -1px #FF40FF,  0px  1px #FF40FF,  1px -1px #FF40FF,  1px  0px #FF40FF,  1px  1px #FF40FF;}
+::cue(.outline3flushorange)        {text-shadow:
+  -1px -1px #FF8000, -1px  0px #FF8000, -1px  1px #FF8000,  0px -1px #FF8000,  0px  1px #FF8000,  1px -1px #FF8000,  1px  0px #FF8000,  1px  1px #FF8000,
+  -2px -2px #FF8000, -2px -1px #FF8000, -2px  0px #FF8000, -2px  1px #FF8000, -2px  2px #FF8000, -1px -2px #FF8000, -1px  2px #FF8000,  0px -2px #FF8000,
+   0px  2px #FF8000,  1px -2px #FF8000,  1px  2px #FF8000,  2px -2px #FF8000,  2px -1px #FF8000,  2px  0px #FF8000,  2px  1px #FF8000,  2px  2px #FF8000,
+  -3px -3px #FF8000, -3px -2px #FF8000, -3px -1px #FF8000, -3px  0px #FF8000, -3px  1px #FF8000, -3px  2px #FF8000, -3px  3px #FF8000, -2px -3px #FF8000,
+  -2px  3px #FF8000, -1px -3px #FF8000, -1px  3px #FF8000,  0px -3px #FF8000,  0px  3px #FF8000,  1px -3px #FF8000,  1px  3px #FF8000,  2px -3px #FF8000,
+   2px  3px #FF8000,  3px -3px #FF8000,  3px -2px #FF8000,  3px -1px #FF8000,  3px  0px #FF8000,  3px  1px #FF8000,  3px  2px #FF8000,  3px  3px #FF8000;}
+::cue(.outline2flushorange)        {text-shadow:
+  -1px -1px #FF8000, -1px  0px #FF8000, -1px  1px #FF8000,  0px -1px #FF8000,  0px  1px #FF8000,  1px -1px #FF8000,  1px  0px #FF8000,  1px  1px #FF8000,
+  -2px -2px #FF8000, -2px -1px #FF8000, -2px  0px #FF8000, -2px  1px #FF8000, -2px  2px #FF8000, -1px -2px #FF8000, -1px  2px #FF8000,  0px -2px #FF8000,
+   0px  2px #FF8000,  1px -2px #FF8000,  1px  2px #FF8000,  2px -2px #FF8000,  2px -1px #FF8000,  2px  0px #FF8000,  2px  1px #FF8000,  2px  2px #FF8000;}
+::cue(.outline1flushorange)        {text-shadow:
+  -1px -1px #FF8000, -1px  0px #FF8000, -1px  1px #FF8000,  0px -1px #FF8000,  0px  1px #FF8000,  1px -1px #FF8000,  1px  0px #FF8000,  1px  1px #FF8000;}
+::cue(.outline3crusta)        {text-shadow:
+  -1px -1px #FF8040, -1px  0px #FF8040, -1px  1px #FF8040,  0px -1px #FF8040,  0px  1px #FF8040,  1px -1px #FF8040,  1px  0px #FF8040,  1px  1px #FF8040,
+  -2px -2px #FF8040, -2px -1px #FF8040, -2px  0px #FF8040, -2px  1px #FF8040, -2px  2px #FF8040, -1px -2px #FF8040, -1px  2px #FF8040,  0px -2px #FF8040,
+   0px  2px #FF8040,  1px -2px #FF8040,  1px  2px #FF8040,  2px -2px #FF8040,  2px -1px #FF8040,  2px  0px #FF8040,  2px  1px #FF8040,  2px  2px #FF8040,
+  -3px -3px #FF8040, -3px -2px #FF8040, -3px -1px #FF8040, -3px  0px #FF8040, -3px  1px #FF8040, -3px  2px #FF8040, -3px  3px #FF8040, -2px -3px #FF8040,
+  -2px  3px #FF8040, -1px -3px #FF8040, -1px  3px #FF8040,  0px -3px #FF8040,  0px  3px #FF8040,  1px -3px #FF8040,  1px  3px #FF8040,  2px -3px #FF8040,
+   2px  3px #FF8040,  3px -3px #FF8040,  3px -2px #FF8040,  3px -1px #FF8040,  3px  0px #FF8040,  3px  1px #FF8040,  3px  2px #FF8040,  3px  3px #FF8040;}
+::cue(.outline2crusta)        {text-shadow:
+  -1px -1px #FF8040, -1px  0px #FF8040, -1px  1px #FF8040,  0px -1px #FF8040,  0px  1px #FF8040,  1px -1px #FF8040,  1px  0px #FF8040,  1px  1px #FF8040,
+  -2px -2px #FF8040, -2px -1px #FF8040, -2px  0px #FF8040, -2px  1px #FF8040, -2px  2px #FF8040, -1px -2px #FF8040, -1px  2px #FF8040,  0px -2px #FF8040,
+   0px  2px #FF8040,  1px -2px #FF8040,  1px  2px #FF8040,  2px -2px #FF8040,  2px -1px #FF8040,  2px  0px #FF8040,  2px  1px #FF8040,  2px  2px #FF8040;}
+::cue(.outline1crusta)        {text-shadow:
+  -1px -1px #FF8080, -1px  0px #FF8080, -1px  1px #FF8080,  0px -1px #FF8080,  0px  1px #FF8080,  1px -1px #FF8080,  1px  0px #FF8080,  1px  1px #FF8080;}
+::cue(.outline3vividtangerine)        {text-shadow:
+  -1px -1px #FF8080, -1px  0px #FF8080, -1px  1px #FF8080,  0px -1px #FF8080,  0px  1px #FF8080,  1px -1px #FF8080,  1px  0px #FF8080,  1px  1px #FF8080,
+  -2px -2px #FF8080, -2px -1px #FF8080, -2px  0px #FF8080, -2px  1px #FF8080, -2px  2px #FF8080, -1px -2px #FF8080, -1px  2px #FF8080,  0px -2px #FF8080,
+   0px  2px #FF8080,  1px -2px #FF8080,  1px  2px #FF8080,  2px -2px #FF8080,  2px -1px #FF8080,  2px  0px #FF8080,  2px  1px #FF8080,  2px  2px #FF8080,
+  -3px -3px #FF8080, -3px -2px #FF8080, -3px -1px #FF8080, -3px  0px #FF8080, -3px  1px #FF8080, -3px  2px #FF8080, -3px  3px #FF8080, -2px -3px #FF8080,
+  -2px  3px #FF8080, -1px -3px #FF8080, -1px  3px #FF8080,  0px -3px #FF8080,  0px  3px #FF8080,  1px -3px #FF8080,  1px  3px #FF8080,  2px -3px #FF8080,
+   2px  3px #FF8080,  3px -3px #FF8080,  3px -2px #FF8080,  3px -1px #FF8080,  3px  0px #FF8080,  3px  1px #FF8080,  3px  2px #FF8080,  3px  3px #FF8080;}
+::cue(.outline2vividtangerine)        {text-shadow:
+  -1px -1px #FF8080, -1px  0px #FF8080, -1px  1px #FF8080,  0px -1px #FF8080,  0px  1px #FF8080,  1px -1px #FF8080,  1px  0px #FF8080,  1px  1px #FF8080,
+  -2px -2px #FF8080, -2px -1px #FF8080, -2px  0px #FF8080, -2px  1px #FF8080, -2px  2px #FF8080, -1px -2px #FF8080, -1px  2px #FF8080,  0px -2px #FF8080,
+   0px  2px #FF8080,  1px -2px #FF8080,  1px  2px #FF8080,  2px -2px #FF8080,  2px -1px #FF8080,  2px  0px #FF8080,  2px  1px #FF8080,  2px  2px #FF8080;}
+::cue(.outline1vividtangerine)        {text-shadow:
+  -1px -1px #FF8080, -1px  0px #FF8080, -1px  1px #FF8080,  0px -1px #FF8080,  0px  1px #FF8080,  1px -1px #FF8080,  1px  0px #FF8080,  1px  1px #FF8080;}
+::cue(.outline3hotpink)        {text-shadow:
+  -1px -1px #FF80C0, -1px  0px #FF80C0, -1px  1px #FF80C0,  0px -1px #FF80C0,  0px  1px #FF80C0,  1px -1px #FF80C0,  1px  0px #FF80C0,  1px  1px #FF80C0,
+  -2px -2px #FF80C0, -2px -1px #FF80C0, -2px  0px #FF80C0, -2px  1px #FF80C0, -2px  2px #FF80C0, -1px -2px #FF80C0, -1px  2px #FF80C0,  0px -2px #FF80C0,
+   0px  2px #FF80C0,  1px -2px #FF80C0,  1px  2px #FF80C0,  2px -2px #FF80C0,  2px -1px #FF80C0,  2px  0px #FF80C0,  2px  1px #FF80C0,  2px  2px #FF80C0,
+  -3px -3px #FF80C0, -3px -2px #FF80C0, -3px -1px #FF80C0, -3px  0px #FF80C0, -3px  1px #FF80C0, -3px  2px #FF80C0, -3px  3px #FF80C0, -2px -3px #FF80C0,
+  -2px  3px #FF80C0, -1px -3px #FF80C0, -1px  3px #FF80C0,  0px -3px #FF80C0,  0px  3px #FF80C0,  1px -3px #FF80C0,  1px  3px #FF80C0,  2px -3px #FF80C0,
+   2px  3px #FF80C0,  3px -3px #FF80C0,  3px -2px #FF80C0,  3px -1px #FF80C0,  3px  0px #FF80C0,  3px  1px #FF80C0,  3px  2px #FF80C0,  3px  3px #FF80C0;}
+::cue(.outline2hotpink)        {text-shadow:
+  -1px -1px #FF80C0, -1px  0px #FF80C0, -1px  1px #FF80C0,  0px -1px #FF80C0,  0px  1px #FF80C0,  1px -1px #FF80C0,  1px  0px #FF80C0,  1px  1px #FF80C0,
+  -2px -2px #FF80C0, -2px -1px #FF80C0, -2px  0px #FF80C0, -2px  1px #FF80C0, -2px  2px #FF80C0, -1px -2px #FF80C0, -1px  2px #FF80C0,  0px -2px #FF80C0,
+   0px  2px #FF80C0,  1px -2px #FF80C0,  1px  2px #FF80C0,  2px -2px #FF80C0,  2px -1px #FF80C0,  2px  0px #FF80C0,  2px  1px #FF80C0,  2px  2px #FF80C0;}
+::cue(.outline1hotpink)        {text-shadow:
+  -1px -1px #FF80C0, -1px  0px #FF80C0, -1px  1px #FF80C0,  0px -1px #FF80C0,  0px  1px #FF80C0,  1px -1px #FF80C0,  1px  0px #FF80C0,  1px  1px #FF80C0;}
+::cue(.outline3blushpink)        {text-shadow:
+  -1px -1px #FF80FF, -1px  0px #FF80FF, -1px  1px #FF80FF,  0px -1px #FF80FF,  0px  1px #FF80FF,  1px -1px #FF80FF,  1px  0px #FF80FF,  1px  1px #FF80FF,
+  -2px -2px #FF80FF, -2px -1px #FF80FF, -2px  0px #FF80FF, -2px  1px #FF80FF, -2px  2px #FF80FF, -1px -2px #FF80FF, -1px  2px #FF80FF,  0px -2px #FF80FF,
+   0px  2px #FF80FF,  1px -2px #FF80FF,  1px  2px #FF80FF,  2px -2px #FF80FF,  2px -1px #FF80FF,  2px  0px #FF80FF,  2px  1px #FF80FF,  2px  2px #FF80FF,
+  -3px -3px #FF80FF, -3px -2px #FF80FF, -3px -1px #FF80FF, -3px  0px #FF80FF, -3px  1px #FF80FF, -3px  2px #FF80FF, -3px  3px #FF80FF, -2px -3px #FF80FF,
+  -2px  3px #FF80FF, -1px -3px #FF80FF, -1px  3px #FF80FF,  0px -3px #FF80FF,  0px  3px #FF80FF,  1px -3px #FF80FF,  1px  3px #FF80FF,  2px -3px #FF80FF,
+   2px  3px #FF80FF,  3px -3px #FF80FF,  3px -2px #FF80FF,  3px -1px #FF80FF,  3px  0px #FF80FF,  3px  1px #FF80FF,  3px  2px #FF80FF,  3px  3px #FF80FF;}
+::cue(.outline2blushpink)        {text-shadow:
+  -1px -1px #FF80FF, -1px  0px #FF80FF, -1px  1px #FF80FF,  0px -1px #FF80FF,  0px  1px #FF80FF,  1px -1px #FF80FF,  1px  0px #FF80FF,  1px  1px #FF80FF,
+  -2px -2px #FF80FF, -2px -1px #FF80FF, -2px  0px #FF80FF, -2px  1px #FF80FF, -2px  2px #FF80FF, -1px -2px #FF80FF, -1px  2px #FF80FF,  0px -2px #FF80FF,
+   0px  2px #FF80FF,  1px -2px #FF80FF,  1px  2px #FF80FF,  2px -2px #FF80FF,  2px -1px #FF80FF,  2px  0px #FF80FF,  2px  1px #FF80FF,  2px  2px #FF80FF;}
+::cue(.outline1blushpink)        {text-shadow:
+  -1px -1px #FF80FF, -1px  0px #FF80FF, -1px  1px #FF80FF,  0px -1px #FF80FF,  0px  1px #FF80FF,  1px -1px #FF80FF,  1px  0px #FF80FF,  1px  1px #FF80FF;}
+::cue(.outline3amber)        {text-shadow:
+  -1px -1px #FFC000, -1px  0px #FFC000, -1px  1px #FFC000,  0px -1px #FFC000,  0px  1px #FFC000,  1px -1px #FFC000,  1px  0px #FFC000,  1px  1px #FFC000,
+  -2px -2px #FFC000, -2px -1px #FFC000, -2px  0px #FFC000, -2px  1px #FFC000, -2px  2px #FFC000, -1px -2px #FFC000, -1px  2px #FFC000,  0px -2px #FFC000,
+   0px  2px #FFC000,  1px -2px #FFC000,  1px  2px #FFC000,  2px -2px #FFC000,  2px -1px #FFC000,  2px  0px #FFC000,  2px  1px #FFC000,  2px  2px #FFC000,
+  -3px -3px #FFC000, -3px -2px #FFC000, -3px -1px #FFC000, -3px  0px #FFC000, -3px  1px #FFC000, -3px  2px #FFC000, -3px  3px #FFC000, -2px -3px #FFC000,
+  -2px  3px #FFC000, -1px -3px #FFC000, -1px  3px #FFC000,  0px -3px #FFC000,  0px  3px #FFC000,  1px -3px #FFC000,  1px  3px #FFC000,  2px -3px #FFC000,
+   2px  3px #FFC000,  3px -3px #FFC000,  3px -2px #FFC000,  3px -1px #FFC000,  3px  0px #FFC000,  3px  1px #FFC000,  3px  2px #FFC000,  3px  3px #FFC000;}
+::cue(.outline2amber)        {text-shadow:
+  -1px -1px #FFC000, -1px  0px #FFC000, -1px  1px #FFC000,  0px -1px #FFC000,  0px  1px #FFC000,  1px -1px #FFC000,  1px  0px #FFC000,  1px  1px #FFC000,
+  -2px -2px #FFC000, -2px -1px #FFC000, -2px  0px #FFC000, -2px  1px #FFC000, -2px  2px #FFC000, -1px -2px #FFC000, -1px  2px #FFC000,  0px -2px #FFC000,
+   0px  2px #FFC000,  1px -2px #FFC000,  1px  2px #FFC000,  2px -2px #FFC000,  2px -1px #FFC000,  2px  0px #FFC000,  2px  1px #FFC000,  2px  2px #FFC000;}
+::cue(.outline1amber)        {text-shadow:
+  -1px -1px #FFC000, -1px  0px #FFC000, -1px  1px #FFC000,  0px -1px #FFC000,  0px  1px #FFC000,  1px -1px #FFC000,  1px  0px #FFC000,  1px  1px #FFC000;}
+::cue(.outline3yelloworange)        {text-shadow:
+  -1px -1px #FFC040, -1px  0px #FFC040, -1px  1px #FFC040,  0px -1px #FFC040,  0px  1px #FFC040,  1px -1px #FFC040,  1px  0px #FFC040,  1px  1px #FFC040,
+  -2px -2px #FFC040, -2px -1px #FFC040, -2px  0px #FFC040, -2px  1px #FFC040, -2px  2px #FFC040, -1px -2px #FFC040, -1px  2px #FFC040,  0px -2px #FFC040,
+   0px  2px #FFC040,  1px -2px #FFC040,  1px  2px #FFC040,  2px -2px #FFC040,  2px -1px #FFC040,  2px  0px #FFC040,  2px  1px #FFC040,  2px  2px #FFC040,
+  -3px -3px #FFC040, -3px -2px #FFC040, -3px -1px #FFC040, -3px  0px #FFC040, -3px  1px #FFC040, -3px  2px #FFC040, -3px  3px #FFC040, -2px -3px #FFC040,
+  -2px  3px #FFC040, -1px -3px #FFC040, -1px  3px #FFC040,  0px -3px #FFC040,  0px  3px #FFC040,  1px -3px #FFC040,  1px  3px #FFC040,  2px -3px #FFC040,
+   2px  3px #FFC040,  3px -3px #FFC040,  3px -2px #FFC040,  3px -1px #FFC040,  3px  0px #FFC040,  3px  1px #FFC040,  3px  2px #FFC040,  3px  3px #FFC040;}
+::cue(.outline2yelloworange)        {text-shadow:
+  -1px -1px #FFC040, -1px  0px #FFC040, -1px  1px #FFC040,  0px -1px #FFC040,  0px  1px #FFC040,  1px -1px #FFC040,  1px  0px #FFC040,  1px  1px #FFC040,
+  -2px -2px #FFC040, -2px -1px #FFC040, -2px  0px #FFC040, -2px  1px #FFC040, -2px  2px #FFC040, -1px -2px #FFC040, -1px  2px #FFC040,  0px -2px #FFC040,
+   0px  2px #FFC040,  1px -2px #FFC040,  1px  2px #FFC040,  2px -2px #FFC040,  2px -1px #FFC040,  2px  0px #FFC040,  2px  1px #FFC040,  2px  2px #FFC040;}
+::cue(.outline1yelloworange)        {text-shadow:
+  -1px -1px #FFC040, -1px  0px #FFC040, -1px  1px #FFC040,  0px -1px #FFC040,  0px  1px #FFC040,  1px -1px #FFC040,  1px  0px #FFC040,  1px  1px #FFC040;}
+::cue(.outline3macncheese)        {text-shadow:
+  -1px -1px #FFC080, -1px  0px #FFC080, -1px  1px #FFC080,  0px -1px #FFC080,  0px  1px #FFC080,  1px -1px #FFC080,  1px  0px #FFC080,  1px  1px #FFC080,
+  -2px -2px #FFC080, -2px -1px #FFC080, -2px  0px #FFC080, -2px  1px #FFC080, -2px  2px #FFC080, -1px -2px #FFC080, -1px  2px #FFC080,  0px -2px #FFC080,
+   0px  2px #FFC080,  1px -2px #FFC080,  1px  2px #FFC080,  2px -2px #FFC080,  2px -1px #FFC080,  2px  0px #FFC080,  2px  1px #FFC080,  2px  2px #FFC080,
+  -3px -3px #FFC080, -3px -2px #FFC080, -3px -1px #FFC080, -3px  0px #FFC080, -3px  1px #FFC080, -3px  2px #FFC080, -3px  3px #FFC080, -2px -3px #FFC080,
+  -2px  3px #FFC080, -1px -3px #FFC080, -1px  3px #FFC080,  0px -3px #FFC080,  0px  3px #FFC080,  1px -3px #FFC080,  1px  3px #FFC080,  2px -3px #FFC080,
+   2px  3px #FFC080,  3px -3px #FFC080,  3px -2px #FFC080,  3px -1px #FFC080,  3px  0px #FFC080,  3px  1px #FFC080,  3px  2px #FFC080,  3px  3px #FFC080;}
+::cue(.outline2macncheese)        {text-shadow:
+  -1px -1px #FFC080, -1px  0px #FFC080, -1px  1px #FFC080,  0px -1px #FFC080,  0px  1px #FFC080,  1px -1px #FFC080,  1px  0px #FFC080,  1px  1px #FFC080,
+  -2px -2px #FFC080, -2px -1px #FFC080, -2px  0px #FFC080, -2px  1px #FFC080, -2px  2px #FFC080, -1px -2px #FFC080, -1px  2px #FFC080,  0px -2px #FFC080,
+   0px  2px #FFC080,  1px -2px #FFC080,  1px  2px #FFC080,  2px -2px #FFC080,  2px -1px #FFC080,  2px  0px #FFC080,  2px  1px #FFC080,  2px  2px #FFC080;}
+::cue(.outline1macncheese)        {text-shadow:
+  -1px -1px #FFC080, -1px  0px #FFC080, -1px  1px #FFC080,  0px -1px #FFC080,  0px  1px #FFC080,  1px -1px #FFC080,  1px  0px #FFC080,  1px  1px #FFC080;}
+::cue(.outline3yourpink)        {text-shadow:
+  -1px -1px #FFC0C0, -1px  0px #FFC0C0, -1px  1px #FFC0C0,  0px -1px #FFC0C0,  0px  1px #FFC0C0,  1px -1px #FFC0C0,  1px  0px #FFC0C0,  1px  1px #FFC0C0,
+  -2px -2px #FFC0C0, -2px -1px #FFC0C0, -2px  0px #FFC0C0, -2px  1px #FFC0C0, -2px  2px #FFC0C0, -1px -2px #FFC0C0, -1px  2px #FFC0C0,  0px -2px #FFC0C0,
+   0px  2px #FFC0C0,  1px -2px #FFC0C0,  1px  2px #FFC0C0,  2px -2px #FFC0C0,  2px -1px #FFC0C0,  2px  0px #FFC0C0,  2px  1px #FFC0C0,  2px  2px #FFC0C0,
+  -3px -3px #FFC0C0, -3px -2px #FFC0C0, -3px -1px #FFC0C0, -3px  0px #FFC0C0, -3px  1px #FFC0C0, -3px  2px #FFC0C0, -3px  3px #FFC0C0, -2px -3px #FFC0C0,
+  -2px  3px #FFC0C0, -1px -3px #FFC0C0, -1px  3px #FFC0C0,  0px -3px #FFC0C0,  0px  3px #FFC0C0,  1px -3px #FFC0C0,  1px  3px #FFC0C0,  2px -3px #FFC0C0,
+   2px  3px #FFC0C0,  3px -3px #FFC0C0,  3px -2px #FFC0C0,  3px -1px #FFC0C0,  3px  0px #FFC0C0,  3px  1px #FFC0C0,  3px  2px #FFC0C0,  3px  3px #FFC0C0;}
+::cue(.outline2yourpink)        {text-shadow:
+  -1px -1px #FFC0C0, -1px  0px #FFC0C0, -1px  1px #FFC0C0,  0px -1px #FFC0C0,  0px  1px #FFC0C0,  1px -1px #FFC0C0,  1px  0px #FFC0C0,  1px  1px #FFC0C0,
+  -2px -2px #FFC0C0, -2px -1px #FFC0C0, -2px  0px #FFC0C0, -2px  1px #FFC0C0, -2px  2px #FFC0C0, -1px -2px #FFC0C0, -1px  2px #FFC0C0,  0px -2px #FFC0C0,
+   0px  2px #FFC0C0,  1px -2px #FFC0C0,  1px  2px #FFC0C0,  2px -2px #FFC0C0,  2px -1px #FFC0C0,  2px  0px #FFC0C0,  2px  1px #FFC0C0,  2px  2px #FFC0C0;}
+::cue(.outline1yourpink)        {text-shadow:
+  -1px -1px #FFC0C0, -1px  0px #FFC0C0, -1px  1px #FFC0C0,  0px -1px #FFC0C0,  0px  1px #FFC0C0,  1px -1px #FFC0C0,  1px  0px #FFC0C0,  1px  1px #FFC0C0;}
+::cue(.outline3pinklace)        {text-shadow:
+  -1px -1px #FFC0FF, -1px  0px #FFC0FF, -1px  1px #FFC0FF,  0px -1px #FFC0FF,  0px  1px #FFC0FF,  1px -1px #FFC0FF,  1px  0px #FFC0FF,  1px  1px #FFC0FF,
+  -2px -2px #FFC0FF, -2px -1px #FFC0FF, -2px  0px #FFC0FF, -2px  1px #FFC0FF, -2px  2px #FFC0FF, -1px -2px #FFC0FF, -1px  2px #FFC0FF,  0px -2px #FFC0FF,
+   0px  2px #FFC0FF,  1px -2px #FFC0FF,  1px  2px #FFC0FF,  2px -2px #FFC0FF,  2px -1px #FFC0FF,  2px  0px #FFC0FF,  2px  1px #FFC0FF,  2px  2px #FFC0FF,
+  -3px -3px #FFC0FF, -3px -2px #FFC0FF, -3px -1px #FFC0FF, -3px  0px #FFC0FF, -3px  1px #FFC0FF, -3px  2px #FFC0FF, -3px  3px #FFC0FF, -2px -3px #FFC0FF,
+  -2px  3px #FFC0FF, -1px -3px #FFC0FF, -1px  3px #FFC0FF,  0px -3px #FFC0FF,  0px  3px #FFC0FF,  1px -3px #FFC0FF,  1px  3px #FFC0FF,  2px -3px #FFC0FF,
+   2px  3px #FFC0FF,  3px -3px #FFC0FF,  3px -2px #FFC0FF,  3px -1px #FFC0FF,  3px  0px #FFC0FF,  3px  1px #FFC0FF,  3px  2px #FFC0FF,  3px  3px #FFC0FF;}
+::cue(.outline2pinklace)        {text-shadow:
+  -1px -1px #FFC0FF, -1px  0px #FFC0FF, -1px  1px #FFC0FF,  0px -1px #FFC0FF,  0px  1px #FFC0FF,  1px -1px #FFC0FF,  1px  0px #FFC0FF,  1px  1px #FFC0FF,
+  -2px -2px #FFC0FF, -2px -1px #FFC0FF, -2px  0px #FFC0FF, -2px  1px #FFC0FF, -2px  2px #FFC0FF, -1px -2px #FFC0FF, -1px  2px #FFC0FF,  0px -2px #FFC0FF,
+   0px  2px #FFC0FF,  1px -2px #FFC0FF,  1px  2px #FFC0FF,  2px -2px #FFC0FF,  2px -1px #FFC0FF,  2px  0px #FFC0FF,  2px  1px #FFC0FF,  2px  2px #FFC0FF;}
+::cue(.outline1pinklace)        {text-shadow:
+  -1px -1px #FFC0FF, -1px  0px #FFC0FF, -1px  1px #FFC0FF,  0px -1px #FFC0FF,  0px  1px #FFC0FF,  1px -1px #FFC0FF,  1px  0px #FFC0FF,  1px  1px #FFC0FF;}
+::cue(.outline3yellow)        {text-shadow:
+  -1px -1px #FFFF00, -1px  0px #FFFF00, -1px  1px #FFFF00,  0px -1px #FFFF00,  0px  1px #FFFF00,  1px -1px #FFFF00,  1px  0px #FFFF00,  1px  1px #FFFF00,
+  -2px -2px #FFFF00, -2px -1px #FFFF00, -2px  0px #FFFF00, -2px  1px #FFFF00, -2px  2px #FFFF00, -1px -2px #FFFF00, -1px  2px #FFFF00,  0px -2px #FFFF00,
+   0px  2px #FFFF00,  1px -2px #FFFF00,  1px  2px #FFFF00,  2px -2px #FFFF00,  2px -1px #FFFF00,  2px  0px #FFFF00,  2px  1px #FFFF00,  2px  2px #FFFF00,
+  -3px -3px #FFFF00, -3px -2px #FFFF00, -3px -1px #FFFF00, -3px  0px #FFFF00, -3px  1px #FFFF00, -3px  2px #FFFF00, -3px  3px #FFFF00, -2px -3px #FFFF00,
+  -2px  3px #FFFF00, -1px -3px #FFFF00, -1px  3px #FFFF00,  0px -3px #FFFF00,  0px  3px #FFFF00,  1px -3px #FFFF00,  1px  3px #FFFF00,  2px -3px #FFFF00,
+   2px  3px #FFFF00,  3px -3px #FFFF00,  3px -2px #FFFF00,  3px -1px #FFFF00,  3px  0px #FFFF00,  3px  1px #FFFF00,  3px  2px #FFFF00,  3px  3px #FFFF00;}
+::cue(.outline2yellow)        {text-shadow:
+  -1px -1px #FFFF00, -1px  0px #FFFF00, -1px  1px #FFFF00,  0px -1px #FFFF00,  0px  1px #FFFF00,  1px -1px #FFFF00,  1px  0px #FFFF00,  1px  1px #FFFF00,
+  -2px -2px #FFFF00, -2px -1px #FFFF00, -2px  0px #FFFF00, -2px  1px #FFFF00, -2px  2px #FFFF00, -1px -2px #FFFF00, -1px  2px #FFFF00,  0px -2px #FFFF00,
+   0px  2px #FFFF00,  1px -2px #FFFF00,  1px  2px #FFFF00,  2px -2px #FFFF00,  2px -1px #FFFF00,  2px  0px #FFFF00,  2px  1px #FFFF00,  2px  2px #FFFF00;}
+::cue(.outline1yellow)        {text-shadow:
+  -1px -1px #FFFF00, -1px  0px #FFFF00, -1px  1px #FFFF00,  0px -1px #FFFF00,  0px  1px #FFFF00,  1px -1px #FFFF00,  1px  0px #FFFF00,  1px  1px #FFFF00;}
+::cue(.outline3goldenfizz)        {text-shadow:
+  -1px -1px #FFFF40, -1px  0px #FFFF40, -1px  1px #FFFF40,  0px -1px #FFFF40,  0px  1px #FFFF40,  1px -1px #FFFF40,  1px  0px #FFFF40,  1px  1px #FFFF40,
+  -2px -2px #FFFF40, -2px -1px #FFFF40, -2px  0px #FFFF40, -2px  1px #FFFF40, -2px  2px #FFFF40, -1px -2px #FFFF40, -1px  2px #FFFF40,  0px -2px #FFFF40,
+   0px  2px #FFFF40,  1px -2px #FFFF40,  1px  2px #FFFF40,  2px -2px #FFFF40,  2px -1px #FFFF40,  2px  0px #FFFF40,  2px  1px #FFFF40,  2px  2px #FFFF40,
+  -3px -3px #FFFF40, -3px -2px #FFFF40, -3px -1px #FFFF40, -3px  0px #FFFF40, -3px  1px #FFFF40, -3px  2px #FFFF40, -3px  3px #FFFF40, -2px -3px #FFFF40,
+  -2px  3px #FFFF40, -1px -3px #FFFF40, -1px  3px #FFFF40,  0px -3px #FFFF40,  0px  3px #FFFF40,  1px -3px #FFFF40,  1px  3px #FFFF40,  2px -3px #FFFF40,
+   2px  3px #FFFF40,  3px -3px #FFFF40,  3px -2px #FFFF40,  3px -1px #FFFF40,  3px  0px #FFFF40,  3px  1px #FFFF40,  3px  2px #FFFF40,  3px  3px #FFFF40;}
+::cue(.outline2goldenfizz)        {text-shadow:
+  -1px -1px #FFFF40, -1px  0px #FFFF40, -1px  1px #FFFF40,  0px -1px #FFFF40,  0px  1px #FFFF40,  1px -1px #FFFF40,  1px  0px #FFFF40,  1px  1px #FFFF40,
+  -2px -2px #FFFF40, -2px -1px #FFFF40, -2px  0px #FFFF40, -2px  1px #FFFF40, -2px  2px #FFFF40, -1px -2px #FFFF40, -1px  2px #FFFF40,  0px -2px #FFFF40,
+   0px  2px #FFFF40,  1px -2px #FFFF40,  1px  2px #FFFF40,  2px -2px #FFFF40,  2px -1px #FFFF40,  2px  0px #FFFF40,  2px  1px #FFFF40,  2px  2px #FFFF40;}
+::cue(.outline1goldenfizz)        {text-shadow:
+  -1px -1px #FFFF40, -1px  0px #FFFF40, -1px  1px #FFFF40,  0px -1px #FFFF40,  0px  1px #FFFF40,  1px -1px #FFFF40,  1px  0px #FFFF40,  1px  1px #FFFF40;}
+::cue(.outline3dolly)        {text-shadow:
+  -1px -1px #FFFF80, -1px  0px #FFFF80, -1px  1px #FFFF80,  0px -1px #FFFF80,  0px  1px #FFFF80,  1px -1px #FFFF80,  1px  0px #FFFF80,  1px  1px #FFFF80,
+  -2px -2px #FFFF80, -2px -1px #FFFF80, -2px  0px #FFFF80, -2px  1px #FFFF80, -2px  2px #FFFF80, -1px -2px #FFFF80, -1px  2px #FFFF80,  0px -2px #FFFF80,
+   0px  2px #FFFF80,  1px -2px #FFFF80,  1px  2px #FFFF80,  2px -2px #FFFF80,  2px -1px #FFFF80,  2px  0px #FFFF80,  2px  1px #FFFF80,  2px  2px #FFFF80,
+  -3px -3px #FFFF80, -3px -2px #FFFF80, -3px -1px #FFFF80, -3px  0px #FFFF80, -3px  1px #FFFF80, -3px  2px #FFFF80, -3px  3px #FFFF80, -2px -3px #FFFF80,
+  -2px  3px #FFFF80, -1px -3px #FFFF80, -1px  3px #FFFF80,  0px -3px #FFFF80,  0px  3px #FFFF80,  1px -3px #FFFF80,  1px  3px #FFFF80,  2px -3px #FFFF80,
+   2px  3px #FFFF80,  3px -3px #FFFF80,  3px -2px #FFFF80,  3px -1px #FFFF80,  3px  0px #FFFF80,  3px  1px #FFFF80,  3px  2px #FFFF80,  3px  3px #FFFF80;}
+::cue(.outline2dolly)        {text-shadow:
+  -1px -1px #FFFF80, -1px  0px #FFFF80, -1px  1px #FFFF80,  0px -1px #FFFF80,  0px  1px #FFFF80,  1px -1px #FFFF80,  1px  0px #FFFF80,  1px  1px #FFFF80,
+  -2px -2px #FFFF80, -2px -1px #FFFF80, -2px  0px #FFFF80, -2px  1px #FFFF80, -2px  2px #FFFF80, -1px -2px #FFFF80, -1px  2px #FFFF80,  0px -2px #FFFF80,
+   0px  2px #FFFF80,  1px -2px #FFFF80,  1px  2px #FFFF80,  2px -2px #FFFF80,  2px -1px #FFFF80,  2px  0px #FFFF80,  2px  1px #FFFF80,  2px  2px #FFFF80;}
+::cue(.outline1dolly)        {text-shadow:
+  -1px -1px #FFFF80, -1px  0px #FFFF80, -1px  1px #FFFF80,  0px -1px #FFFF80,  0px  1px #FFFF80,  1px -1px #FFFF80,  1px  0px #FFFF80,  1px  1px #FFFF80;}
+::cue(.outline3shalimar)        {text-shadow:
+  -1px -1px #FFFFC0, -1px  0px #FFFFC0, -1px  1px #FFFFC0,  0px -1px #FFFFC0,  0px  1px #FFFFC0,  1px -1px #FFFFC0,  1px  0px #FFFFC0,  1px  1px #FFFFC0,
+  -2px -2px #FFFFC0, -2px -1px #FFFFC0, -2px  0px #FFFFC0, -2px  1px #FFFFC0, -2px  2px #FFFFC0, -1px -2px #FFFFC0, -1px  2px #FFFFC0,  0px -2px #FFFFC0,
+   0px  2px #FFFFC0,  1px -2px #FFFFC0,  1px  2px #FFFFC0,  2px -2px #FFFFC0,  2px -1px #FFFFC0,  2px  0px #FFFFC0,  2px  1px #FFFFC0,  2px  2px #FFFFC0,
+  -3px -3px #FFFFC0, -3px -2px #FFFFC0, -3px -1px #FFFFC0, -3px  0px #FFFFC0, -3px  1px #FFFFC0, -3px  2px #FFFFC0, -3px  3px #FFFFC0, -2px -3px #FFFFC0,
+  -2px  3px #FFFFC0, -1px -3px #FFFFC0, -1px  3px #FFFFC0,  0px -3px #FFFFC0,  0px  3px #FFFFC0,  1px -3px #FFFFC0,  1px  3px #FFFFC0,  2px -3px #FFFFC0,
+   2px  3px #FFFFC0,  3px -3px #FFFFC0,  3px -2px #FFFFC0,  3px -1px #FFFFC0,  3px  0px #FFFFC0,  3px  1px #FFFFC0,  3px  2px #FFFFC0,  3px  3px #FFFFC0;}
+::cue(.outline2shalimar)        {text-shadow:
+  -1px -1px #FFFFC0, -1px  0px #FFFFC0, -1px  1px #FFFFC0,  0px -1px #FFFFC0,  0px  1px #FFFFC0,  1px -1px #FFFFC0,  1px  0px #FFFFC0,  1px  1px #FFFFC0,
+  -2px -2px #FFFFC0, -2px -1px #FFFFC0, -2px  0px #FFFFC0, -2px  1px #FFFFC0, -2px  2px #FFFFC0, -1px -2px #FFFFC0, -1px  2px #FFFFC0,  0px -2px #FFFFC0,
+   0px  2px #FFFFC0,  1px -2px #FFFFC0,  1px  2px #FFFFC0,  2px -2px #FFFFC0,  2px -1px #FFFFC0,  2px  0px #FFFFC0,  2px  1px #FFFFC0,  2px  2px #FFFFC0;}
+::cue(.outline1shalimar)        {text-shadow:
+  -1px -1px #FFFFC0, -1px  0px #FFFFC0, -1px  1px #FFFFC0,  0px -1px #FFFFC0,  0px  1px #FFFFC0,  1px -1px #FFFFC0,  1px  0px #FFFFC0,  1px  1px #FFFFC0;}
+::cue(.outline3white)        {text-shadow:
+  -1px -1px #FFFFFF, -1px  0px #FFFFFF, -1px  1px #FFFFFF,  0px -1px #FFFFFF,  0px  1px #FFFFFF,  1px -1px #FFFFFF,  1px  0px #FFFFFF,  1px  1px #FFFFFF,
+  -2px -2px #FFFFFF, -2px -1px #FFFFFF, -2px  0px #FFFFFF, -2px  1px #FFFFFF, -2px  2px #FFFFFF, -1px -2px #FFFFFF, -1px  2px #FFFFFF,  0px -2px #FFFFFF,
+   0px  2px #FFFFFF,  1px -2px #FFFFFF,  1px  2px #FFFFFF,  2px -2px #FFFFFF,  2px -1px #FFFFFF,  2px  0px #FFFFFF,  2px  1px #FFFFFF,  2px  2px #FFFFFF,
+  -3px -3px #FFFFFF, -3px -2px #FFFFFF, -3px -1px #FFFFFF, -3px  0px #FFFFFF, -3px  1px #FFFFFF, -3px  2px #FFFFFF, -3px  3px #FFFFFF, -2px -3px #FFFFFF,
+  -2px  3px #FFFFFF, -1px -3px #FFFFFF, -1px  3px #FFFFFF,  0px -3px #FFFFFF,  0px  3px #FFFFFF,  1px -3px #FFFFFF,  1px  3px #FFFFFF,  2px -3px #FFFFFF,
+   2px  3px #FFFFFF,  3px -3px #FFFFFF,  3px -2px #FFFFFF,  3px -1px #FFFFFF,  3px  0px #FFFFFF,  3px  1px #FFFFFF,  3px  2px #FFFFFF,  3px  3px #FFFFFF;}
+::cue(.outline2white)        {text-shadow:
+  -1px -1px #FFFFFF, -1px  0px #FFFFFF, -1px  1px #FFFFFF,  0px -1px #FFFFFF,  0px  1px #FFFFFF,  1px -1px #FFFFFF,  1px  0px #FFFFFF,  1px  1px #FFFFFF,
+  -2px -2px #FFFFFF, -2px -1px #FFFFFF, -2px  0px #FFFFFF, -2px  1px #FFFFFF, -2px  2px #FFFFFF, -1px -2px #FFFFFF, -1px  2px #FFFFFF,  0px -2px #FFFFFF,
+   0px  2px #FFFFFF,  1px -2px #FFFFFF,  1px  2px #FFFFFF,  2px -2px #FFFFFF,  2px -1px #FFFFFF,  2px  0px #FFFFFF,  2px  1px #FFFFFF,  2px  2px #FFFFFF;}
+::cue(.outline1white)        {text-shadow:
+  -1px -1px #FFFFFF, -1px  0px #FFFFFF, -1px  1px #FFFFFF,  0px -1px #FFFFFF,  0px  1px #FFFFFF,  1px -1px #FFFFFF,  1px  0px #FFFFFF,  1px  1px #FFFFFF;}


### PR DESCRIPTION
So the flag is commented out, but when uncommented it would add class descriptions that match the event's style in font-family, font-size, primary color, outline color, background color (if BorderStyle is 3 not 1), in outline size in pixels. 

- All colors use a palette of 125 colors indexed as palette[red 0-4][green 0-4][blue 0-4]. Direct quantization of color components is used. Same color name is used for all classes, so the same string array can be used for look-up.
- 2 Alpha values are used for primary color, background color. Alpha value of 0 (fully opaque) is exclusively used for outlines.
- Outline is implemented with 3 possible sizes: 1px, 2px, 3px. The css file provides a full 2-d framing of any font used.
- strikethrough is now supported, since VTT can't insert this inline. It has to be inserted in the class/style.
- Replaced all the macros and macro expansions used, since the preprocessor was not doing what is expected. Straight code has fewer surprises and easier to debug.
- Replaced a lot of the color bigEndian/smallEndian decoding, since we are building/running/debugging exclusively on linux.
- Fixed bugs related to initialization and reading of the Title and Language fields in the ScriptInfo.
- Added the crstyles.css in the code-base for reference.

3 examples of input/output can be checked at https://ellation.atlassian.net/browse/VOD-2826.