### PR TITLE
VOD-5061: caption position 2nd attempt

### DIFF
--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -974,45 +974,7 @@ ass_parse_frames(
 			// line is integer in range of [0 - 12] given 16 rows of lines in the frame.
 			// if (marg_l || marg_r || marg_v)
 			{
-				// center/middle means we are giving the coordinate of the center/middle point
-				int line, sizeH, pos;
-
-				if (final_alignment < 4)	    // bottom alignment  for values 1, 2, 3
-				{
-					marg_v = 100 - marg_v;
-					line = FFMINMAX((marg_v+4) >> 3, 0, 12);
-				}
-				else if (final_alignment < 7)	// middle alignment  for values 4, 5, 6
-				{
-					line = 7;
-				}
-				else							// top alignment is the default assumption
-				{
-					line = FFMINMAX((marg_v+4) >> 3, 0, 12);
-				}
-
-				// sizeH should match the width of the max_run of characters, relative to max_allowed_run
-				// of characters allowed for this global style font-size
-				sizeH = FFMIN((int)max_run * 100 / (int)max_chars_allowed, 100);
-				if ((!bleft) && (!bright))						//center alignment  2/5/8
-				{
-					pos = FFMINMAX((marg_r + marg_l + 1)/2, sizeH/2, 100 - sizeH/2);
-				}
-				else if (bleft)									//left   alignment  1/4/7
-				{
-					pos = FFMINMAX(marg_l, 0, 100 - sizeH);
-				}
-				else											//right  alignment  3/6/9
-				{
-					pos = FFMINMAX(marg_r, sizeH, 100);
-				}
-
-				p = vod_copy(p, " position:", 10);
-				p = vod_sprintf(p, "%03uD", pos);
-				p = vod_copy(p, "% size:", 7);
-				p = vod_sprintf(p, "%03uD", sizeH);
-				p = vod_copy(p, "% line:", 7);
-				p = vod_sprintf(p, "%02uD", line);
+				p = vod_copy(p, "% line:90%%", 10);
 			}
 			// We should only insert this if an alignment override tag {\a...}is in the text, otherwise follow the style's alignment
 			// but for now, insert it all the time till all players can read styles

--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -894,7 +894,6 @@ ass_parse_frames(
 		// Split the event text into multiple chunks so we can insert each chunk as a separate frame in webVTT, all under a single cue
 		u_char*	event_textp[NUM_OF_TAGS_ALLOWED_PER_LINE];
 		int		event_len  [NUM_OF_TAGS_ALLOWED_PER_LINE];
-		int		marg_l, marg_r, marg_v; // all of these are integer percentage values
 
 		// allocate memory for the chunk pointer itself first
 		for (chunkcounter = 0; chunkcounter < NUM_OF_TAGS_ALLOWED_PER_LINE; chunkcounter++)

--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -970,7 +970,7 @@ ass_parse_frames(
 			// line is integer in range of [0 - 12] given 16 rows of lines in the frame.
 			// if (marg_l || marg_r || marg_v)
 			{
-				p = vod_copy(p, "% line:90%%", 10);
+				p = vod_copy(p, " line:90%%", 9);
 			}
 			// We should only insert this if an alignment override tag {\a...}is in the text, otherwise follow the style's alignment
 			// but for now, insert it all the time till all players can read styles

--- a/vod/subtitle/ass_format.c
+++ b/vod/subtitle/ass_format.c
@@ -967,9 +967,6 @@ ass_parse_frames(
 				ass_track->play_res_y = 480;
 			}
 
-			marg_l = ((cur_event->margin_l > 0) ? cur_event->margin_l : cur_style->margin_l) * 100 / ass_track->play_res_x;
-			marg_r = (ass_track->play_res_x - ((cur_event->margin_r > 0) ? cur_event->margin_r : cur_style->margin_r)) * 100 / ass_track->play_res_x;
-			marg_v = ((cur_event->margin_v > 0) ? cur_event->margin_v : cur_style->margin_v) * 100 / ass_track->play_res_y; // top assumed
 			// All the margX variables are percentages in rounded integer values.
 			// line is integer in range of [0 - 12] given 16 rows of lines in the frame.
 			// if (marg_l || marg_r || marg_v)


### PR DESCRIPTION
jira: VOD-5061 

My previous PR was just for scc->vtt. This one does ass/ssa as well. After testing on staging, I was seeing captions come in other formats aside from scc. So it's better if all the version code is consistent. 